### PR TITLE
fix(common): update header doc link title

### DIFF
--- a/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
@@ -18,7 +18,7 @@ export default function DocLink({ link }: { link: string }) {
       target='_blank'
       rel='noopener'
     >
-      {t('common:document_title')}
+      {t('common:product_document_title')}
     </Button>
   );
 }

--- a/src/locales/common/locale/en_US.ts
+++ b/src/locales/common/locale/en_US.ts
@@ -18,6 +18,7 @@ const en_US = {
   unit: 'Unit',
   page_help: 'Help',
   document_title: 'Documentation',
+  product_document_title: 'Product documentation',
   more_document_link: 'More documents',
   and: 'And',
   yes: 'Yes',

--- a/src/locales/common/locale/ja_JP.ts
+++ b/src/locales/common/locale/ja_JP.ts
@@ -18,6 +18,7 @@ const ja_JP = {
   unit: '単位',
   page_help: '使用説明',
   document_title: 'ドキュメント',
+  product_document_title: '製品ドキュメント',
   more_document_link: 'さらにドキュメント',
   and: 'および',
   yes: 'はい',

--- a/src/locales/common/locale/ru_RU.ts
+++ b/src/locales/common/locale/ru_RU.ts
@@ -18,6 +18,7 @@ const ru_RU = {
   unit: 'Единица',
   page_help: 'Инструкция',
   document_title: 'Документация',
+  product_document_title: 'Документация продукта',
   more_document_link: 'Больше документов',
   and: 'И',
   yes: 'Да',

--- a/src/locales/common/locale/zh_CN.ts
+++ b/src/locales/common/locale/zh_CN.ts
@@ -18,6 +18,7 @@ const zh_CN = {
   unit: '单位',
   page_help: '使用说明',
   document_title: '说明文档',
+  product_document_title: '产品文档',
   more_document_link: '更多文档',
   and: '且',
   yes: '是',

--- a/src/locales/common/locale/zh_HK.ts
+++ b/src/locales/common/locale/zh_HK.ts
@@ -18,6 +18,7 @@ const zh_HK = {
   unit: '單位',
   page_help: '使用說明',
   document_title: '說明文檔',
+  product_document_title: '產品文檔',
   more_document_link: '更多文檔',
   and: '且',
   yes: '是',


### PR DESCRIPTION
## Summary
- Add a dedicated common i18n key for the header product documentation link.
- Update the page layout DocLink button to use `common:product_document_title` instead of reusing `common:document_title`.
- Keep the existing `common:document_title` translation unchanged for other call sites.

## Review
- `/cmt strict` review performed with project rules from `.cursor/commands/cr.md`, `.cursor/rules/app.mdc`, `.cursor/rules/tailwind-usage.mdc`, and `CLAUDE.md`.
- No blocker or warn findings found for the scoped diff.

## Verification
- `git diff --check` passed.
- Focused i18n key verification script passed for DocLink and common locale files.
- `pre` merge verification passed before pushing `pre`.

## Notes/Risks
- Tolgee remote was not updated because local Tolgee API credentials were not available in the workspace environment.