### PR TITLE
feat(side-menu): refine profile settings menu

### DIFF
--- a/src/components/SideMenu/index.tsx
+++ b/src/components/SideMenu/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState, useContext } 
 import { useHistory, useLocation } from 'react-router-dom';
 import { Dropdown, Menu } from 'antd';
 import { LogoutOutlined, UserOutlined } from '@ant-design/icons';
-import { Sun } from 'lucide-react';
+import { Settings, Sun } from 'lucide-react';
 import _ from 'lodash';
 import querystring from 'query-string';
 import { useTranslation } from 'react-i18next';
@@ -311,6 +311,7 @@ const SideMenu = (props: SideMenuProps) => {
     effectiveSideMenuBgMode === 'theme' ? 'side-menu-profile-menu-on-theme' : effectiveSideMenuBgMode === 'dark' ? 'side-menu-profile-menu-on-dark' : '';
   const profileMenuClassName = cn('side-menu-profile-menu', profilePopupThemeClassName);
   const profileSubmenuClassName = cn('side-menu-profile-submenu', profilePopupThemeClassName);
+  const profileMenuAlign = { points: ['bl', 'tr'] as [string, string], offset: [collapsed ? 8 : -24, 0] as [number, number] };
   const profileMenu = (
     <Menu
       className={profileMenuClassName}
@@ -461,36 +462,54 @@ const SideMenu = (props: SideMenuProps) => {
               isCustomBg ? 'border-[rgba(255,255,255,0.12)]' : 'border-[var(--fc-sidemenu-border)]',
             )}
           >
-            <div className='side-menu-profile-row'>
-              <Dropdown
-                overlay={profileMenu}
-                trigger={['click']}
-                placement={collapsed ? 'topRight' : 'topLeft'}
-                visible={profileMenuOpen}
-                onVisibleChange={setProfileMenuOpen}
+            <Dropdown
+              overlay={profileMenu}
+              trigger={['hover']}
+              placement='topLeft'
+              align={profileMenuAlign}
+              visible={profileMenuOpen}
+              onVisibleChange={setProfileMenuOpen}
+            >
+              <div
+                className={cn(
+                  'side-menu-profile-row rounded transition-colors',
+                  collapsed ? 'justify-center' : '',
+                  isCustomBg ? 'text-[#fff]' : 'text-title hover:bg-fc-200',
+                )}
               >
                 <button
                   type='button'
                   className={cn(
-                    'side-menu-profile-trigger flex cursor-pointer items-center rounded border-0 bg-transparent p-0 text-left transition-colors',
+                    'side-menu-profile-trigger flex cursor-pointer items-center border-0 bg-transparent p-0 text-left',
                     collapsed ? 'h-10 justify-center' : 'h-12 gap-2 px-2',
-                    isCustomBg ? 'text-[#fff]' : 'text-title hover:bg-fc-200',
+                    isCustomBg ? 'text-[#fff]' : 'text-title',
                   )}
                 >
                   <span className='side-menu-profile-avatar'>
                     {profile?.portrait ? <img src={profile.portrait} /> : <span>{profileDisplay.initial}</span>}
                   </span>
                   {!collapsed && (
-                    <>
-                      <span className='min-w-0 flex-1'>
-                        <span className='block truncate text-[13px] font-medium leading-5'>{profileDisplay.name}</span>
-                        {profileDisplay.detail && <span className={cn('block truncate text-[11px] leading-4', isCustomBg ? 'side-menu-profile-detail-on-dark' : 'text-hint')}>{profileDisplay.detail}</span>}
-                      </span>
-                    </>
+                    <span className='min-w-0 flex-1'>
+                      <span className='block truncate text-[13px] font-medium leading-5'>{profileDisplay.name}</span>
+                      {profileDisplay.detail && <span className={cn('block truncate text-[11px] leading-4', isCustomBg ? 'side-menu-profile-detail-on-dark' : 'text-hint')}>{profileDisplay.detail}</span>}
+                    </span>
                   )}
                 </button>
-              </Dropdown>
-            </div>
+                {!collapsed && (
+                  <button
+                    type='button'
+                    className={cn(
+                      'side-menu-profile-setting-button flex shrink-0 cursor-pointer items-center justify-center border-0 bg-transparent p-0',
+                      isCustomBg ? 'text-[#fff]' : 'text-hint',
+                    )}
+                    aria-label={t('menu.setting')}
+                    onClick={() => setProfileMenuOpen(true)}
+                  >
+                    <Settings size={16} strokeWidth={1.8} />
+                  </button>
+                )}
+              </div>
+            </Dropdown>
           </div>
         </aside>
       </div>

--- a/src/components/SideMenu/menu.less
+++ b/src/components/SideMenu/menu.less
@@ -177,6 +177,12 @@
   flex: 1 1 auto;
 }
 
+.side-menu-profile-setting-button {
+  width: 28px;
+  height: 28px;
+  opacity: 0.72;
+}
+
 .side-menu-profile-detail-on-dark {
   color: rgba(255, 255, 255, 0.68);
 }


### PR DESCRIPTION
## Summary
- Add a lucide settings icon to the side menu profile row.
- Change the profile menu to open on hover with a unified row hover state.
- Move the profile menu toward the side menu's right side while keeping it visually closer to the settings icon.

## Review
- Ran /cmt strict style review with project-local rules from .cursor/commands/cr.md, .cursor/rules, and CLAUDE.md.
- No blocker or warn findings found in the focused SideMenu diff.

## Verification
- git diff --check
- npm test -- --runTestsByPath src/components/SideMenu/profile.test.ts src/components/SideMenu/menu.test.ts --runInBand

## Notes/Risks
- Full tsc was not used as the gating check because current main/pre have unrelated SqlEditorProps enableFormat type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a settings icon button integrated into the profile dropdown trigger area.

* **UI/UX Improvements**
  * Profile dropdown behavior updated: now triggers on hover instead of click with adaptive positioning.
  * Profile section styling enhanced with improved visual presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/n9e/fe/pull/2103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->