### PR TITLE
chore(dashboard): add pie detail

### DIFF
--- a/src/components/G2PieChart/index.tsx
+++ b/src/components/G2PieChart/index.tsx
@@ -30,6 +30,7 @@ interface ListItem extends DataType {
 type DataType = {
   name: string;
   value: number;
+  metric: any;
 };
 interface Props {
   data: DataType[];
@@ -38,6 +39,9 @@ interface Props {
   labelWithName: boolean;
   labelWithValue: boolean;
   dataFormatter: Function;
+  detailFormatter: Function;
+  detailName?: string;
+  detailUrl?: string;
   themeMode?: 'dark';
   donut?: boolean;
 }
@@ -59,7 +63,7 @@ function renderStatistic(containerWidth, text, style) {
 }
 
 const DemoPie = (props: Props) => {
-  const { data, positon, hidden, labelWithName, labelWithValue, themeMode, donut, dataFormatter } = props;
+  const { data, positon, hidden, labelWithName, labelWithValue, themeMode, detailName, detailUrl, donut, dataFormatter, detailFormatter } = props;
 
   const config: PieConfig = {
     padding: [16, 8, 16, 8],
@@ -120,9 +124,14 @@ const DemoPie = (props: Props) => {
       },
     ],
     tooltip: {
-      fields: ['name', 'value', 'unit'],
+      position: 'top',
+      offset: 2,
+      enterable: true,
+      fields: ['name', 'value', 'metric'],
       formatter: (datum) => {
-        return { name: datum.name, value: dataFormatter(datum.value) };
+        const formatUrl = detailFormatter(datum);
+        const detailDom = detailUrl && datum.name !== '其他' ? `&nbsp;|&nbsp;<span><a href=${formatUrl} target="_blank">${detailName}</a></span>` : '';
+        return { name: datum.name, value: dataFormatter(datum.value) + detailDom };
       },
     },
     legend: hidden

--- a/src/pages/dashboard/Editor/Options/Pie/GraphStyles.tsx
+++ b/src/pages/dashboard/Editor/Options/Pie/GraphStyles.tsx
@@ -15,7 +15,7 @@
  *
  */
 import React from 'react';
-import { Form, Select, Row, Col, InputNumber, Switch } from 'antd';
+import { Form, Select, Row, Col, InputNumber, Switch, Input } from 'antd';
 import { CaretDownOutlined } from '@ant-design/icons';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -74,6 +74,16 @@ export default function GraphStyles() {
           <Col span={6}>
             <Form.Item label={t('panel.custom.pie.labelWithValue')} name={[...namePrefix, 'labelWithValue']} valuePropName='checked'>
               <Switch />
+            </Form.Item>
+          </Col>
+          <Col span={12}>
+            <Form.Item label={t('panel.custom.detailName')} name={[...namePrefix, 'detailName']}>
+              <Input style={{ width: '100%' }} />
+            </Form.Item>
+          </Col>
+          <Col span={12}>
+            <Form.Item label={t('panel.custom.detailUrl')} name={[...namePrefix, 'detailUrl']}>
+              <Input style={{ width: '100%' }} />
             </Form.Item>
           </Col>
         </Row>

--- a/src/pages/dashboard/Editor/Options/Pie/GraphStyles.tsx
+++ b/src/pages/dashboard/Editor/Options/Pie/GraphStyles.tsx
@@ -76,13 +76,13 @@ export default function GraphStyles() {
               <Switch />
             </Form.Item>
           </Col>
-          <Col span={12}>
-            <Form.Item label={t('panel.custom.detailName')} name={[...namePrefix, 'detailName']}>
+          <Col span={9}>
+            <Form.Item label={t('panel.custom.pie.detailName')} name={[...namePrefix, 'detailName']}>
               <Input style={{ width: '100%' }} />
             </Form.Item>
           </Col>
-          <Col span={12}>
-            <Form.Item label={t('panel.custom.detailUrl')} name={[...namePrefix, 'detailUrl']}>
+          <Col span={15}>
+            <Form.Item label={t('panel.custom.pie.detailUrl')} name={[...namePrefix, 'detailUrl']}>
               <Input style={{ width: '100%' }} />
             </Form.Item>
           </Col>

--- a/src/pages/dashboard/Editor/config.tsx
+++ b/src/pages/dashboard/Editor/config.tsx
@@ -169,6 +169,7 @@ export const defaultCustomValuesMap = {
     calc: 'lastNotNull',
     textSize: {},
     legengPosition: 'right',
+    detailName: '详情',
   },
   table: {
     showHeader: true,

--- a/src/pages/dashboard/Renderer/Renderer/Iframe/index.tsx
+++ b/src/pages/dashboard/Renderer/Renderer/Iframe/index.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { IPanel, IIframeStyles } from '../../../types';
-import { replaceFieldWithVariable } from '../../../VariableConfig/constant';
+import { replaceFieldWithVariable, getOptionsList } from '../../../VariableConfig/constant';
 import { useGlobalState } from '../../../globalState';
-import { IRawTimeRange, parseRange } from '@/components/TimeRangePicker';
-import moment from 'moment';
+import { IRawTimeRange } from '@/components/TimeRangePicker';
 
 interface IProps {
   values: IPanel;
@@ -17,25 +16,7 @@ export default function index(props: IProps) {
   const { values, time } = props;
   const { custom } = values;
   const { src } = custom as IIframeStyles;
-  const rangeTime = parseRange(time);
-  const from = moment(rangeTime.start).valueOf();
-  const fromDateSeconds = moment(rangeTime.start).unix();
-  const fromDateISO = moment(rangeTime.start).toISOString();
-  const to = moment(rangeTime.end).valueOf();
-  const toDateSeconds = moment(rangeTime.end).unix();
-  const toDateISO = moment(rangeTime.end).toISOString();
-  const optionsList = [
-    ...(dashboardMeta.variableConfigWithOptions ? dashboardMeta.variableConfigWithOptions : []),
-    { name: '__from', value: from },
-    { name: '__from_date_seconds', value: fromDateSeconds },
-    { name: '__from_date_iso', value: fromDateISO },
-    { name: '__from_date', value: fromDateISO },
-    { name: '__to', value: to },
-    { name: '__to_date_seconds', value: toDateSeconds },
-    { name: '__to_date_iso', value: toDateISO },
-    { name: '__to_date', value: toDateISO },
-  ];
-  const content = replaceFieldWithVariable(src, dashboardMeta.dashboardId, optionsList);
+  const content = replaceFieldWithVariable(src, dashboardMeta.dashboardId, getOptionsList(dashboardMeta, time));
 
   return (
     <iframe

--- a/src/pages/dashboard/Renderer/Renderer/Pie/index.tsx
+++ b/src/pages/dashboard/Renderer/Renderer/Pie/index.tsx
@@ -52,10 +52,10 @@ export default function Pie(props: IProps) {
   };
 
   const detailFormatter = (data: any) => {
+    // 指标数据
+    const formatUrl =  data ? replaceExpressionDetail(detailUrl, data) : detailUrl;
     // 渲染下钻链接, 变量
-    let formatUrl = replaceFieldWithVariable(detailUrl, dashboardMeta.dashboardId, getOptionsList(dashboardMeta, time));
-    // 指标
-    return data ? replaceExpressionDetail(formatUrl, data) : formatUrl;
+    return replaceFieldWithVariable(formatUrl, dashboardMeta.dashboardId, getOptionsList(dashboardMeta, time));
   };
 
   const calculatedValues = getCalculatedValuesBySeries(

--- a/src/pages/dashboard/Renderer/Renderer/Pie/index.tsx
+++ b/src/pages/dashboard/Renderer/Renderer/Pie/index.tsx
@@ -19,21 +19,28 @@ import _ from 'lodash';
 import G2PieChart from '@/components/G2PieChart';
 import { IPanel } from '../../../types';
 import getCalculatedValuesBySeries from '../../utils/getCalculatedValuesBySeries';
+import { replaceExpressionDetail } from '../../utils/replaceExpressionDetail';
+
 import valueFormatter from '../../utils/valueFormatter';
 import './style.less';
+import { replaceFieldWithVariable, getOptionsList } from '../../../VariableConfig/constant';
+import { useGlobalState } from '../../../globalState';
+import { IRawTimeRange } from '@/components/TimeRangePicker';
 
 interface IProps {
   values: IPanel;
   series: any[];
   themeMode?: 'dark';
+  time: IRawTimeRange;
 }
 
 export default function Pie(props: IProps) {
-  const { values, series, themeMode } = props;
+  const [dashboardMeta] = useGlobalState('dashboardMeta');
+  const { values, series, themeMode, time } = props;
   const { custom, options } = values;
-  const { calc, legengPosition, max, labelWithName, labelWithValue, donut = false } = custom;
+  const { calc, legengPosition, max, labelWithName, labelWithValue, detailUrl, detailName, donut = false } = custom;
   const dataFormatter = (text: number) => {
-   const resFormatter =   valueFormatter(
+    const resFormatter = valueFormatter(
       {
         unit: options?.standardOptions?.util,
         decimals: options?.standardOptions?.decimals,
@@ -41,7 +48,14 @@ export default function Pie(props: IProps) {
       },
       text,
     );
-    return `${resFormatter.value}${resFormatter.unit}`
+    return `${resFormatter.value}${resFormatter.unit}`;
+  };
+
+  const detailFormatter = (data: any) => {
+    // 渲染下钻链接, 变量
+    let formatUrl = replaceFieldWithVariable(detailUrl, dashboardMeta.dashboardId, getOptionsList(dashboardMeta, time));
+    // 指标
+    return data ? replaceExpressionDetail(formatUrl, data) : formatUrl;
   };
 
   const calculatedValues = getCalculatedValuesBySeries(
@@ -60,10 +74,9 @@ export default function Pie(props: IProps) {
     max && sortedValues.length > max
       ? sortedValues
           .slice(0, max)
-          .map((i) => ({ name: i.name, value: i.stat }))
-          .concat({ name: '其他', value: sortedValues.slice(max).reduce((previousValue, currentValue) => currentValue.stat + previousValue, 0) })
-      : sortedValues.map((i) => ({ name: i.name, value: i.stat }));
-
+          .map((i) => ({ name: i.name, value: i.stat, metric: i.metric }))
+          .concat({ name: '其他', value: sortedValues.slice(max).reduce((previousValue, currentValue) => currentValue.stat + previousValue, 0), metric: {} })
+      : sortedValues.map((i) => ({ name: i.name, value: i.stat, metric: i.metric }));
   return (
     <div className='renderer-pie-container'>
       <G2PieChart
@@ -74,6 +87,9 @@ export default function Pie(props: IProps) {
         labelWithName={labelWithName}
         labelWithValue={labelWithValue}
         dataFormatter={dataFormatter}
+        detailFormatter={detailFormatter}
+        detailName={detailName}
+        detailUrl={detailUrl}
         donut={donut}
       />
     </div>

--- a/src/pages/dashboard/Renderer/Renderer/index.tsx
+++ b/src/pages/dashboard/Renderer/Renderer/index.tsx
@@ -103,7 +103,7 @@ function index(props: IProps) {
     timeseries: () => <Timeseries {...subProps} themeMode={themeMode} time={time} />,
     stat: () => <Stat {...subProps} bodyWrapRef={bodyWrapRef} themeMode={themeMode} />,
     table: () => <Table {...subProps} themeMode={themeMode} />,
-    pie: () => <Pie {...subProps} themeMode={themeMode} />,
+    pie: () => <Pie {...subProps} themeMode={themeMode} time={time} />,
     hexbin: () => <Hexbin {...subProps} themeMode={themeMode} />,
     barGauge: () => <BarGauge {...subProps} themeMode={themeMode} />,
     text: () => <Text {...subProps} />,

--- a/src/pages/dashboard/Renderer/utils/replaceExpressionDetail.ts
+++ b/src/pages/dashboard/Renderer/utils/replaceExpressionDetail.ts
@@ -15,7 +15,7 @@ const replaceValueVariables = (url, dataValue) => {
 };
 
 const replaceNameVariables = (url, dataValue) => {
-  return replaceData(/\${__field\.(__name)}/g, url, dataValue);
+  return replaceData(/\${__field\.(__name__)}/g, url, dataValue);
 };
 
 const replaceData = (pattern: RegExp, url, dataValue) => {

--- a/src/pages/dashboard/Renderer/utils/replaceExpressionDetail.ts
+++ b/src/pages/dashboard/Renderer/utils/replaceExpressionDetail.ts
@@ -1,0 +1,34 @@
+import _ from 'lodash';
+const replaceLabelsVariables = (url, variables) => {
+  // 匹配 ${} 中的变量名
+  const pattern = /\${__field\.labels\.(.*?)}/g;
+  return url.replace(pattern, (match, variable) => {
+    // 获取变量的值
+    const value = variables[variable.trim()];
+    // 如果变量值存在，则替换；否则保留原字符串
+    return value !== undefined ? value : match;
+  });
+};
+
+const replaceValueVariables = (url, dataValue) => {
+  return replaceData(/\${__field\.(__value)}/g, url, dataValue);
+};
+
+const replaceNameVariables = (url, dataValue) => {
+  return replaceData(/\${__field\.(__name)}/g, url, dataValue);
+};
+
+const replaceData = (pattern: RegExp, url, dataValue) => {
+  return url.replace(pattern, (match, _) => {
+    const value = dataValue; // 获取变量的值
+    return value !== undefined ? value : match;
+  });
+};
+
+export const replaceExpressionDetail = (url, data) => {
+  let resultUrl = url;
+  resultUrl = data?.name ? replaceNameVariables(resultUrl, data.name) : resultUrl;
+  resultUrl = data?.value ? replaceValueVariables(resultUrl, data.value) : resultUrl;
+  resultUrl = data?.metric ? replaceLabelsVariables(resultUrl, data.metric) : resultUrl;
+  return resultUrl;
+};

--- a/src/pages/dashboard/VariableConfig/constant.tsx
+++ b/src/pages/dashboard/VariableConfig/constant.tsx
@@ -289,6 +289,30 @@ export function replaceFieldWithVariable(value: string, dashboardId?: string, va
   }
   return replaceExpressionVars(value, variableConfig, variableConfig.length, dashboardId);
 }
+export const getOptionsList =  ( dashboardMeta: {
+    dashboardId: string;
+    variableConfigWithOptions: any;
+},
+time: IRawTimeRange) => {
+  const rangeTime = parseRange(time);
+  const from = moment(rangeTime.start).valueOf();
+  const fromDateSeconds = moment(rangeTime.start).unix();
+  const fromDateISO = moment(rangeTime.start).toISOString();
+  const to = moment(rangeTime.end).valueOf();
+  const toDateSeconds = moment(rangeTime.end).unix();
+  const toDateISO = moment(rangeTime.end).toISOString();
+  return [
+    ...(dashboardMeta.variableConfigWithOptions ? dashboardMeta.variableConfigWithOptions : []),
+    { name: '__from', value: from },
+    { name: '__from_date_seconds', value: fromDateSeconds },
+    { name: '__from_date_iso', value: fromDateISO },
+    { name: '__from_date', value: fromDateISO },
+    { name: '__to', value: to },
+    { name: '__to_date_seconds', value: toDateSeconds },
+    { name: '__to_date_iso', value: toDateISO },
+    { name: '__to_date', value: toDateISO },
+  ];
+}
 
 export function filterOptionsByReg(options, reg, formData: IVariable[], limit: number, id: string) {
   reg = replaceExpressionVars(reg, formData, limit, id);

--- a/src/pages/dashboard/locale/en_US.ts
+++ b/src/pages/dashboard/locale/en_US.ts
@@ -183,6 +183,8 @@ const en_US = {
         donut: 'Donut',
         labelWithName: 'Label with name',
         labelWithValue: 'Label with metric value',
+        detailName: 'Link name',
+        detailUrl: 'Link addr',
       },
       table: {
         displayMode: 'Display mode',

--- a/src/pages/dashboard/locale/zh_CN.ts
+++ b/src/pages/dashboard/locale/zh_CN.ts
@@ -189,6 +189,8 @@ const zh_CN = {
         donut: '环图模式',
         labelWithName: 'label是否包含名称',
         labelWithValue: 'label显示指标值',
+        detailName: '链接名称',
+        detailUrl: '链接地址',
       },
       table: {
         displayMode: '显示模式',


### PR DESCRIPTION
https://github.com/n9e/fe/issues/26
 先实现的PIE， 配置添加到了图表样式
![image](https://user-images.githubusercontent.com/29848365/236357098-91178eac-c0aa-4b23-b749-01a137fded56.png)
![image](https://user-images.githubusercontent.com/29848365/236357212-b884c19f-458b-455e-93c2-1c898e99c15c.png)

实现了 
```
/dashboards/share/181?datasource=${__field.labels.cluster_id}&namespace=${__field.labels.namespace}&viewMode=fullscreen&value=${__field.__value}&name=${__field.__name__}  
-> 
/dashboards/share/181?datasource=61&namespace=jgfwptfz&viewMode=fullscreen&value=5&name=cluster170:jgfwptfz
```
