### PR TITLE
refactor: change tag click to double-click in alert event tables

### DIFF
--- a/src/pages/alertCurEvent/pages/List/AlertTable.tsx
+++ b/src/pages/alertCurEvent/pages/List/AlertTable.tsx
@@ -112,7 +112,7 @@ export default function AlertTable(props: IProps) {
                   <Tag
                     key={item}
                     style={{ maxWidth: '100%' }}
-                    onClick={() => {
+                    onDoubleClick={() => {
                       if (!_.includes(filter.query, item)) {
                         setFilter({
                           ...filter,

--- a/src/pages/event/Table.tsx
+++ b/src/pages/event/Table.tsx
@@ -84,7 +84,7 @@ export default function TableCpt(props: IProps) {
                     <Tag
                       // color='purple'
                       style={{ maxWidth: '100%' }}
-                      onClick={() => {
+                      onDoubleClick={() => {
                         if (!filter.queryContent.includes(item)) {
                           setFilter({
                             ...filter,


### PR DESCRIPTION
## 描述

将告警事件列表和历史事件列表中标签的单击事件改为双击事件，避免用户误触导致意外添加过滤条件。

## 变更内容

- src/pages/alertCurEvent/pages/List/AlertTable.tsx: 将 Tag 组件的 `onClick` 改为 `onDoubleClick`
- src/pages/event/Table.tsx: 将 Tag 组件的 `onClick` 改为 `onDoubleClick`


## 相关 Issue

Fixes https://github.com/ccfos/nightingale/issues/2825



## Checklist

- [x] 代码遵循项目的代码规范
- [x] 已在本地测试验证功能正常
- [x] 变更不会影响现有功能
- [x] 已关联相关 Issue
