### PR TITLE
feat(theme): fc-menu-dark token and outlined style polish

### DIFF
--- a/src/components/OutlinedAutoComplete/style.less
+++ b/src/components/OutlinedAutoComplete/style.less
@@ -12,7 +12,7 @@
     left: 9px;
     top: 50%;
     transform: translateY(-50%);
-    background: var(--fc-fill-2); // 使用主题背景色
+    background: var(--fc-fill-2-5); // 使用主题背景色
     color: var(--fc-text-placeholder); // 使用占位符文本色
     padding: 0 4px;
     font-size: 12px;

--- a/src/components/OutlinedInput/style.less
+++ b/src/components/OutlinedInput/style.less
@@ -12,7 +12,7 @@
     left: 9px;
     top: 50%;
     transform: translateY(-50%);
-    background: var(--fc-fill-2); // 使用主题背景色
+    background: var(--fc-fill-2-5); // 使用主题背景色
     color: var(--fc-text-placeholder); // 使用占位符文本色
     padding: 0 4px;
     font-size: 12px;

--- a/src/components/OutlinedInputNumber/style.less
+++ b/src/components/OutlinedInputNumber/style.less
@@ -12,7 +12,7 @@
     left: 9px;
     top: 50%;
     transform: translateY(-50%);
-    background: var(--fc-fill-2); // 使用主题背景色
+    background: var(--fc-fill-2-5); // 使用主题背景色
     color: var(--fc-text-placeholder); // 使用占位符文本色
     padding: 0 4px;
     font-size: 12px;

--- a/src/components/OutlinedSelect/style.less
+++ b/src/components/OutlinedSelect/style.less
@@ -12,7 +12,7 @@
     left: 9px;
     top: 50%;
     transform: translateY(-50%);
-    background: var(--fc-fill-2); // 使用主题背景色
+    background: var(--fc-fill-2-5); // 使用主题背景色
     color: var(--fc-text-placeholder); // 使用占位符文本色
     padding: 0 4px;
     font-size: 12px;

