### PR TITLE
fix: polish dark table and side menu styles

### DIFF
--- a/scripts/generate_antd_dark_less.js
+++ b/scripts/generate_antd_dark_less.js
@@ -39,9 +39,6 @@ function saveLess(filePath, filename, callback) {
         'border-color-base': 'rgba(204,204,220,0.2)', // input框的边框颜色
         'border-color-split': 'rgb(57, 60, 77)',
         'component-background': 'rgb(22 22 24)', //fc-fill-2
-        // 'table-header-bg': 'rgb(34 37 43)', //fc-fill-3
-        // 'table-row-hover-bg': 'rgba(204, 204, 220, 0.08)',
-        'table-header-sort-bg': 'rgba(204, 204, 220, 0.08)',
         'popover-background': 'rgb(22 22 24)', //fc-fill-2
         'normal-color': 'rgb(79, 82, 99)',
 
@@ -53,12 +50,16 @@ function saveLess(filePath, filename, callback) {
         'table-body-sort-bg': 'var(--fc-fill-2-5)',
         'table-row-hover-bg': 'rgb(var(--fc-fill-5-rgb) / 0.2)',
         'table-selected-row-color': 'inherit',
-        // Keep Less color functions compile-safe; runtime CSS vars are patched in theme/default.less.
+        // AntD wraps @table-selected-row-bg in darken() (default.less:644), so it must
+        // be a Less-parsable color literal, not a var(). Keep this explicit neutral overlay.
         'table-selected-row-bg': 'rgba(228, 228, 231, 0.15)',
         'table-body-selected-sort-bg': '@table-selected-row-bg',
+        // Explicit override so AntD's darken(@table-selected-row-bg) default is not used.
         'table-selected-row-hover-bg': 'rgba(228, 228, 231, 0.25)',
         'table-expanded-row-bg': 'var(--fc-fill-2-5)',
-        'table-border-color': '#e4e4e7',
+        // AntD uses @table-border-color in Less color functions such as lighten(),
+        // so this must be the compiled dark value of --fc-border-color, not a CSS var().
+        'table-border-color': 'rgba(255, 255, 255, 0.06)',
         'table-padding-vertical': '16px',
         'table-padding-horizontal': '16px',
         'table-padding-vertical-md': '(@table-padding-vertical * 3 / 4)',

--- a/src/components/SideMenu/MenuList.tsx
+++ b/src/components/SideMenu/MenuList.tsx
@@ -392,7 +392,7 @@ export function MenuItem(props: { item: IMenuItem; isSub?: boolean; isBgBlack?: 
                 'absolute right-[5px] top-[4px] h-[18px] scale-75 text-[9px] leading-[15px]',
                 isLight
                   ? 'rounded-full bg-[var(--fc-sidemenu-beta-bg)] px-[6px] py-[1px] text-[var(--fc-sidemenu-beta-text)]'
-                  : 'fc-border rounded-full bg-gradient-to-r from-yellow-400 to-yellow-300 px-[3px] py-[1px] text-yellow-700',
+                  : 'fc-border rounded-full bg-gradient-to-r from-yellow-400 to-yellow-300 px-[3px] py-[1px] text-[var(--fc-yellow-9)]',
               )}
             >
               Beta
@@ -457,7 +457,7 @@ function AbsoluteMenuItem(props: { item: IMenuItem; isSub?: boolean; isBgBlack?:
                 'absolute right-[25px] top-[4px] h-[18px] scale-75 text-[9px] leading-[15px]',
                 isLight
                   ? 'rounded-full bg-[var(--fc-sidemenu-beta-bg)] px-[6px] py-[1px] text-[var(--fc-sidemenu-beta-text)]'
-                  : 'fc-border rounded-full bg-gradient-to-r from-yellow-400 to-yellow-300 px-[3px] py-[1px] text-yellow-700',
+                  : 'fc-border rounded-full bg-gradient-to-r from-yellow-400 to-yellow-300 px-[3px] py-[1px] text-[var(--fc-yellow-9)]',
               )}
             >
               Beta
@@ -703,7 +703,7 @@ export default function MenuList(
                                         'ml-2 shrink-0 scale-75 text-[9px] leading-[15px]',
                                         isLight
                                           ? 'rounded-full bg-[var(--fc-sidemenu-beta-bg)] px-[6px] py-[1px] text-[var(--fc-sidemenu-beta-text)]'
-                                          : 'fc-border rounded-full bg-gradient-to-r from-yellow-400 to-yellow-300 px-[3px] py-[1px] text-yellow-700',
+                                          : 'fc-border rounded-full bg-gradient-to-r from-yellow-400 to-yellow-300 px-[3px] py-[1px] text-[var(--fc-yellow-9)]',
                                       )}
                                     >
                                       Beta

--- a/src/components/SideMenu/menu.less
+++ b/src/components/SideMenu/menu.less
@@ -26,8 +26,23 @@
   }
 }
 
