### PR TITLE
fix(pageLayout): restore docs center visibility

### DIFF
--- a/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
@@ -16,6 +16,7 @@ export default function DocLink({ link }: { link: string }) {
       icon={<IconFont type='icon-ic_book_one' />}
       href={href}
       target='_blank'
+      rel='noopener'
     >
       {t('common:document_title')}
     </Button>

--- a/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
@@ -1,24 +1,21 @@
 import React from 'react';
 import { Button } from 'antd';
-import DocumentDrawer from '@/components/DocumentDrawer';
 import IconFont from '@/components/IconFont';
 import { useTranslation } from 'react-i18next';
+import { IS_ENT } from '@/utils/constant';
 
 export default function DocLink({ link }: { link: string }) {
   const { t } = useTranslation();
+  const href = IS_ENT ? link.replace('https://flashcat.cloud', '') : link;
+
   return (
     <Button
       className='document-open-button page-layout-header-button'
       size='small'
       type='default'
       icon={<IconFont type='icon-ic_book_one' />}
-      onClick={() =>
-        DocumentDrawer({
-          title: t('common:page_help'),
-          type: 'iframe',
-          documentPath: link,
-        })
-      }
+      href={href}
+      target='_blank'
     >
       {t('common:document_title')}
     </Button>

--- a/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
@@ -8,7 +8,7 @@ export default function DocLink({ link }: { link: string }) {
   const { t } = useTranslation();
   return (
     <Button
-      className='document-open-button'
+      className='document-open-button page-layout-header-button'
       size='small'
       type='default'
       icon={<IconFont type='icon-ic_book_one' />}

--- a/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
@@ -1,29 +1,26 @@
 import React from 'react';
-import { Menu, Dropdown, Space, Drawer, Button, Tooltip, Divider } from 'antd';
+import { Button } from 'antd';
 import DocumentDrawer from '@/components/DocumentDrawer';
 import IconFont from '@/components/IconFont';
 import { useTranslation } from 'react-i18next';
-import { IS_ENT } from '@/utils/constant';
 
 export default function DocLink({ link }: { link: string }) {
   const { t } = useTranslation();
   return (
-    <>
-      <Divider type='vertical' style={{ margin: '0 0 0 12px' }} />
-      <Button
-        className='document-open-button'
-        type='link'
-        icon={<IconFont type='icon-ic_book_one' />}
-        onClick={() =>
-          DocumentDrawer({
-            title: t('common:page_help'),
-            type: 'iframe',
-            documentPath: link,
-          })
-        }
-      >
-        {t('common:document_title')}
-      </Button>
-    </>
+    <Button
+      className='document-open-button'
+      size='small'
+      type='default'
+      icon={<IconFont type='icon-ic_book_one' />}
+      onClick={() =>
+        DocumentDrawer({
+          title: t('common:page_help'),
+          type: 'iframe',
+          documentPath: link,
+        })
+      }
+    >
+      {t('common:document_title')}
+    </Button>
   );
 }

--- a/src/components/pageLayout/PageLayoutWithTabs/index.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/index.tsx
@@ -54,7 +54,8 @@ interface IPageLayoutProps {
   tabGroup?: string;
 }
 
-const DEFAULT_DOCUMENT_URL = '/docs/content/flashcat/overview/';
+const DEFAULT_DOCUMENT_URL_ENT = '/docs/content/flashcat/overview/';
+const DEFAULT_DOCUMENT_URL = 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v7/introduction/?ask_ai=1';
 
 const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introIcon, children, customArea, showBack, backPath, doc, tabGroup }) => {
   const { t, i18n } = useTranslation('pageLayout');
@@ -65,7 +66,7 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
   const embed = localStorage.getItem('embed') === '1' && window.self !== window.top;
   const [currentMenu, setCurrentMenu] = useState<MenuMatchResult | null>(null);
   const menuList = getCurrentMenuList();
-  const fallbackDocUrl = siteInfo?.document_url || DEFAULT_DOCUMENT_URL;
+  const documentUrl = doc || siteInfo?.document_url || (IS_ENT ? DEFAULT_DOCUMENT_URL_ENT : DEFAULT_DOCUMENT_URL);
 
   useEffect(() => {
     const result = findMenuByPath(location.pathname, menuList);
@@ -133,7 +134,7 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
 
                   <div className='page-header-action-group'>
                     {rightArea}
-                    {IS_ENT && <DocLink link={doc || fallbackDocUrl} />}
+                    {IS_ENT && <DocLink link={documentUrl} />}
                     <FlashAiButton />
                     <AdvancedWrap var='VITE_IS_PRO,VITE_IS_ENT'>
                       <License />
@@ -143,7 +144,7 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
                     </AdvancedWrap>
 
                     {!IS_ENT && IS_PLUS && (
-                      <Button target='_blank' href={fallbackDocUrl} size='small' type='text'>
+                      <Button target='_blank' href={documentUrl} size='small' type='text'>
                         <Tooltip title={t('docs')}>
                           <DocIcon className='text-[12px]' />
                         </Tooltip>

--- a/src/components/pageLayout/PageLayoutWithTabs/index.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/index.tsx
@@ -54,8 +54,6 @@ interface IPageLayoutProps {
   tabGroup?: string;
 }
 
-const DEFAULT_DOCUMENT_URL = '/docs/content/flashcat/overview/';
-
 const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introIcon, children, customArea, showBack, backPath, doc, tabGroup }) => {
   const { t, i18n } = useTranslation('pageLayout');
   const history = useHistory();
@@ -65,7 +63,6 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
   const embed = localStorage.getItem('embed') === '1' && window.self !== window.top;
   const [currentMenu, setCurrentMenu] = useState<MenuMatchResult | null>(null);
   const menuList = getCurrentMenuList();
-  const documentUrl = doc || siteInfo?.document_url || DEFAULT_DOCUMENT_URL;
 
   useEffect(() => {
     const result = findMenuByPath(location.pathname, menuList);
@@ -141,14 +138,18 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
                       <FeatureNotification />
                     </AdvancedWrap>
 
-                    <Button target='_blank' href={documentUrl} size='small' type='text' className='page-layout-doc-center-btn'>
-                      <Tooltip title={t('docsCenter')}>
-                        <span className='inline-flex items-center gap-1'>
+                    {!IS_ENT && IS_PLUS && (
+                      <Button
+                        target='_blank'
+                        href={siteInfo?.document_url || 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v7/introduction/'}
+                        size='small'
+                        type='text'
+                      >
+                        <Tooltip title={t('docs')}>
                           <DocIcon className='text-[12px]' />
-                          <span>{t('docsCenter')}</span>
-                        </span>
-                      </Tooltip>
-                    </Button>
+                        </Tooltip>
+                      </Button>
+                    )}
                     <FlashAiButton />
 
                     {!IS_ENT && !IS_PLUS && (

--- a/src/components/pageLayout/PageLayoutWithTabs/index.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/index.tsx
@@ -122,7 +122,6 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
                     </div>
                   )}
                   <TabMenu currentMenu={currentMenu} />
-                  {IS_ENT && doc && <DocLink link={doc} />}
                 </div>
 
                 <div className={'page-header-right-area flex-shrink-0'} style={{ display: sessionStorage.getItem('menuHide') === '1' ? 'none' : undefined }}>
@@ -138,6 +137,7 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
                       <FeatureNotification />
                     </AdvancedWrap>
 
+                    {IS_ENT && doc && <DocLink link={doc} />}
                     {!IS_ENT && IS_PLUS && (
                       <Button
                         target='_blank'

--- a/src/components/pageLayout/PageLayoutWithTabs/index.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/index.tsx
@@ -65,7 +65,7 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
   const embed = localStorage.getItem('embed') === '1' && window.self !== window.top;
   const [currentMenu, setCurrentMenu] = useState<MenuMatchResult | null>(null);
   const menuList = getCurrentMenuList();
-  const documentUrl = doc || siteInfo?.document_url || DEFAULT_DOCUMENT_URL;
+  const fallbackDocUrl = siteInfo?.document_url || DEFAULT_DOCUMENT_URL;
 
   useEffect(() => {
     const result = findMenuByPath(location.pathname, menuList);
@@ -133,6 +133,8 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
 
                   <div className='page-header-action-group'>
                     {rightArea}
+                    {IS_ENT && <DocLink link={doc || fallbackDocUrl} />}
+                    <FlashAiButton />
                     <AdvancedWrap var='VITE_IS_PRO,VITE_IS_ENT'>
                       <License />
                     </AdvancedWrap>
@@ -140,20 +142,13 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
                       <FeatureNotification />
                     </AdvancedWrap>
 
-                    {IS_ENT && <DocLink link={documentUrl} />}
                     {!IS_ENT && IS_PLUS && (
-                      <Button
-                        target='_blank'
-                        href={siteInfo?.document_url || 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v7/introduction/'}
-                        size='small'
-                        type='text'
-                      >
+                      <Button target='_blank' href={fallbackDocUrl} size='small' type='text'>
                         <Tooltip title={t('docs')}>
                           <DocIcon className='text-[12px]' />
                         </Tooltip>
                       </Button>
                     )}
-                    <FlashAiButton />
 
                     {!IS_ENT && !IS_PLUS && (
                       <Button size='small' type='text' icon={<HistoryOutlined />} className='relative'>

--- a/src/components/pageLayout/PageLayoutWithTabs/index.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/index.tsx
@@ -144,7 +144,7 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
                     </AdvancedWrap>
 
                     {!IS_ENT && IS_PLUS && (
-                      <Button target='_blank' href={documentUrl} size='small' type='text'>
+                      <Button target='_blank' href={documentUrl} size='small' type='text' rel='noopener'>
                         <Tooltip title={t('docs')}>
                           <DocIcon className='text-[12px]' />
                         </Tooltip>

--- a/src/components/pageLayout/PageLayoutWithTabs/index.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/index.tsx
@@ -54,6 +54,8 @@ interface IPageLayoutProps {
   tabGroup?: string;
 }
 
+const DEFAULT_DOCUMENT_URL = '/docs/content/flashcat/overview/';
+
 const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introIcon, children, customArea, showBack, backPath, doc, tabGroup }) => {
   const { t, i18n } = useTranslation('pageLayout');
   const history = useHistory();
@@ -63,6 +65,7 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
   const embed = localStorage.getItem('embed') === '1' && window.self !== window.top;
   const [currentMenu, setCurrentMenu] = useState<MenuMatchResult | null>(null);
   const menuList = getCurrentMenuList();
+  const documentUrl = doc || siteInfo?.document_url || DEFAULT_DOCUMENT_URL;
 
   useEffect(() => {
     const result = findMenuByPath(location.pathname, menuList);
@@ -137,7 +140,7 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
                       <FeatureNotification />
                     </AdvancedWrap>
 
-                    {IS_ENT && doc && <DocLink link={doc} />}
+                    {IS_ENT && <DocLink link={documentUrl} />}
                     {!IS_ENT && IS_PLUS && (
                       <Button
                         target='_blank'

--- a/src/components/pageLayout/index.less
+++ b/src/components/pageLayout/index.less
@@ -49,6 +49,7 @@
           }
         }
 
+        .page-layout-header-button.ant-btn,
         .document-open-button.ant-btn {
           font-size: 11px;
           font-weight: 400;

--- a/src/components/pageLayout/index.less
+++ b/src/components/pageLayout/index.less
@@ -50,20 +50,6 @@
         }
       }
 
-      .page-layout-doc-center-btn {
-        border: 1px solid var(--fc-border-color);
-        border-radius: 8px;
-        padding: 0 10px;
-        color: var(--fc-text-2);
-        background: var(--fc-fill-2);
-
-        &:hover {
-          color: var(--fc-text-link);
-          border-color: var(--fc-text-link);
-          background: var(--fc-fill-3);
-        }
-      }
-
       .language {
         margin-right: 20px;
         height: 20px;

--- a/src/components/pageLayout/index.less
+++ b/src/components/pageLayout/index.less
@@ -48,6 +48,17 @@
             line-height: 1;
           }
         }
+
+        .document-open-button.ant-btn {
+          font-size: 11px;
+          font-weight: 400;
+          color: var(--fc-text-3) !important;
+
+          .anticon {
+            font-size: 11px;
+            color: inherit;
+          }
+        }
       }
 
       .language {


### PR DESCRIPTION
## Summary
- Restore the docs center button visibility condition in fe PageLayoutWithTabs.
- Remove the newly added text-button docs center style so pages without the original docs center entry remain unchanged.

## Verification
- git diff --check origin/main...HEAD

## Notes
- Draft PR for feat-branch testing first; not merged into pre yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Documentation links now open in a new browser tab instead of an in-app drawer
  * Documentation button placement and visibility reorganized; enterprise builds use an enterprise-specific document URL and rendering rules

* **Style**
  * Button styling refined with smaller, lighter typography, adjusted icon sizing, and updated text colors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/n9e/fe/pull/2095)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->