--- a/src/components/SideMenu/menu.less
+++ b/src/components/SideMenu/menu.less
@@ -130,11 +130,11 @@
 }
 
 .sidemenu-hover-panel--light .sidemenu-hover-panel-header-title {
-  color: var(--fc-text-1);
+  color: var(--fc-sidemenu-subitem-text);
 }
 
 .sidemenu-hover-panel--on-dark .sidemenu-hover-panel-header-title {
-  color: var(--fc-text-2, #e6e6e8);
+  color: var(--fc-sidemenu-subitem-text);
 }
 
 .sidemenu-hover-panel-divider {

--- a/src/components/SideMenu/menu.test.ts
+++ b/src/components/SideMenu/menu.test.ts
@@ -1,0 +1,15 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('SideMenu hover panel styles', () => {
+  it('uses the submenu text token for the hover panel header title in both themes', () => {
+    const lessPath = path.join(__dirname, 'menu.less');
+    const content = fs.readFileSync(lessPath, 'utf8');
+
+    expect(content).toContain('.sidemenu-hover-panel--light .sidemenu-hover-panel-header-title');
+    expect(content).toContain('color: var(--fc-sidemenu-subitem-text);');
+    expect(content).toContain('.sidemenu-hover-panel--on-dark .sidemenu-hover-panel-header-title');
+    expect(content).not.toContain('.sidemenu-hover-panel--light .sidemenu-hover-panel-header-title {\n  color: var(--fc-text-1);');
+    expect(content).not.toContain('.sidemenu-hover-panel--on-dark .sidemenu-hover-panel-header-title {\n  color: var(--fc-text-2, #e6e6e8);');
+  });
+});

--- a/src/components/pageLayout/SideMenuColorSetting/index.test.ts
+++ b/src/components/pageLayout/SideMenuColorSetting/index.test.ts
@@ -1,0 +1,13 @@
+/// <reference types="jest" />
+
+jest.mock('@/App', () => ({
+  CommonStateContext: {},
+}));
+
+import { getSideMenuBgColor } from './index';
+
+describe('getSideMenuBgColor', () => {
+  it('uses the dark menu background variable for dark mode menus', () => {
+    expect(getSideMenuBgColor('dark')).toBe('var(--fc-menu-dark-bg)');
+  });
+});

--- a/src/components/pageLayout/SideMenuColorSetting/index.tsx
+++ b/src/components/pageLayout/SideMenuColorSetting/index.tsx
@@ -10,7 +10,7 @@ export const getSideMenuBgColor = (color: SideMenuColors) => {
     case 'light':
       return 'var(--fc-sidemenu-bg)';
     case 'dark':
-      return 'rgb(24, 27, 31)';
+      return 'var(--fc-menu-dark-bg)';
     case 'theme':
       return THEME_COLOR;
     default:

--- a/src/theme/antd.dark.less
+++ b/src/theme/antd.dark.less
@@ -7413,7 +7413,7 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 }
 .ant-dropdown-menu-dark,
 .ant-dropdown-menu-dark .ant-dropdown-menu {
-  background: #181b1f;
+  background: var(--fc-menu-dark-bg);
 }
 .ant-dropdown-menu-dark .ant-dropdown-menu-item,
 .ant-dropdown-menu-dark .ant-dropdown-menu-submenu-title,
@@ -16680,7 +16680,7 @@ textarea.ant-mentions {
 .ant-menu-dark .ant-menu-sub,
 .ant-menu.ant-menu-dark .ant-menu-sub {
   color: rgba(255, 255, 255, 0.65);
-  background: #181b1f;
+  background: var(--fc-menu-dark-bg);
 }
 .ant-menu.ant-menu-dark .ant-menu-submenu-title .ant-menu-submenu-arrow,
 .ant-menu-dark .ant-menu-sub .ant-menu-submenu-title .ant-menu-submenu-arrow,
@@ -16700,7 +16700,7 @@ textarea.ant-mentions {
   background: transparent;
 }
 .ant-menu-dark .ant-menu-inline.ant-menu-sub {
-  background: #181b1f;
+  background: var(--fc-menu-dark-sub-bg);
 }
 .ant-menu-dark.ant-menu-horizontal {
   border-bottom: 0;
@@ -16710,7 +16710,7 @@ textarea.ant-mentions {
   top: 0;
   margin-top: 0;
   padding: 0 20px;
-  border-color: #181b1f;
+  border-color: var(--fc-menu-dark-bg);
   border-bottom: 0;
 }
 .ant-menu-dark.ant-menu-horizontal > .ant-menu-item:hover {

--- a/src/theme/antd.light-blue.less
+++ b/src/theme/antd.light-blue.less
@@ -7413,7 +7413,7 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 }
 .ant-dropdown-menu-dark,
 .ant-dropdown-menu-dark .ant-dropdown-menu {
-  background: #001529;
+  background: var(--fc-menu-dark-bg);
 }
 .ant-dropdown-menu-dark .ant-dropdown-menu-item,
 .ant-dropdown-menu-dark .ant-dropdown-menu-submenu-title,
@@ -16675,7 +16675,7 @@ textarea.ant-mentions {
 .ant-menu-dark .ant-menu-sub,
 .ant-menu.ant-menu-dark .ant-menu-sub {
   color: rgba(255, 255, 255, 0.65);
-  background: #001529;
+  background: var(--fc-menu-dark-bg);
 }
 .ant-menu.ant-menu-dark .ant-menu-submenu-title .ant-menu-submenu-arrow,
 .ant-menu-dark .ant-menu-sub .ant-menu-submenu-title .ant-menu-submenu-arrow,
@@ -16695,7 +16695,7 @@ textarea.ant-mentions {
   background: transparent;
 }
 .ant-menu-dark .ant-menu-inline.ant-menu-sub {
-  background: #000c17;
+  background: var(--fc-menu-dark-sub-bg);
 }
 .ant-menu-dark.ant-menu-horizontal {
   border-bottom: 0;
@@ -16705,7 +16705,7 @@ textarea.ant-mentions {
   top: 0;
   margin-top: 0;
   padding: 0 20px;
-  border-color: #001529;
+  border-color: var(--fc-menu-dark-bg);
   border-bottom: 0;
 }
 .ant-menu-dark.ant-menu-horizontal > .ant-menu-item:hover {

--- a/src/theme/antd.light-gold.less
+++ b/src/theme/antd.light-gold.less
@@ -7413,7 +7413,7 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 }
 .ant-dropdown-menu-dark,
 .ant-dropdown-menu-dark .ant-dropdown-menu {
-  background: #001529;
+  background: var(--fc-menu-dark-bg);
 }
 .ant-dropdown-menu-dark .ant-dropdown-menu-item,
 .ant-dropdown-menu-dark .ant-dropdown-menu-submenu-title,
@@ -16675,7 +16675,7 @@ textarea.ant-mentions {
 .ant-menu-dark .ant-menu-sub,
 .ant-menu.ant-menu-dark .ant-menu-sub {
   color: rgba(255, 255, 255, 0.65);
-  background: #001529;
+  background: var(--fc-menu-dark-bg);
 }
 .ant-menu.ant-menu-dark .ant-menu-submenu-title .ant-menu-submenu-arrow,
 .ant-menu-dark .ant-menu-sub .ant-menu-submenu-title .ant-menu-submenu-arrow,
@@ -16695,7 +16695,7 @@ textarea.ant-mentions {
   background: transparent;
 }
 .ant-menu-dark .ant-menu-inline.ant-menu-sub {
-  background: #000c17;
+  background: var(--fc-menu-dark-sub-bg);
 }
 .ant-menu-dark.ant-menu-horizontal {
   border-bottom: 0;
@@ -16705,7 +16705,7 @@ textarea.ant-mentions {
   top: 0;
   margin-top: 0;
   padding: 0 20px;
-  border-color: #001529;
+  border-color: var(--fc-menu-dark-bg);
   border-bottom: 0;
 }
 .ant-menu-dark.ant-menu-horizontal > .ant-menu-item:hover {

--- a/src/theme/variable.css
+++ b/src/theme/variable.css
@@ -373,11 +373,9 @@
   /* 渐变色 */
   --fc-gradient-1-color: linear-gradient(90deg, #272c3c 0%, #24253b 25%, #221f33 50%, #1e1e28 75%, #181b1f 100%);
 
-  /* boxshadow*/
-  /* --fc-boxshadow-base-color: green;
-  --fc-boxshadow-hover-color: red; */
-  --fc-boxshadow-base-color: rgba(0, 0, 0, 0.28);
-  --fc-boxshadow-hover-color: rgba(0, 0, 0, 0.45);
+  /* boxshadow：深色背景上用白色半透明，避免黑阴影发灰 */
+  --fc-boxshadow-base-color: rgba(255, 255, 255, 0.1);
+  --fc-boxshadow-hover-color: rgba(255, 255, 255, 0.18);
 
   /* 新版设计色阶 2026-03-24 release-23 */
 

--- a/src/theme/variable.css
+++ b/src/theme/variable.css
@@ -68,8 +68,8 @@
   --fc-background-color-light: rgba(250, 250, 250, 1);
   --fc-card-border: #f0f0f0;
   --fc-border-radius-base: 8px;
-  
-  
+  --fc-menu-dark-bg: rgb(24, 27, 31);
+  --fc-menu-dark-sub-bg: var(--fc-menu-dark-bg);
 
   /* 浅色侧栏（Firemap 参考，组件内 isLight 时引用） */
   --fc-sidemenu-bg: rgb(247, 247, 248);
@@ -262,6 +262,8 @@
 
   --fc-fill-2-rgb: 22 22 24;
   --fc-fill-2: rgb(var(--fc-fill-2-rgb));
+  --fc-menu-dark-bg: var(--fc-fill-2);
+  --fc-menu-dark-sub-bg: var(--fc-menu-dark-bg);
 
   --fc-fill-2-5-rgb: 27 27 29;
   --fc-fill-2-5: rgb(var(--fc-fill-2-5-rgb));
@@ -483,6 +485,8 @@
 }
 
 .theme-light-gold {
+  --fc-menu-dark-bg: #001529;
+  --fc-menu-dark-sub-bg: #000c17;
   --fc-fill-primary: #ffbc0d;
   --fc-primary-color: #ffbc0d;
   --fc-gold-text: #222;
@@ -492,6 +496,8 @@
 
 
 .theme-light-blue{
+  --fc-menu-dark-bg: #001529;
+  --fc-menu-dark-sub-bg: #000c17;
   --fc-fill-primary: #427AF4;
   --fc-primary-color: #427AF4;
   --fc-text-link: #2D5BCF;


### PR DESCRIPTION
## Summary

- 新增 `fc-menu-dark` 等主题变量，并在 Ant Design 主题 less 与侧栏配色设置中接入；补充相关单测。
- Outlined 系列控件浮动标签背景改为 `--fc-fill-2-5`；深色场景下 boxshadow 使用白色半透明，避免黑阴影发灰。

## Test plan

- [ ] 切换明暗主题，检查侧栏/菜单配色与 `SideMenuColorSetting` 行为
- [ ] 检查 OutlinedInput / Select / AutoComplete / InputNumber 浮动标签与聚焦态可读性

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated floating label background colors for outlined form components (AutoComplete, Input, InputNumber, Select) for improved visual consistency.
  * Refactored dark theme menu backgrounds across all theme variants to use CSS variables for better maintainability.
  * Updated dark theme shadow colors for enhanced visual hierarchy.

* **Tests**
  * Added unit test coverage for menu background color functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->