### PR TITLE
fix: restore sidemenu subitem text token

### DIFF
--- a/src/components/SideMenu/menu.test.ts
+++ b/src/components/SideMenu/menu.test.ts
@@ -12,4 +12,14 @@ describe('SideMenu hover panel styles', () => {
     expect(content).toMatch(/\.sidemenu-hover-panel--light\s*\{[^}]*color:\s*var\(--fc-text-1\);/);
     expect(content).toMatch(/\.sidemenu-hover-panel--on-dark\s*\{[^}]*color:\s*#e6e6e8;/);
   });
+
+  it('defines the submenu text token used by nested menu items', () => {
+    const menuListPath = path.join(__dirname, 'MenuList.tsx');
+    const variablePath = path.join(__dirname, '../../theme/variable.css');
+    const menuListContent = fs.readFileSync(menuListPath, 'utf8');
+    const variableContent = fs.readFileSync(variablePath, 'utf8');
+
+    expect(menuListContent).toContain('var(--fc-sidemenu-subitem-text)');
+    expect(variableContent).toContain('--fc-sidemenu-subitem-text:');
+  });
 });

--- a/src/theme/variable.css
+++ b/src/theme/variable.css
@@ -78,6 +78,8 @@
   /* 对齐 fc-firemap: --sidebar-foreground: 215 14% 34% => rgb(75, 85, 99) */
   --fc-sidemenu-item-icon: rgb(75, 85, 99);
   --fc-sidemenu-item-text: rgb(75, 85, 99);
+  /* 对齐 fc-firemap 子菜单默认色：text-muted-foreground => 215 14% 46% */
+  --fc-sidemenu-subitem-text: rgb(101, 115, 134);
   --fc-sidemenu-item-active-bg: rgb(243, 238, 252);
   --fc-sidemenu-item-active-text: #5720b6;
   --fc-sidemenu-item-hover-bg: rgb(241, 241, 244);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case to verify side menu submenu text token configuration and CSS variable declarations.

* **Style**
  * Added CSS variable for side menu submenu item text color to support consistent light theme styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->