### PR TITLE
fix: Ensure that namePathValues is a valid array

### DIFF
--- a/src/pages/alertRules/Form/Rule/Rule/Metric/Prometheus/VariablesConfig/index.tsx
+++ b/src/pages/alertRules/Form/Rule/Rule/Metric/Prometheus/VariablesConfig/index.tsx
@@ -185,7 +185,11 @@ export default function index(props: Props) {
         }}
         onOk={(vals) => {
           const values = _.cloneDeep(form.getFieldsValue());
-          const namePathValues = _.get(values, namePath, []);
+          let namePathValues = _.get(values, namePath, []);
+          // Ensure that namePathValues is a valid array
+          if (namePathValues === null) {
+            namePathValues = [];
+          }
           if (editModalData.action === 'create') {
             _.set(values, namePath, _.concat(namePathValues, [vals]));
           } else if (editModalData.action === 'edit') {


### PR DESCRIPTION
当首次启用变量时，param_val路径存在值为null, _.concat(namePathValues, [vals])) 会得到[null, vals]