### PR TITLE
fix: update tooltip overlay style property

### DIFF
--- a/src/pages/dashboard/Renderer/Renderer/index.tsx
+++ b/src/pages/dashboard/Renderer/Renderer/index.tsx
@@ -196,7 +196,7 @@ function index(props: IProps) {
             <Tooltip
               title={error}
               placement='leftTop'
-              overlayInnerStyle={{
+              overlayStyle={{
                 maxWidth: 300,
               }}
               getPopupContainer={() => ref.current!}
@@ -218,7 +218,7 @@ function index(props: IProps) {
             {tipsVisible ? (
               <Tooltip
                 placement='top'
-                overlayInnerStyle={{
+                overlayStyle={{
                   maxWidth: 300,
                 }}
                 getPopupContainer={() => ref.current!}


### PR DESCRIPTION
By default, the tooltip card's `max-width` is set to `250px`, which can be overridden using `overlayStyle`. However, setting `max-width` greater than `250px` via `overlayInnerStyle` has no effect, since the inner content is constrained by the card's width. [\[1\]](https://4x.ant.design/components/tooltip/)

<img width="746" alt="image" src="https://github.com/user-attachments/assets/4abada96-04a0-4804-8483-bf6713a25305" />

I moved the `max-width` style from `OverlayInner` to `Overlay`. This ensures that the max-width is actually applied.

## Before

<img width="372" alt="image" src="https://github.com/user-attachments/assets/a5504800-0f01-4fbd-886d-a45f1726fc3f" />

## After

<img width="398" alt="image" src="https://github.com/user-attachments/assets/aa1ca30e-3c0c-48d9-853b-d5a03380db46" />
