### PR TITLE
feat(dashboard): add Legend detail

### DIFF
--- a/src/pages/dashboard/Editor/Fields/Legend/index.tsx
+++ b/src/pages/dashboard/Editor/Fields/Legend/index.tsx
@@ -15,9 +15,9 @@
  *
  */
 import React from 'react';
-import { Form, Radio, Row, Col, Select } from 'antd';
+import { Form, Radio, Row, Col, Select, Input } from 'antd';
 import _ from 'lodash';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { Panel } from '../../Components/Collapse';
 import { CaretDownOutlined } from '@ant-design/icons';
 
@@ -28,7 +28,7 @@ export default function index() {
 
   return (
     <Panel header='Legend'>
-      <Row>
+      <Row gutter={10}>
         <Col span={12}>
           <Form.Item label={t('panel.options.legend.displayMode.label')} name={[...namePrefix, 'displayMode']}>
             <Radio.Group buttonStyle='solid'>
@@ -67,6 +67,23 @@ export default function index() {
               }
               return null;
             }}
+          </Form.Item>
+        </Col>
+        <Col span={9}>
+          <Form.Item label={t('panel.custom.detailName')} name={[...namePrefix, 'detailName']}>
+            <Input style={{ width: '100%' }} />
+          </Form.Item>
+        </Col>
+        <Col span={15}>
+          <Form.Item
+            label={t('panel.custom.detailUrl')}
+            name={[...namePrefix, 'detailUrl']}
+            tooltip={{
+              overlayInnerStyle: { width: 330 },
+              title: <Trans ns='dashboard' i18nKey='dashboard:link.url_tip' components={{ 1: <br /> }} />,
+            }}
+          >
+            <Input style={{ width: '100%' }} />
           </Form.Item>
         </Col>
       </Row>

--- a/src/pages/dashboard/Editor/Fields/Legend/index.tsx
+++ b/src/pages/dashboard/Editor/Fields/Legend/index.tsx
@@ -29,7 +29,7 @@ export default function index() {
   return (
     <Panel header='Legend'>
       <Row gutter={10}>
-        <Col span={12}>
+        <Col span={9}>
           <Form.Item label={t('panel.options.legend.displayMode.label')} name={[...namePrefix, 'displayMode']}>
             <Radio.Group buttonStyle='solid'>
               <Radio.Button value='table'>{t('panel.options.legend.displayMode.table')}</Radio.Button>
@@ -38,7 +38,7 @@ export default function index() {
             </Radio.Group>
           </Form.Item>
         </Col>
-        <Col span={12}>
+        <Col span={15}>
           <Form.Item noStyle shouldUpdate={(prevValues, curValues) => _.get(prevValues, [...namePrefix, 'displayMode']) !== _.get(curValues, [...namePrefix, 'displayMode'])}>
             {({ getFieldValue }) => {
               if (getFieldValue([...namePrefix, 'displayMode']) === 'list') {

--- a/src/pages/dashboard/types.ts
+++ b/src/pages/dashboard/types.ts
@@ -84,6 +84,8 @@ export interface IOptions {
     displayMode: 'list' | 'table' | 'hidden';
     placement: 'right' | 'bottom';
     columns?: string[];
+    detailName: string;
+    detailUrl: string;
   };
   tooltip?: {
     mode: 'single' | 'all';


### PR DESCRIPTION
给 Timeseries 的Legend 添加下钻,
配置方式
![image](https://github.com/n9e/fe/assets/29848365/a7a3a487-fa09-4ef8-9f13-8d338f21772c)
展示效果- 表格
![image](https://github.com/n9e/fe/assets/29848365/ff7082e4-e95a-4674-8849-be65fcfa0e2c)
展示效果-列表
![image](https://github.com/n9e/fe/assets/29848365/49933ef7-31de-4968-99cc-d3bc42487834)
