### PR TITLE
fix(dashboard): fix legend order bug

### DIFF
--- a/src/pages/dashboard/Renderer/Renderer/Timeseries/index.tsx
+++ b/src/pages/dashboard/Renderer/Renderer/Timeseries/index.tsx
@@ -303,7 +303,7 @@ export default function index(props: IProps) {
         title: t(`panel.options.legend.${column}`),
         dataIndex: column,
         width: 100,
-        sorter: (a, b) => a[column].value - b[column].value,
+        sorter: (a, b) => a[column].stat - b[column].stat,
         render: (text) => {
           return text.text;
         },

--- a/src/pages/dashboard/Renderer/utils/byteConverter.ts
+++ b/src/pages/dashboard/Renderer/utils/byteConverter.ts
@@ -79,6 +79,7 @@ export function format(value: number, options = defaultOptions) {
       value: '',
       unit: '',
       text: '',
+      stat: '',
     };
   const baseUtil = options.base ? baseUtilMap[options.base] : ''; // 支持
   if ((options.type === 'si' && Math.abs(value) < 1000) || (options.type === 'iec' && Math.abs(value) < 1024)) {
@@ -86,6 +87,7 @@ export function format(value: number, options = defaultOptions) {
       value: _.round(value, options.decimals),
       unit: baseUtil,
       text: _.round(value, options.decimals) + baseUtil,
+      stat: value,
     };
   }
 
@@ -103,6 +105,7 @@ export function format(value: number, options = defaultOptions) {
         value: NaN,
         unit: '',
         text: NaN,
+        stat: NaN,
       };
     }
     const unit = _.get(map, options.type);
@@ -114,12 +117,14 @@ export function format(value: number, options = defaultOptions) {
       value: newValue,
       unit: unit + baseUtil,
       text: newValue + unit + baseUtil,
+      stat: value,
     };
   }
   return {
     value: _.round(value, options.decimals),
     unit: '',
     text: _.round(value, options.decimals),
+    stat: value,
   };
 }
 

--- a/src/pages/dashboard/Renderer/utils/valueFormatter.ts
+++ b/src/pages/dashboard/Renderer/utils/valueFormatter.ts
@@ -25,6 +25,7 @@ export function timeFormatter(val, type: 'seconds' | 'milliseconds', decimals) {
       value: val,
       unit: '',
       text: val,
+      stat: val,
     };
   const timeMap = [
     {
@@ -77,6 +78,7 @@ export function timeFormatter(val, type: 'seconds' | 'milliseconds', decimals) {
     value: _.round(newVal, decimals),
     unit,
     text: _.round(newVal, decimals) + ' ' + unit,
+    stat: val,
   };
 }
 
@@ -86,6 +88,7 @@ const valueFormatter = ({ unit, decimals = 3, dateFormat = 'YYYY-MM-DD HH:mm:ss'
       value: '',
       unit: '',
       text: '',
+      stat: '',
     };
   }
   if (typeof val !== 'number') {
@@ -106,6 +109,7 @@ const valueFormatter = ({ unit, decimals = 3, dateFormat = 'YYYY-MM-DD HH:mm:ss'
         value: _.round(val, decimals),
         unit: '',
         text: _.round(val, decimals),
+        stat: val,
       };
     }
     if (unit === 'percent') {
@@ -113,6 +117,7 @@ const valueFormatter = ({ unit, decimals = 3, dateFormat = 'YYYY-MM-DD HH:mm:ss'
         value: _.round(val, decimals),
         unit: '%',
         text: _.round(val, decimals) + '%',
+        stat: val,
       };
     }
     if (unit === 'percentUnit') {
@@ -120,6 +125,7 @@ const valueFormatter = ({ unit, decimals = 3, dateFormat = 'YYYY-MM-DD HH:mm:ss'
         value: _.round(val * 100, decimals),
         unit: '%',
         text: _.round(val * 100, decimals) + '%',
+        stat: val,
       };
     }
     if (unit === 'humantimeSeconds') {
@@ -127,6 +133,7 @@ const valueFormatter = ({ unit, decimals = 3, dateFormat = 'YYYY-MM-DD HH:mm:ss'
         value: moment.duration(val, 'seconds').humanize(),
         unit: '',
         text: moment.duration(val, 'seconds').humanize(),
+        stat: val,
       };
     }
     if (unit === 'humantimeMilliseconds') {
@@ -134,6 +141,7 @@ const valueFormatter = ({ unit, decimals = 3, dateFormat = 'YYYY-MM-DD HH:mm:ss'
         value: moment.duration(val, 'milliseconds').humanize(),
         unit: '',
         text: moment.duration(val, 'milliseconds').humanize(),
+        stat: val,
       };
     }
     if (unit === 'seconds') {
@@ -147,6 +155,7 @@ const valueFormatter = ({ unit, decimals = 3, dateFormat = 'YYYY-MM-DD HH:mm:ss'
         value: moment.unix(val).format(dateFormat),
         unit: '',
         text: moment.unix(val).format(dateFormat),
+        stat: val,
       };
     }
     if (unit === 'datetimeMilliseconds') {
@@ -154,12 +163,14 @@ const valueFormatter = ({ unit, decimals = 3, dateFormat = 'YYYY-MM-DD HH:mm:ss'
         value: moment(val).format(dateFormat),
         unit: '',
         text: moment(val).format(dateFormat),
+        stat: val,
       };
     }
     return {
       value: _.round(val, decimals),
       unit: '',
       text: _.round(val, decimals),
+      stat: val,
     };
   }
   // 默认返回 SI 不带基础单位


### PR DESCRIPTION
Timeseries 组件的legend 在Table 模式下的排序使用的是value， value 在添加单位的情况下会出现 800Mi > 1Gi 的情况， 所以在数据处理的过程中添加了  stat 字段， 保存数据的原值，用于排序使用。