-.side-menu-profile-submenu {
+.side-menu-profile-menu {
+  .ant-dropdown-menu-item-icon,
+  .anticon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    vertical-align: middle;
+  }
 
+  .ant-dropdown-menu-item-icon svg,
+  .anticon svg {
+    display: block;
+  }
+}
+
+.side-menu-profile-submenu {
   .ant-dropdown-menu-item-active:not(:hover),
   .ant-dropdown-menu-submenu-title.ant-dropdown-menu-item-active:not(:hover),
   .ant-dropdown-menu-submenu-active>.ant-dropdown-menu-submenu-title:not(:hover) {

--- a/src/theme/antd.dark.less
+++ b/src/theme/antd.dark.less
@@ -21736,11 +21736,11 @@ span.ant-radio + * {
   padding-inline-start: 2px;
 }
 .ant-table.ant-table-bordered > .ant-table-title {
-  border: 1px solid #e4e4e7;
+  border: 1px solid rgba(255, 255, 255, 0.06);
   border-bottom: 0;
 }
 .ant-table.ant-table-bordered > .ant-table-container {
-  border-left: 1px solid #e4e4e7;
+  border-left: 1px solid rgba(255, 255, 255, 0.06);
 }
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-content > table > thead > tr > th,
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-header > table > thead > tr > th,
@@ -21758,13 +21758,13 @@ span.ant-radio + * {
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-header > table > tfoot > tr > td,
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-body > table > tfoot > tr > td,
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-summary > table > tfoot > tr > td {
-  border-right: 1px solid #e4e4e7;
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
 }
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-content > table > thead > tr:not(:last-child) > th,
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-header > table > thead > tr:not(:last-child) > th,
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-body > table > thead > tr:not(:last-child) > th,
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-summary > table > thead > tr:not(:last-child) > th {
-  border-bottom: 1px solid #e4e4e7;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-content > table > thead > tr > th::before,
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-header > table > thead > tr > th::before,
@@ -21784,7 +21784,7 @@ span.ant-radio + * {
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-header > table > tfoot > tr > .ant-table-cell-fix-right-first::after,
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-body > table > tfoot > tr > .ant-table-cell-fix-right-first::after,
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-summary > table > tfoot > tr > .ant-table-cell-fix-right-first::after {
-  border-right: 1px solid #e4e4e7;
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
 }
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-content > table > tbody > tr > td > .ant-table-expanded-row-fixed,
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-header > table > tbody > tr > td > .ant-table-expanded-row-fixed,
@@ -21800,12 +21800,12 @@ span.ant-radio + * {
   top: 0;
   right: 1px;
   bottom: 0;
-  border-right: 1px solid #e4e4e7;
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
   content: '';
 }
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-content > table,
 .ant-table.ant-table-bordered > .ant-table-container > .ant-table-header > table {
-  border-top: 1px solid #e4e4e7;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 .ant-table.ant-table-bordered.ant-table-scroll-horizontal > .ant-table-container > .ant-table-body > table > tbody > tr.ant-table-expanded-row > td,
 .ant-table.ant-table-bordered.ant-table-scroll-horizontal > .ant-table-container > .ant-table-body > table > tbody > tr.ant-table-placeholder > td {
@@ -21820,7 +21820,7 @@ span.ant-radio + * {
   margin: -8px -9px;
 }
 .ant-table.ant-table-bordered > .ant-table-footer {
-  border: 1px solid #e4e4e7;
+  border: 1px solid rgba(255, 255, 255, 0.06);
   border-top: 0;
 }
 .ant-table-cell .ant-table-container:first-child {
@@ -21915,7 +21915,7 @@ span.ant-radio + * {
   font-weight: 500;
   text-align: left;
   background: var(--fc-fill-2-5);
-  border-bottom: 1px solid #e4e4e7;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   transition: background 0.3s ease;
 }
 .ant-table-thead > tr > th[colspan]:not([colspan='1']) {
@@ -21936,7 +21936,7 @@ span.ant-radio + * {
   border-bottom: 0;
 }
 .ant-table-tbody > tr > td {
-  border-bottom: 1px solid #e4e4e7;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   transition: background 0.3s;
 }
 .ant-table-tbody > tr > td > .ant-table-wrapper:only-child .ant-table,
@@ -21970,11 +21970,11 @@ span.ant-radio + * {
   background: var(--fc-fill-2);
 }
 div.ant-table-summary {
-  box-shadow: 0 -1px 0 #e4e4e7;
+  box-shadow: 0 -1px 0 rgba(255, 255, 255, 0.06);
 }
 .ant-table-summary > tr > th,
 .ant-table-summary > tr > td {
-  border-bottom: 1px solid #e4e4e7;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 .ant-table-pagination.ant-pagination {
   margin: 16px 0;
@@ -22161,7 +22161,7 @@ td.ant-table-column-sort {
   padding: 7px 8px;
   overflow: hidden;
   background-color: #161618;
-  border-top: 1px solid #e4e4e7;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 .ant-table-selection-col {
   width: 32px;
@@ -22231,7 +22231,7 @@ table tr th.ant-table-selection-column::after {
   color: inherit;
   line-height: 17px;
   background: transparent;
-  border: 1px solid #e4e4e7;
+  border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 8px;
   outline: none;
   transform: scale(0.94117647);
@@ -22396,8 +22396,8 @@ tr.ant-table-expanded-row .ant-descriptions-view table {
   z-index: calc(2 + 1);
   display: flex;
   align-items: center;
-  background: #ffffff;
-  border-top: 1px solid #e4e4e7;
+  background: rgba(255, 255, 255, 0.06);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
   opacity: 0.6;
 }
 .ant-table-sticky-scroll:hover {


### PR DESCRIPTION
## Summary
- Align dark table border token generation with the dark border color to avoid bright table dividers.
- Regenerate `antd.dark.less` from the updated dark token config.
- Align profile menu icons vertically without changing menu item height.
- Update side menu Beta text color to use the theme yellow token.

## Review
- Branch already contained committed work before `/ship cmt`; no new `/cmt strict` commit step was needed during shipping.
- Reviewed the PR diff before creation.

## Verification
- `git diff --check`
- `node scripts/generate_antd_dark_less.js`

## Notes/Risks
- Visual screenshot verification was not run in this shipping step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark theme table styling with updated color scheme for better visual consistency.
  * Enhanced table border and background colors using semi-transparent white values in dark mode.
  * Updated badge styling in menus to use theme variables for improved consistency.
  * Refined dropdown menu icon rendering and alignment in the profile menu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/n9e/fe/pull/2110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->