### PR TITLE
chore(dashboard): Timeseries Legend column edit

### DIFF
--- a/src/pages/dashboard/Editor/Fields/Legend/index.tsx
+++ b/src/pages/dashboard/Editor/Fields/Legend/index.tsx
@@ -15,14 +15,16 @@
  *
  */
 import React from 'react';
-import { Form, Radio, Row, Col } from 'antd';
+import { Form, Radio, Row, Col, Select } from 'antd';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Panel } from '../../Components/Collapse';
+import { CaretDownOutlined } from '@ant-design/icons';
 
 export default function index() {
   const { t } = useTranslation('dashboard');
   const namePrefix = ['options', 'legend'];
+  const tableColumn = ['max', 'min', 'avg', 'sum', 'last']
 
   return (
     <Panel header='Legend'>
@@ -48,6 +50,18 @@ export default function index() {
                     </Radio.Group>
                   </Form.Item>
                 );
+              } else if (getFieldValue([...namePrefix, 'displayMode']) === 'table') {
+                  return (
+                      <Form.Item label={t('panel.options.legend.columns')} name={[...namePrefix, 'columns']}>
+                          <Select mode='multiple' placeholder='' suffixIcon={<CaretDownOutlined />} >
+                              {_.map(tableColumn,(item) => {
+                                  return (<Select.Option key={item} value={item}>
+                                      {t(`panel.options.legend.${item}`)}
+                                  </Select.Option>);
+                              }) }
+                          </Select>
+                      </Form.Item>
+                  );
               }
               return null;
             }}

--- a/src/pages/dashboard/locale/en_US.ts
+++ b/src/pages/dashboard/locale/en_US.ts
@@ -102,6 +102,12 @@ const en_US = {
           hidden: 'Hidden',
         },
         placement: 'Placement',
+        max: 'Max',
+        min: 'Min',
+        avg: 'Avg',
+        sum: 'Sum',
+        last: 'Last',
+        columns: 'Columns',
       },
       thresholds: {
         title: 'Thresholds',

--- a/src/pages/dashboard/locale/zh_CN.ts
+++ b/src/pages/dashboard/locale/zh_CN.ts
@@ -102,6 +102,12 @@ const zh_CN = {
           hidden: '隐藏',
         },
         placement: '位置',
+        max: '最大值',
+        min: '最小值',
+        avg: '平均值',
+        sum: '汇总值',
+        last: '当前值',
+        columns: '显示列',
       },
       thresholds: {
         title: '阈值',

--- a/src/pages/dashboard/types.ts
+++ b/src/pages/dashboard/types.ts
@@ -82,6 +82,7 @@ export interface IOptions {
     calcs: string[];
     displayMode: 'list' | 'table' | 'hidden';
     placement: 'right' | 'bottom';
+    columns?:[]
   };
   tooltip?: {
     mode: 'single' | 'all';


### PR DESCRIPTION
实现时间序列图的 Legend 的 Table 模式下，展示列的配置
默认配置为空， 表示展示所有列
![image](https://user-images.githubusercontent.com/29848365/224965570-65e4469b-e165-40df-a1a1-4ac3a443b4da.png)
效果
![image](https://user-images.githubusercontent.com/29848365/224965631-e2405d05-7e1d-4fe4-a59d-ce6218190d52.png)
选择对应的列后， 展示对应的列
![image](https://user-images.githubusercontent.com/29848365/224965805-2294bcf9-7b72-4c25-8f7c-65c52fec5bb1.png)
效果
![image](https://user-images.githubusercontent.com/29848365/224965836-f65c0439-ca17-45d9-9a19-6a286b37bedf.png)
