### PR TITLE
有道添加，告警升级

### DIFF
--- a/src/components/PromGraphCpt/metric.tsx
+++ b/src/components/PromGraphCpt/metric.tsx
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2022 Nightingale Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+/**
+ * 类似 prometheus graph 的组件
+ */
+import React, { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { Input, Tabs, Button, Alert, Checkbox } from 'antd';
+import { CloseSquareOutlined, GlobalOutlined } from '@ant-design/icons';
+import _ from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { IRawTimeRange } from '@/components/TimeRangePicker';
+import PromQueryBuilderModal from '@/components/PromQueryBuilder/PromQueryBuilderModal';
+import PromQLInput from '../PromQLInput';
+import Table from './Table';
+import Graph from './Graph';
+import QueryStatsView, { QueryStats } from './components/QueryStatsView';
+import MetricsExplorer from './components/MetricsExplorer';
+import './locale';
+import './style.less';
+
+interface IProps {
+  url?: string;
+  datasourceValue: number;
+  contentMaxHeight?: number;
+  type?: 'table' | 'graph';
+  onTypeChange?: (type: 'table' | 'graph') => void;
+  defaultTime?: IRawTimeRange | number;
+  onTimeChange?: (time: IRawTimeRange) => void; // 用于外部控制时间范围
+  promQL?: string;
+  graphOperates?: {
+    enabled: boolean;
+  };
+  readonly?: boolean;
+  onChange?: (prom_ql: string) => void;
+  executeQuery?: (promQL?: string) => void;
+}
+
+const TabPane = Tabs.TabPane;
+
+export default function index(props: IProps) {
+  const { t } = useTranslation('promGraphCpt');
+  const {
+    url = '/api/n9e/proxy',
+    datasourceValue,
+    promQL,
+    contentMaxHeight = 300,
+    type = 'table',
+    readonly,
+    onTypeChange,
+    onTimeChange,
+    graphOperates = {
+      enabled: false,
+    },
+    onChange,
+    executeQuery,
+  } = props;
+  const [value, setValue] = useState<string | undefined>(promQL); // for promQLInput
+  const [promql, setPromql] = useState<string | undefined>(promQL);
+  const [queryStats, setQueryStats] = useState<QueryStats | null>(null);
+  const [errorContent, setErrorContent] = useState('');
+  const [tabActiveKey, setTabActiveKey] = useState(type);
+  const [timestamp, setTimestamp] = useState<number>(); // for table
+  const [refreshFlag, setRefreshFlag] = useState(_.uniqueId('refreshFlag_')); // for table
+  const [range, setRange] = useState<IRawTimeRange>({ start: 'now-1h', end: 'now' }); // for graph
+  const [step, setStep] = useState<number>(); // for graph
+  const [metricsExplorerVisible, setMetricsExplorerVisible] = useState(false);
+  const [completeEnabled, setCompleteEnabled] = useState(true);
+  const [showPanel, setShow] = useState<boolean>(false)
+  const promQLInputRef = useRef<any>(null);
+
+  let defaultTime: undefined | IRawTimeRange;
+
+  if (typeof defaultTime === 'number') {
+    if (tabActiveKey == 'table') {
+      setTimestamp(defaultTime);
+    }
+  } else {
+    if (defaultTime?.start && defaultTime?.end) {
+      setRange(defaultTime);
+    }
+  }
+
+  useEffect(() => {
+    setTabActiveKey(type);
+  }, [type]);
+
+  useEffect(() => {
+    setValue(promql);
+    setPromql(promql);
+  }, [promql]);
+
+  return (
+    <div className='prom-graph-container'>
+      <div className='prom-graph-global-operate'>
+        <Checkbox
+          checked={completeEnabled}
+          onChange={(e) => {
+            setCompleteEnabled(e.target.checked);
+          }}
+        >
+          Enable autocomplete
+        </Checkbox>
+      </div>
+
+      <div className='prom-graph-expression-input'>
+        <Input.Group>
+          <span className='ant-input-affix-wrapper'>
+            <PromQLInput
+              ref={promQLInputRef}
+              url={url}
+              value={value}
+              readonly={readonly}
+              onChange={(val)=>{
+                setValue(val);
+                val && onChange && onChange(val);
+              }}
+              executeQuery={(val) => {
+                setPromql(val);
+                executeQuery && executeQuery(val);
+              }}
+              completeEnabled={completeEnabled}
+              datasourceValue={datasourceValue}
+            />
+            <span className='ant-input-suffix'>
+              <GlobalOutlined
+                className='prom-graph-metrics-target'
+                onClick={() => {
+                  setMetricsExplorerVisible(true);
+                }}
+              />
+            </span>
+          </span>
+          <span
+            className='ant-input-group-addon'
+            style={{
+              border: 0,
+              padding: '0 0 0 10px',
+              background: 'none',
+            }}
+          >
+            <Button
+              onClick={() => {
+                PromQueryBuilderModal({
+                  range,
+                  datasourceValue,
+                  value,
+                  onChange: setValue,
+                });
+              }}
+            >
+              {t('builder_btn')}
+            </Button>
+          </span>
+          <span
+            className='ant-input-group-addon'
+            style={{
+              border: 0,
+              padding: '0 0 0 10px',
+              background: 'none',
+            }}
+          >
+            <Button
+              type='primary'
+              onClick={() => {
+                setShow(true)
+                setRefreshFlag(_.uniqueId('refreshFlag_'));
+                setPromql(value);
+                executeQuery && executeQuery(value);
+              }}
+            >
+              {t('query_btn')}
+            </Button>
+          </span>
+        </Input.Group>
+      </div>
+      {errorContent && <Alert style={{ marginBottom: 16 }} message={errorContent} type='error' />}
+      { showPanel && 
+        <Tabs
+          destroyInactiveTabPane
+          tabBarGutter={0}
+          activeKey={tabActiveKey}
+          onChange={(key: 'table' | 'graph' | 'close') => {
+            if (key=='close'){
+              setShow(false)
+            }else{
+              setTabActiveKey(key);
+              onTypeChange && onTypeChange(key);
+              setErrorContent('');
+              setQueryStats(null);
+            }
+          }}
+          type='card'
+          tabBarExtraContent={queryStats && <QueryStatsView {...queryStats} />}
+        >
+          <TabPane tab='Table' key='table'>
+            <Table
+              url={url}
+              contentMaxHeight={contentMaxHeight}
+              datasourceValue={datasourceValue}
+              promql={promql}
+              setQueryStats={setQueryStats}
+              setErrorContent={setErrorContent}
+              timestamp={timestamp}
+              setTimestamp={(val) => {
+                setTimestamp(val);
+              }}
+              refreshFlag={refreshFlag}
+            />
+          </TabPane>
+          <TabPane tab='Graph' key='graph'>
+            <Graph
+              url={url}
+              contentMaxHeight={contentMaxHeight}
+              datasourceValue={datasourceValue}
+              promql={promql}
+              setQueryStats={setQueryStats}
+              setErrorContent={setErrorContent}
+              range={range}
+              setRange={(newRange) => {
+                setRange(newRange);
+                onTimeChange && onTimeChange(newRange);
+              }}
+              step={step}
+              setStep={setStep}
+              graphOperates={graphOperates}
+              refreshFlag={refreshFlag}
+            />
+          </TabPane>
+          <TabPane 
+            tab={
+              <div style={{color:"red"}}>
+                <CloseSquareOutlined />
+                隐藏
+              </div>
+            }
+            key='close'>
+          </TabPane>
+        </Tabs>
+      }
+      <MetricsExplorer
+        url={url}
+        datasourceValue={datasourceValue}
+        show={metricsExplorerVisible}
+        updateShow={setMetricsExplorerVisible}
+        insertAtCursor={(val) => {
+          if (promQLInputRef.current !== null) {
+            const { from, to } = promQLInputRef.current.state.selection.ranges[0];
+            promQLInputRef.current.dispatch(
+              promQLInputRef.current.state.update({
+                changes: { from, to, insert: val },
+              }),
+            );
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/PromQLInput/index.tsx
+++ b/src/components/PromQLInput/index.tsx
@@ -183,7 +183,7 @@ const ExpressionInput = (
 
       // view.focus();
     }
-  }, [onChange, JSON.stringify(headers), completeEnabled]);
+  }, [onChange, JSON.stringify(headers), completeEnabled,datasourceValue]);
 
   useEffect(() => {
     if (realValue.current !== value) {

--- a/src/pages/account/info.tsx
+++ b/src/pages/account/info.tsx
@@ -53,9 +53,7 @@ export default function Info() {
 
   const handleSubmit = async () => {
     try {
-      console.log(111);
       await form.validateFields();
-      console.log(222);
       updateProfile();
     } catch (err) {
       console.log(err);

--- a/src/pages/alertRules/Form/Combine.tsx
+++ b/src/pages/alertRules/Form/Combine.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Collapse } from 'antd';
+import { CaretRightOutlined,  } from '@ant-design/icons';
+import { panelBaseProps,  } from '../constants';
+import Combine from './components/combine'
+const { Panel } = Collapse;
+
+export default function index({disabled}) {
+  const { t } = useTranslation('alertRules');
+  return (
+    <Collapse {...panelBaseProps} defaultActiveKey={['0']}>
+      <Panel header="自定义报警通知" key="0">
+        <Collapse
+          accordion
+          defaultActiveKey={[]}
+          expandIcon={({ isActive }) => <CaretRightOutlined rotate={isActive ? 90 : 0} />}>
+          <Panel header="一级报警" key="1" forceRender={true}>
+            <Combine index={'1'} disabled={disabled} />
+          </Panel>
+          <Panel header="二级报警" key="2" forceRender={true}>
+            <Combine index={'2'} disabled={disabled} />
+          </Panel>
+          <Panel header="三级报警" key="3" forceRender={true}>
+            <Combine index={'3'} disabled={disabled} />
+          </Panel>
+        </Collapse>
+      </Panel>
+    </Collapse>
+  );
+}

--- a/src/pages/alertRules/Form/components/combine.tsx
+++ b/src/pages/alertRules/Form/components/combine.tsx
@@ -1,0 +1,177 @@
+import React, { useState, useEffect } from 'react';
+import _ from 'lodash';
+import { PlusCircleOutlined, MinusCircleOutlined } from '@ant-design/icons';
+import { getTeamInfoList, getNotifiesList } from '@/services/manage';
+import { useTranslation } from 'react-i18next';
+import { Form, Space, Select, TimePicker, Checkbox, Row, Col, InputNumber  } from 'antd';
+import { daysOfWeek } from '../../constants';
+interface IProps {
+    index: string;
+    disabled: boolean;
+  }
+export default function com(props: IProps) {
+  const { index, disabled } = props
+  const { t } = useTranslation('alertRules');
+  const [contactList, setContactList] = useState<{ key: string; label: string }[]>([]);
+  const [notifyGroups, setNotifyGroups] = useState<any[]>([]);
+  const getNotifyChannel = () => {
+    getNotifiesList().then((res) => {
+      setContactList(res || []);
+    });
+  };
+  const getGroups = async (str) => {
+    const res = await getTeamInfoList({ query: str });
+    const data = res.dat || res;
+    setNotifyGroups(data || []);
+  };
+
+  useEffect(() => {
+    getGroups('');
+    getNotifyChannel();
+  }, []);
+
+  return (
+    <div>
+      <Form.List name={['rule_config', 'alert_configs', index,'effective_time']}>
+      {(fields, { add, remove }) => (
+          <>
+          <Space>
+              <div style={{ width: 450 }}>
+              <Space align='baseline'>
+                  {t('effective_time')}
+                  <PlusCircleOutlined className='control-icon-normal' onClick={() => add()} />
+              </Space>
+              </div>
+              <div style={{ width: 110 }}>{t('effective_time_start')}</div>
+              <div style={{ width: 110 }}>{t('effective_time_end')}</div>
+          </Space>
+          {fields.map(({ key, name, ...restField }) => (
+              <Space
+              key={key}
+              style={{
+                  display: 'flex',
+                  marginBottom: 8,
+              }}
+              align='baseline'
+              >
+              <Form.Item
+                  {...restField}
+                  name={[name, 'enable_days_of_week']}
+                  style={{ width: 450 }}
+                  rules={[
+                  {
+                      required: true,
+                      message: t('effective_time_week_msg'),
+                  },
+                  ]}
+              >
+                  <Select mode='tags'>
+                  {daysOfWeek.map((item) => {
+                      return (
+                      <Select.Option key={item} value={String(item)}>
+                          {t(`common:time.weekdays.${item}`)}
+                      </Select.Option>
+                      );
+                  })}
+                  </Select>
+              </Form.Item>
+              <Form.Item
+                  {...restField}
+                  name={[name, 'enable_stime']}
+                  style={{ width: 110 }}
+                  rules={[
+                  {
+                      required: true,
+                      message: t('effective_time_start_msg'),
+                  },
+                  ]}
+              >
+                  <TimePicker format='HH:mm' />
+              </Form.Item>
+              <Form.Item
+                  {...restField}
+                  name={[name, 'enable_etime']}
+                  style={{ width: 110 }}
+                  rules={[
+                  {
+                      required: true,
+                      message: t('effective_time_end_msg'),
+                  },
+                  ]}
+              >
+                  <TimePicker format='HH:mm' />
+              </Form.Item>
+              <MinusCircleOutlined onClick={() => remove(name)} />
+            </Space>
+          ))}
+          </>
+      )}
+      </Form.List>
+      <Form.Item label={t('notify_channels')} name={['rule_config', 'alert_configs', index,'notify_channels']}>
+        <Checkbox.Group disabled={disabled}>
+          {contactList.map((item) => {
+            return (
+              <Checkbox value={item.key} key={item.label}>
+                {item.label}
+              </Checkbox>
+            );
+          })}
+        </Checkbox.Group>
+      </Form.Item>
+      <Form.Item label={t('notify_groups')} name={['rule_config', 'alert_configs', index,'notify_groups']}>
+        <Select mode='multiple' showSearch optionFilterProp='children'>
+          {_.map(notifyGroups, (item) => {
+            // id to string 兼容 v5
+            return (
+              <Select.Option value={_.toString(item.id)} key={item.id}>
+                {item.name}
+              </Select.Option>
+            );
+          })}
+        </Select>
+      </Form.Item>
+      
+      <Form.Item shouldUpdate noStyle>
+        {({ getFieldValue }) => {
+          return (
+            <Row gutter={16}>
+              <Col span={8}>
+                <Form.Item label={t('recover_duration')} name={['rule_config', 'alert_configs', index,'recover_duration']} tooltip={t('recover_duration_tip', { num: getFieldValue('recover_duration') })}>
+                  <InputNumber min={0} style={{ width: '100%' }} />
+                </Form.Item>
+              </Col>
+              <Col span={8}>
+                <Form.Item
+                  label={t('notify_repeat_step')}
+                  name={['rule_config', 'alert_configs', index,'notify_repeat_step']}
+                  rules={[
+                    {
+                      required: true,
+                    },
+                  ]}
+                  tooltip={t('notify_repeat_step_tip', { num: getFieldValue('notify_repeat_step') })}
+                >
+                  <InputNumber min={0} style={{ width: '100%' }} />
+                </Form.Item>
+              </Col>
+              <Col span={8}>
+                <Form.Item
+                  label={t('notify_max_number')}
+                  name={['rule_config', 'alert_configs', index,'notify_max_number']}
+                  rules={[
+                    {
+                      required: true,
+                    },
+                  ]}
+                  tooltip={t('notify_max_number_tip')}
+                >
+                  <InputNumber min={0} precision={0} style={{ width: '100%' }} />
+                </Form.Item>
+              </Col>
+            </Row>
+          );
+        }}
+      </Form.Item>
+    </div>
+  );
+}

--- a/src/pages/alertRules/Form/constants.ts
+++ b/src/pages/alertRules/Form/constants.ts
@@ -22,8 +22,48 @@ export const defaultRuleConfig = {
       {
         prom_ql: '',
         severity: 2,
+        custom_notify:false,
+        title:''
       },
     ],
+    alert_configs:{
+      "1":{
+        effective_time: [
+          {
+            enable_days_of_week: ['0', '1', '2', '3', '4', '5', '6'],
+            enable_stime: moment('00:00', 'HH:mm'),
+            enable_etime: moment('23:59', 'HH:mm'),
+          },
+        ],
+        recover_duration: 0,
+        notify_repeat_step: 60,
+        notify_max_number: 0,
+      },
+      "2":{
+        effective_time: [
+          {
+            enable_days_of_week: ['0', '1', '2', '3', '4', '5', '6'],
+            enable_stime: moment('00:00', 'HH:mm'),
+            enable_etime: moment('23:59', 'HH:mm'),
+          },
+        ],
+        recover_duration: 0,
+        notify_repeat_step: 60,
+        notify_max_number: 0,
+      },
+      "3":{
+        effective_time: [
+          {
+            enable_days_of_week: ['0', '1', '2', '3', '4', '5', '6'],
+            enable_stime: moment('00:00', 'HH:mm'),
+            enable_etime: moment('23:59', 'HH:mm'),
+          },
+        ],
+        recover_duration: 0,
+        notify_repeat_step: 60,
+        notify_max_number: 0,
+      }
+    }
   },
   logging: {
     queries: [
@@ -75,7 +115,7 @@ export const defaultValues = {
   prom_for_duration: 60,
   prod: 'metric',
   cate: 'prometheus',
-  enable_status: true,
+  enable_status: true
 };
 
 export const ruleTypeOptions = [
@@ -83,8 +123,8 @@ export const ruleTypeOptions = [
     label: 'Metric',
     value: 'metric',
   },
-  {
-    label: 'Host',
-    value: 'host',
-  },
+  // {
+  //   label: 'Host',
+  //   value: 'host',
+  // },
 ];

--- a/src/pages/alertRules/Form/index.tsx
+++ b/src/pages/alertRules/Form/index.tsx
@@ -27,6 +27,7 @@ import Effective from './Effective';
 import Notify from './Notify';
 import { getFirstDatasourceId, processFormValues, processInitialValues } from './utils';
 import { defaultValues } from './constants';
+import Combine from './Combine';
 
 interface IProps {
   type?: number; // 空: 新增 1:编辑 2:克隆 3:查看
@@ -43,7 +44,7 @@ export default function index(props: IProps) {
   const { bgid } = useParams<{ bgid: string }>();
   const { t } = useTranslation('alertRules');
   const [form] = Form.useForm();
-  const { groupedDatasourceList } = useContext(CommonStateContext);
+  // const { groupedDatasourceList } = useContext(CommonStateContext);
   const disabled = type === 3;
   const handleCheck = async (values) => {
     if (values.cate === 'prometheus') {
@@ -93,8 +94,9 @@ export default function index(props: IProps) {
   };
 
   useEffect(() => {
-    if (type === 1 || type === 2 || type === 3) {
-      form.setFieldsValue(processInitialValues(initialValues));
+    if ((type === 1 || type === 2 || type === 3) ) {
+      let val = processInitialValues(initialValues)
+      form.setFieldsValue(val);
     } else {
       form.setFieldsValue(defaultValues);
     }
@@ -115,6 +117,7 @@ export default function index(props: IProps) {
           <Rule form={form} />
           <Effective />
           <Notify disabled={disabled} />
+          <Combine disabled={disabled}/>
           {!disabled && (
             <Space>
               <Button

--- a/src/pages/alertRules/Form/utils.ts
+++ b/src/pages/alertRules/Form/utils.ts
@@ -96,6 +96,26 @@ export function processFormValues(values) {
       }
       return trigger;
     });
+  } else if (values.prod === 'metric') {
+    if (values.rule_config.alert_configs) {
+      ["1","2","3"].forEach((key)=>{
+        if (!values.rule_config.alert_configs.hasOwnProperty(key)){
+          values.rule_config.alert_configs[key]=defaultRuleConfig.metric.alert_configs[key]
+        }
+      })
+    } else {
+      values.rule_config['alert_configs'] = defaultRuleConfig.metric.alert_configs
+    }
+    Object.keys(values.rule_config.alert_configs).forEach((key)=>{
+      if(values.rule_config.alert_configs[key].effective_time){
+        values.rule_config.alert_configs[key]={
+          ..._.omit(values.rule_config.alert_configs[key], 'effective_time'),
+          enable_days_of_weeks: values.rule_config.alert_configs[key].effective_time.map((item) => item.enable_days_of_week),
+          enable_stimes: values.rule_config.alert_configs[key].effective_time.map((item) => item.enable_stime.format('HH:mm')),
+          enable_etimes: values.rule_config.alert_configs[key].effective_time.map((item) => item.enable_etime.format('HH:mm'))
+        }
+      }
+    })
   }
   const data = {
     ..._.omit(values, 'effective_time'),
@@ -122,6 +142,38 @@ export function processInitialValues(values) {
         interval_unit: parseTimeToValueAndUnit(item.interval).unit,
       };
     });
+  } else if (values.prod === 'metric' && values.rule_config.alert_configs) {
+    ["1","2","3"].forEach((key)=>{
+      if (!values.rule_config.alert_configs.hasOwnProperty(key)){
+        values.rule_config.alert_configs[key]={
+          effective_time: [
+            {
+              enable_days_of_week: ['0', '1', '2', '3', '4', '5', '6'],
+              enable_stime: moment('00:00', 'HH:mm'),
+              enable_etime: moment('23:59', 'HH:mm'),
+            },
+          ],
+          recover_duration: 0,
+          notify_repeat_step: 60,
+          notify_max_number: 0,
+        }
+      }
+    })
+    Object.keys(values.rule_config.alert_configs).forEach((key)=>{
+      values.rule_config.alert_configs[key]["effective_time"]=values.rule_config.alert_configs[key]?.enable_etimes
+      ? values.rule_config.alert_configs[key]?.enable_etimes.map((item, index) => ({
+          enable_stime: moment(values.rule_config.alert_configs[key].enable_stimes[index], 'HH:mm'),
+          enable_etime: moment(values.rule_config.alert_configs[key].enable_etimes[index], 'HH:mm'),
+          enable_days_of_week: values.rule_config.alert_configs[key].enable_days_of_weeks[index],
+        }))
+      : [
+          {
+            enable_stime: moment('00:00', 'HH:mm'),
+            enable_etime: moment('23:59', 'HH:mm'),
+            enable_days_of_week: ['1', '2', '3', '4', '5', '6', '0'],
+          },
+        ]
+    })
   }
   return {
     ...values,

--- a/src/pages/alertRules/List/MoreOperations.tsx
+++ b/src/pages/alertRules/List/MoreOperations.tsx
@@ -104,7 +104,7 @@ export default function MoreOperations(props: MoreOperationsProps) {
             >
               <span>{t('batch.delete')}</span>
             </li>
-            <li
+            {/* <li
               className='ant-dropdown-menu-item'
               onClick={() => {
                 if (selectRowKeys.length == 0) {
@@ -115,7 +115,7 @@ export default function MoreOperations(props: MoreOperationsProps) {
               }}
             >
               <span>{t('batch.update.title')}</span>
-            </li>
+            </li> */}
           </ul>
         }
         trigger={['click']}

--- a/src/pages/alertRules/locale/zh_CN.ts
+++ b/src/pages/alertRules/locale/zh_CN.ts
@@ -9,7 +9,7 @@ const zh_CN = {
   append_tags: '附加标签',
   append_tags_msg: '标签格式不正确，请检查！',
   append_tags_msg1: '标签长度应小于等于 64 位',
-  append_tags_msg2: '标签格式应为 key=value。且 key 以字母或下划线开头，由字母、数字和下划线组成。',
+  append_tags_msg2: '标签格式应为 key=value。且 key 以字母或下划线开头，由字母、数字和下划线组成。[cmdb_为保留前缀]',
   append_tags_placeholder: '标签格式为 key=value ，使用回车或空格分隔',
   note: '备注',
   rule_configs: '规则配置',

--- a/src/pages/collects/Form/index.tsx
+++ b/src/pages/collects/Form/index.tsx
@@ -60,7 +60,6 @@ export default function index(props: IProps) {
 
   useEffect(() => {
     if (type === 1 || type === 2 || type === 3) {
-      console.log(processInitialValues(initialValues));
       form.setFieldsValue(processInitialValues(initialValues));
     } else {
       form.setFieldsValue({

--- a/src/pages/event/Detail/Prometheus.tsx
+++ b/src/pages/event/Detail/Prometheus.tsx
@@ -13,7 +13,6 @@ interface IProps {
 
 export default function PrometheusDetail(props: IProps) {
   const { eventDetail, history } = props;
-
   return [
     {
       label: 'PromQL',
@@ -24,6 +23,11 @@ export default function PrometheusDetail(props: IProps) {
           <div style={{ width: '100%' }}>
             {_.map(queries, (query) => {
               const { prom_ql } = query;
+              if (typeof eventDetail.prom_ql === 'string' && eventDetail.prom_ql.length != 0 ) {
+                if (prom_ql != eventDetail.prom_ql ) {
+                  return
+                }
+              }
               return (
                 <Row className='promql-row' key={prom_ql}>
                   <Col span={20}>

--- a/src/pages/historyEvents/index.tsx
+++ b/src/pages/historyEvents/index.tsx
@@ -105,7 +105,14 @@ const Event: React.FC = () => {
         );
       },
     },
-
+    {
+      title: t('状态'),
+      dataIndex: 'is_recovered',
+      width: 60,
+      render(isRecovered) {
+        return <Tag color={isRecovered ? 'green' : 'red'}>{isRecovered ? 'Recovered' : 'Triggered'}</Tag>;
+      },
+    },
     {
       title: t('last_eval_time'),
       dataIndex: 'last_eval_time',

--- a/src/pages/recordingRules/PageTable.tsx
+++ b/src/pages/recordingRules/PageTable.tsx
@@ -281,7 +281,7 @@ const PageTable: React.FC<Props> = ({ bgid }) => {
         >
           <span>{t('batch.delete')}</span>
         </li>
-        <li
+        {/* <li
           className='ant-dropdown-menu-item'
           onClick={() => {
             if (selectRowKeys.length == 0) {
@@ -292,7 +292,7 @@ const PageTable: React.FC<Props> = ({ bgid }) => {
           }}
         >
           <span>{t('batch.update.title')}</span>
-        </li>
+        </li> */}
       </ul>
     );
   }, [selectRowKeys, t]);

--- a/src/pages/recordingRules/locale/zh_CN.ts
+++ b/src/pages/recordingRules/locale/zh_CN.ts
@@ -11,7 +11,7 @@ const zh_CN = {
   append_tags: '附加标签',
   append_tags_msg: '标签格式不正确，请检查！',
   append_tags_msg1: '标签长度应小于等于 64 位',
-  append_tags_msg2: '标签格式应为 key=value。且 key 以字母或下划线开头，由字母、数字和下划线组成。',
+  append_tags_msg2: '标签格式应为 key=value。且 key 以字母或下划线开头，由字母、数字和下划线组成。[cmdb_为保留前缀]',
   append_tags_placeholder: '标签格式为 key=value ，使用回车或空格分隔',
   batch: {
     must_select_one: '未选择任何规则',

--- a/src/pages/targets/locale/en_US.ts
+++ b/src/pages/targets/locale/en_US.ts
@@ -33,6 +33,7 @@ const en_US = {
   bind_tag: {
     title: 'Bind tag',
     placeholder: 'Tag format is key=value, separated by enter or space',
+    placeholder_select: '',
     msg1: 'Please fill in at least one tag!',
     msg2: 'Tag format is incorrect, please check!',
     render_tip1: 'Tag length should be less than or equal to 64 bits',

--- a/src/pages/targets/locale/zh_CN.ts
+++ b/src/pages/targets/locale/zh_CN.ts
@@ -33,10 +33,11 @@ const zh_CN = {
   bind_tag: {
     title: '绑定标签',
     placeholder: '标签格式为 key=value ，使用回车或空格分隔',
+    placeholder_select: '选择标签或自定义新增标签',
     msg1: '请填写至少一项标签！',
     msg2: '标签格式不正确，请检查！',
     render_tip1: '标签长度应小于等于 64 位',
-    render_tip2: '标签格式应为 key=value。且 key 以字母或下划线开头，由字母、数字和下划线组成。',
+    render_tip2: '标签格式应为 key=value。且 key 以字母或下划线开头，由字母、数字和下划线组成。[cmdb_为保留前缀]',
   },
   unbind_tag: {
     title: '解绑标签',

--- a/src/routers/index.tsx
+++ b/src/routers/index.tsx
@@ -140,8 +140,9 @@ export default function Content() {
 
         <Route exact path='/alert-cur-events' component={Event} />
         <Route exact path='/alert-his-events' component={historyEvents} />
-        <Route exact path='/alert-cur-events/:eventId' component={EventDetail} />
-        <Route exact path='/alert-his-events/:eventId' component={EventDetail} />
+        <Route exact path='/alert-cur-events/:eventCode' component={EventDetail} />
+        <Route exact path='/alert-his-events/:eventCode' component={EventDetail} />
+        <Route exact path='/alert-events/:eventCode' component={EventDetail} />
         <Route exact path='/targets' component={Targets} />
 
         <Route exact path='/job-tpls' component={TaskTpl} />

--- a/src/services/warning.ts
+++ b/src/services/warning.ts
@@ -233,6 +233,12 @@ export function getHistoryEventsById(busiId, eventId) {
     method: RequestMethod.Get,
   });
 }
+
+export function getAlertEventsByCode(busiId, eventCode) {
+  return request(`/api/n9e/alert-event/${eventCode}`, {
+    method: RequestMethod.Get,
+  });
+}
 /**
  * 批量删除(忽略)告警历史
  */


### PR DESCRIPTION
用来解决运维监控下，告警升级定制功能。除了可以通过订阅来实现持续时长的升级，还能支持不同阈值的告警升级。基于现在的告警抑制功能，我们在同一个规则下配置相同条件不同阈值，并且设置不同的告警级别，这样可以满足需求，但是希望不同级别的告警可以定制发送方式，比如说一级告警非常紧急必须电话通知，二级、三级简单通知即可，所以进行了定制。改动如下

支持为每个查询条件设置描述信息、生效时间、通知媒介、告警接收组、留观时长、重复发送间隔、最大发送次数等配置项
每个查询条件下增加一键查询数据源的功能，方面管理员配置规则前进行查询，减少误报
增加内置告警详情页，/alert-events/:hash，以便在告警消息中应用，打开实时查看。(现在的alert-cur-event和alert-his-event使用的id查询，每次都会生成新事件，id会变，对用户不友好)

希望能合并到社区版本，让夜莺v6版本功能更丰富，让监控功能更强大
后端已经提交pr：https://github.com/ccfos/nightingale/pull/1544