### PR TITLE
refactor: hide template select and use full-width layout for callback channel

### DIFF
--- a/src/pages/notificationRules/pages/Form/RuleConfig.tsx
+++ b/src/pages/notificationRules/pages/Form/RuleConfig.tsx
@@ -73,7 +73,7 @@ export default function NotifyConfig(props: Props) {
       )}
       <div className='p-4 pb-0 mb-4 rounded bg-fc-100 fc-border'>
         <Row gutter={SIZE}>
-          <Col span={channelItem?.request_type !== 'flashduty' && channelItem?.request_type !== 'pagerduty' ? 12 : 24}>
+          <Col span={channelItem?.request_type !== 'flashduty' && channelItem?.request_type !== 'pagerduty' && channelItem?.ident !== 'callback' ? 12 : 24}>
             <ChannelSelect
               prefixNamePath={['notify_configs']}
               field={field}
@@ -82,7 +82,7 @@ export default function NotifyConfig(props: Props) {
               }}
             />
           </Col>
-          {channelItem?.request_type !== 'flashduty' && channelItem?.request_type !== 'pagerduty' && (
+          {channelItem?.request_type !== 'flashduty' && channelItem?.request_type !== 'pagerduty' && channelItem?.ident !== 'callback' && (
             <Col span={12}>
               <TemplateSelect prefixNamePath={['notify_configs']} field={field} />
             </Col>


### PR DESCRIPTION
<img width="3374" height="582" alt="image" src="https://github.com/user-attachments/assets/251fb13d-d03c-4341-aae7-67b85c43737a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification rule configuration form layout for callback channels. Template selection field is now properly hidden when using callback channel type, allowing the channel selection field to expand and utilize the full available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->