### PR TITLE
fix(side-menu): refine bottom menu behavior

### DIFF
--- a/src/components/SideMenu/MenuList.tsx
+++ b/src/components/SideMenu/MenuList.tsx
@@ -143,6 +143,7 @@ function SectionHeader(props: { section: NonNullable<IMenuItem['section']>; coll
 export function MenuGroup(props: { item: IMenuItem } & IMenuProps) {
   const { t } = useTranslation('sideMenu');
   const { item, collapsed, selectedKeys, sideMenuBgColor, isLight, ...otherProps } = props;
+  const rootRef = useRef<HTMLDivElement | null>(null);
   const isBlueTheme = localStorage.getItem('n9e-dark-mode') === '3';
   const isActive = isMenuGroupActive(item, selectedKeys);
   const [isExpand, setIsExpand] = useState<boolean>(false);
@@ -181,7 +182,7 @@ export function MenuGroup(props: { item: IMenuItem } & IMenuProps) {
   const submenuOpen = isExpand && !collapsed && visibleChildren.length > 0;
 
   return (
-    <div className='w-full'>
+    <div className='w-full' ref={rootRef}>
       <div
         onClick={() => {
           if (collapsed) {
@@ -208,6 +209,11 @@ export function MenuGroup(props: { item: IMenuItem } & IMenuProps) {
         className={cn(submenuOpen ? 'mt-0.5' : 'mt-0', 'overflow-hidden transition-height')}
         style={{
           height: !isExpand || collapsed ? 0 : visibleChildren.length * 30,
+        }}
+        onTransitionEnd={(e) => {
+          if (e.propertyName === 'height' && submenuOpen) {
+            rootRef.current?.scrollIntoView({ block: 'nearest' });
+          }
         }}
       >
         <div
@@ -535,7 +541,7 @@ export default function MenuList(
 
   return (
     <>
-      <div className={cn('h-full pl-2 pr-4', isLight ? 'text-[var(--fc-sidemenu-item-text)]' : props.isCustomBg ? 'text-[#e6e6e8]' : 'text-main')}>
+      <div className={cn('h-full pl-2 pr-4 pb-2.5', isLight ? 'text-[var(--fc-sidemenu-item-text)]' : props.isCustomBg ? 'text-[#e6e6e8]' : 'text-main')}>
         {IS_ENT ? (
           <Link
             to='/landing'

--- a/src/components/SideMenu/menu.less
+++ b/src/components/SideMenu/menu.less
@@ -176,8 +176,8 @@
 }
 
 .side-menu-footer {
-  padding-top: 6px;
-  padding-bottom: 8px;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .side-menu-profile-row {


### PR DESCRIPTION
## Summary
- Remove vertical padding from the side menu profile footer.
- Add bottom padding to the side menu list with Tailwind.
- Keep bottom menu groups visible after their first expand transition.
- Add the existing beta menu flag to the shared side menu item type.

## Verification
- npm test -- --runTestsByPath src/components/SideMenu/menu.test.ts --runInBand
- npx tsc --noEmit

## Notes
- Per request, this was not merged into pre.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Menu groups now automatically scroll into view when their submenus expand in the navigation interface.

* **Style**
  * Adjusted spacing in the side menu footer and menu padding for improved visual balance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/n9e/fe/pull/2112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->