### PR TITLE
feat: adjust documentation links

### DIFF
--- a/src/components/pageLayout/PageLayoutWithTabs/DocLink.test.ts
+++ b/src/components/pageLayout/PageLayoutWithTabs/DocLink.test.ts
@@ -1,13 +1,13 @@
 jest.mock('@/components/IconFont', () => () => null);
 jest.mock('@/utils/constant', () => ({ IS_ENT: false }));
 
-import { getProductDocumentHref, PRODUCT_DOCUMENT_URL, PRODUCT_DOCUMENT_URL_ENT } from './DocLink';
+import { getProductDocumentHref } from './DocLink';
 
 describe('getProductDocumentHref', () => {
-  it('ignores page-specific document links and uses the product docs homepage', () => {
+  it('opens the provided page document link and keeps ENT links relative', () => {
     const pageDocumentUrl = 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/rules/alert-rules/';
 
-    expect(getProductDocumentHref(pageDocumentUrl, false)).toBe(PRODUCT_DOCUMENT_URL);
-    expect(getProductDocumentHref(pageDocumentUrl, true)).toBe(PRODUCT_DOCUMENT_URL_ENT);
+    expect(getProductDocumentHref(pageDocumentUrl, false)).toBe(pageDocumentUrl);
+    expect(getProductDocumentHref(pageDocumentUrl, true)).toBe('/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/rules/alert-rules/');
   });
 });

--- a/src/components/pageLayout/PageLayoutWithTabs/DocLink.test.ts
+++ b/src/components/pageLayout/PageLayoutWithTabs/DocLink.test.ts
@@ -1,0 +1,13 @@
+jest.mock('@/components/IconFont', () => () => null);
+jest.mock('@/utils/constant', () => ({ IS_ENT: false }));
+
+import { getProductDocumentHref, PRODUCT_DOCUMENT_URL, PRODUCT_DOCUMENT_URL_ENT } from './DocLink';
+
+describe('getProductDocumentHref', () => {
+  it('ignores page-specific document links and uses the product docs homepage', () => {
+    const pageDocumentUrl = 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/rules/alert-rules/';
+
+    expect(getProductDocumentHref(pageDocumentUrl, false)).toBe(PRODUCT_DOCUMENT_URL);
+    expect(getProductDocumentHref(pageDocumentUrl, true)).toBe(PRODUCT_DOCUMENT_URL_ENT);
+  });
+});

--- a/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
@@ -4,9 +4,16 @@ import IconFont from '@/components/IconFont';
 import { useTranslation } from 'react-i18next';
 import { IS_ENT } from '@/utils/constant';
 
-export default function DocLink({ link }: { link: string }) {
+export const PRODUCT_DOCUMENT_URL_ENT = '/docs/content/flashcat/overview/';
+export const PRODUCT_DOCUMENT_URL = 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/prologue/introduction/';
+
+export function getProductDocumentHref(_pageDocumentUrl?: string, isEnt = IS_ENT) {
+  return isEnt ? PRODUCT_DOCUMENT_URL_ENT : PRODUCT_DOCUMENT_URL;
+}
+
+export default function DocLink({ link }: { link?: string }) {
   const { t } = useTranslation();
-  const href = IS_ENT ? link.replace('https://flashcat.cloud', '') : link;
+  const href = getProductDocumentHref(link);
 
   return (
     <Button

--- a/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
@@ -4,14 +4,11 @@ import IconFont from '@/components/IconFont';
 import { useTranslation } from 'react-i18next';
 import { IS_ENT } from '@/utils/constant';
 
-export const PRODUCT_DOCUMENT_URL_ENT = '/docs/content/flashcat/overview/';
-export const PRODUCT_DOCUMENT_URL = 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/prologue/introduction/';
-
-export function getProductDocumentHref(_pageDocumentUrl?: string, isEnt = IS_ENT) {
-  return isEnt ? PRODUCT_DOCUMENT_URL_ENT : PRODUCT_DOCUMENT_URL;
+export function getProductDocumentHref(pageDocumentUrl: string, isEnt = IS_ENT) {
+  return isEnt ? pageDocumentUrl.replace('https://flashcat.cloud', '') : pageDocumentUrl;
 }
 
-export default function DocLink({ link }: { link?: string }) {
+export default function DocLink({ link }: { link: string }) {
   const { t } = useTranslation();
   const href = getProductDocumentHref(link);
 

--- a/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.test.ts
+++ b/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.test.ts
@@ -1,14 +1,24 @@
 jest.mock('@/components/IconFont', () => () => null);
 jest.mock('@/utils/constant', () => ({ IS_ENT: false }));
+jest.mock('@/components/DocumentDrawer', () => jest.fn());
+jest.mock('@/App', () => {
+  const React = require('react');
+  return { CommonStateContext: React.createContext({ darkMode: false }) };
+});
 
-import { getPageDocumentHref, PAGE_DOCUMENT_LABEL_KEY } from './PageDocLink';
+import { getPageDocumentDrawerOptions, PAGE_DOCUMENT_LABEL_KEY } from './PageDocLink';
 
-describe('getPageDocumentHref', () => {
-  it('keeps the page-specific document link for the PageLayout doc entry', () => {
+describe('getPageDocumentDrawerOptions', () => {
+  it('opens the page-specific document in a drawer', () => {
     const pageDocumentUrl = 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/rules/alert-rules/';
 
-    expect(getPageDocumentHref(pageDocumentUrl, false)).toBe(pageDocumentUrl);
-    expect(getPageDocumentHref(pageDocumentUrl, true)).toBe('/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/rules/alert-rules/');
+    expect(getPageDocumentDrawerOptions(pageDocumentUrl, '说明文档', 'zh_CN', true)).toEqual({
+      darkMode: true,
+      documentPath: pageDocumentUrl,
+      language: 'zh_CN',
+      title: '说明文档',
+      type: 'iframe',
+    });
     expect(PAGE_DOCUMENT_LABEL_KEY).toBe('common:document_title');
   });
 });

--- a/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.test.ts
+++ b/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.test.ts
@@ -6,12 +6,12 @@ jest.mock('@/App', () => {
   return { CommonStateContext: React.createContext({ darkMode: false }) };
 });
 
-import { getPageDocumentDrawerOptions, PAGE_DOCUMENT_LABEL_KEY } from './PageDocLink';
+import { getPageDocumentDrawerOptions, PAGE_DOCUMENT_LABEL_KEY, shouldShowPageDocLink } from './PageDocLink';
+
+const pageDocumentUrl = 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/rules/alert-rules/';
 
 describe('getPageDocumentDrawerOptions', () => {
   it('opens the page-specific document in a drawer', () => {
-    const pageDocumentUrl = 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/rules/alert-rules/';
-
     expect(getPageDocumentDrawerOptions(pageDocumentUrl, '说明文档', 'zh_CN', true)).toEqual({
       darkMode: true,
       documentPath: pageDocumentUrl,
@@ -20,5 +20,11 @@ describe('getPageDocumentDrawerOptions', () => {
       type: 'iframe',
     });
     expect(PAGE_DOCUMENT_LABEL_KEY).toBe('common:document_title');
+  });
+
+  it('only shows the page document entry for ENT pages that provide a document', () => {
+    expect(shouldShowPageDocLink(pageDocumentUrl, true)).toBe(true);
+    expect(shouldShowPageDocLink(pageDocumentUrl, false)).toBe(false);
+    expect(shouldShowPageDocLink(undefined, true)).toBe(false);
   });
 });

--- a/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.test.ts
+++ b/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.test.ts
@@ -1,0 +1,14 @@
+jest.mock('@/components/IconFont', () => () => null);
+jest.mock('@/utils/constant', () => ({ IS_ENT: false }));
+
+import { getPageDocumentHref, PAGE_DOCUMENT_LABEL_KEY } from './PageDocLink';
+
+describe('getPageDocumentHref', () => {
+  it('keeps the page-specific document link for the PageLayout doc entry', () => {
+    const pageDocumentUrl = 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/rules/alert-rules/';
+
+    expect(getPageDocumentHref(pageDocumentUrl, false)).toBe(pageDocumentUrl);
+    expect(getPageDocumentHref(pageDocumentUrl, true)).toBe('/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/rules/alert-rules/');
+    expect(PAGE_DOCUMENT_LABEL_KEY).toBe('common:document_title');
+  });
+});

--- a/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.tsx
@@ -4,8 +4,13 @@ import DocumentDrawer from '@/components/DocumentDrawer';
 import IconFont from '@/components/IconFont';
 import { useTranslation } from 'react-i18next';
 import { CommonStateContext } from '@/App';
+import { IS_ENT } from '@/utils/constant';
 
 export const PAGE_DOCUMENT_LABEL_KEY = 'common:document_title';
+
+export function shouldShowPageDocLink(documentPath: string | undefined, isEnt = IS_ENT): documentPath is string {
+  return isEnt && !!documentPath;
+}
 
 export function getPageDocumentDrawerOptions(documentPath: string, title: string, language: string, darkMode: boolean) {
   return {

--- a/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.tsx
@@ -1,18 +1,25 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Button } from 'antd';
+import DocumentDrawer from '@/components/DocumentDrawer';
 import IconFont from '@/components/IconFont';
 import { useTranslation } from 'react-i18next';
-import { IS_ENT } from '@/utils/constant';
+import { CommonStateContext } from '@/App';
 
 export const PAGE_DOCUMENT_LABEL_KEY = 'common:document_title';
 
-export function getPageDocumentHref(pageDocumentUrl: string, isEnt = IS_ENT) {
-  return isEnt ? pageDocumentUrl.replace('https://flashcat.cloud', '') : pageDocumentUrl;
+export function getPageDocumentDrawerOptions(documentPath: string, title: string, language: string, darkMode: boolean) {
+  return {
+    darkMode,
+    documentPath,
+    language,
+    title,
+    type: 'iframe' as const,
+  };
 }
 
 export default function PageDocLink({ link }: { link: string }) {
-  const { t } = useTranslation();
-  const href = getPageDocumentHref(link);
+  const { t, i18n } = useTranslation();
+  const { darkMode } = useContext(CommonStateContext);
 
   return (
     <Button
@@ -20,9 +27,9 @@ export default function PageDocLink({ link }: { link: string }) {
       size='small'
       type='link'
       icon={<IconFont type='icon-ic_book_one' />}
-      href={href}
-      target='_blank'
-      rel='noopener'
+      onClick={() => {
+        DocumentDrawer(getPageDocumentDrawerOptions(link, t(PAGE_DOCUMENT_LABEL_KEY), i18n.language, darkMode));
+      }}
     >
       {t(PAGE_DOCUMENT_LABEL_KEY)}
     </Button>

--- a/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Button } from 'antd';
+import IconFont from '@/components/IconFont';
+import { useTranslation } from 'react-i18next';
+import { IS_ENT } from '@/utils/constant';
+
+export const PAGE_DOCUMENT_LABEL_KEY = 'common:document_title';
+
+export function getPageDocumentHref(pageDocumentUrl: string, isEnt = IS_ENT) {
+  return isEnt ? pageDocumentUrl.replace('https://flashcat.cloud', '') : pageDocumentUrl;
+}
+
+export default function PageDocLink({ link }: { link: string }) {
+  const { t } = useTranslation();
+  const href = getPageDocumentHref(link);
+
+  return (
+    <Button
+      className='document-open-button page-layout-page-doc-button'
+      size='small'
+      type='link'
+      icon={<IconFont type='icon-ic_book_one' />}
+      href={href}
+      target='_blank'
+      rel='noopener'
+    >
+      {t(PAGE_DOCUMENT_LABEL_KEY)}
+    </Button>
+  );
+}

--- a/src/components/pageLayout/PageLayoutWithTabs/index.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/index.tsx
@@ -29,7 +29,7 @@ import { MenuMatchResult } from '@/components/SideMenu/types';
 import FlashAiButton from '@/components/AiChatNG/FlashAiButton';
 
 import DocLink from './DocLink';
-import PageDocLink from './PageDocLink';
+import PageDocLink, { shouldShowPageDocLink } from './PageDocLink';
 import { TabMenu } from './TabMenu';
 import Version from '../Version';
 import HelpLink from '../HelpLink';
@@ -126,7 +126,7 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
                     </div>
                   )}
                   <TabMenu currentMenu={currentMenu} />
-                  {doc && <PageDocLink link={doc} />}
+                  {shouldShowPageDocLink(doc) && <PageDocLink link={doc} />}
                 </div>
 
                 <div className={'page-header-right-area flex-shrink-0'} style={{ display: sessionStorage.getItem('menuHide') === '1' ? 'none' : undefined }}>

--- a/src/components/pageLayout/PageLayoutWithTabs/index.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/index.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import React, { ReactNode, useState, useEffect, useLayoutEffect } from 'react';
+import React, { ReactNode, useContext, useState, useEffect, useLayoutEffect } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import querystring from 'query-string';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +22,7 @@ import { Space, Button } from 'antd';
 import { RollbackOutlined, HistoryOutlined, GithubOutlined } from '@ant-design/icons';
 
 import AdvancedWrap, { License } from '@/components/AdvancedWrap';
+import { CommonStateContext } from '@/App';
 import { IS_ENT, IS_PLUS } from '@/utils/constant';
 import { findMenuByPath, getCurrentMenuList } from '@/components/SideMenu/utils';
 import { MenuMatchResult } from '@/components/SideMenu/types';
@@ -53,14 +54,19 @@ interface IPageLayoutProps {
   tabGroup?: string;
 }
 
+const DEFAULT_DOCUMENT_URL_ENT = '/docs/content/flashcat/overview/';
+const DEFAULT_DOCUMENT_URL = 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/prologue/introduction/';
+
 const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introIcon, children, customArea, showBack, backPath, doc, tabGroup }) => {
   const { t, i18n } = useTranslation('pageLayout');
   const history = useHistory();
   const location = useLocation();
   const query = querystring.parse(location.search);
+  const { siteInfo } = useContext(CommonStateContext);
   const embed = localStorage.getItem('embed') === '1' && window.self !== window.top;
   const [currentMenu, setCurrentMenu] = useState<MenuMatchResult | null>(null);
   const menuList = getCurrentMenuList();
+  const documentUrl = doc || siteInfo?.document_url || (IS_ENT ? DEFAULT_DOCUMENT_URL_ENT : DEFAULT_DOCUMENT_URL);
 
   useEffect(() => {
     const result = findMenuByPath(location.pathname, menuList);
@@ -134,7 +140,7 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
                     )}
                     <FlashAiButton />
                     {rightArea}
-                    <DocLink />
+                    <DocLink link={documentUrl} />
                     {!IS_ENT && !IS_PLUS && (
                       <Button className='text-hint text-[11px]' target='_blank' href='https://github.com/ccfos/nightingale/issues' size='small' icon={<GithubOutlined />}>
                         {t('submit_issue')}

--- a/src/components/pageLayout/PageLayoutWithTabs/index.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/index.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import React, { ReactNode, useContext, useState, useEffect, useLayoutEffect } from 'react';
+import React, { ReactNode, useState, useEffect, useLayoutEffect } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import querystring from 'query-string';
 import { useTranslation } from 'react-i18next';
@@ -22,13 +22,13 @@ import { Space, Button } from 'antd';
 import { RollbackOutlined, HistoryOutlined, GithubOutlined } from '@ant-design/icons';
 
 import AdvancedWrap, { License } from '@/components/AdvancedWrap';
-import { CommonStateContext } from '@/App';
 import { IS_ENT, IS_PLUS } from '@/utils/constant';
 import { findMenuByPath, getCurrentMenuList } from '@/components/SideMenu/utils';
 import { MenuMatchResult } from '@/components/SideMenu/types';
 import FlashAiButton from '@/components/AiChatNG/FlashAiButton';
 
 import DocLink from './DocLink';
+import PageDocLink from './PageDocLink';
 import { TabMenu } from './TabMenu';
 import Version from '../Version';
 import HelpLink from '../HelpLink';
@@ -53,19 +53,14 @@ interface IPageLayoutProps {
   tabGroup?: string;
 }
 
-const DEFAULT_DOCUMENT_URL_ENT = '/docs/content/flashcat/overview/';
-const DEFAULT_DOCUMENT_URL = 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/prologue/introduction/';
-
 const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introIcon, children, customArea, showBack, backPath, doc, tabGroup }) => {
   const { t, i18n } = useTranslation('pageLayout');
   const history = useHistory();
   const location = useLocation();
   const query = querystring.parse(location.search);
-  const { siteInfo } = useContext(CommonStateContext);
   const embed = localStorage.getItem('embed') === '1' && window.self !== window.top;
   const [currentMenu, setCurrentMenu] = useState<MenuMatchResult | null>(null);
   const menuList = getCurrentMenuList();
-  const documentUrl = doc || siteInfo?.document_url || (IS_ENT ? DEFAULT_DOCUMENT_URL_ENT : DEFAULT_DOCUMENT_URL);
 
   useEffect(() => {
     const result = findMenuByPath(location.pathname, menuList);
@@ -125,6 +120,7 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
                     </div>
                   )}
                   <TabMenu currentMenu={currentMenu} />
+                  {doc && <PageDocLink link={doc} />}
                 </div>
 
                 <div className={'page-header-right-area flex-shrink-0'} style={{ display: sessionStorage.getItem('menuHide') === '1' ? 'none' : undefined }}>
@@ -138,7 +134,7 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
                     )}
                     <FlashAiButton />
                     {rightArea}
-                    <DocLink link={documentUrl} />
+                    <DocLink />
                     {!IS_ENT && !IS_PLUS && (
                       <Button className='text-hint text-[11px]' target='_blank' href='https://github.com/ccfos/nightingale/issues' size='small' icon={<GithubOutlined />}>
                         {t('submit_issue')}

--- a/src/components/pageLayout/index.less
+++ b/src/components/pageLayout/index.less
@@ -107,6 +107,15 @@
           padding-bottom: 5px !important;
         }
       }
+
+      .page-layout-page-doc-button.ant-btn {
+        display: inline-flex;
+        align-items: center;
+        height: 28px;
+        min-height: 28px;
+        font-size: 12px;
+        line-height: 1;
+      }
     }
 
     .n9e-page-header-content {


### PR DESCRIPTION
Summary:
- Keep the left PageLayout page document entry and display it as the existing document label.
- Change the right product document entry to ignore page-specific docs and open the product documentation homepage.
- Add focused tests for product-document and page-document link behavior.

Review:
- Reviewed the diff against origin/main; no blocking issues found.

Verification:
- `npm test -- --runInBand src/components/pageLayout/PageLayoutWithTabs/DocLink.test.ts src/components/pageLayout/PageLayoutWithTabs/PageDocLink.test.ts` passed.
- `git diff --check origin/main...HEAD` passed.
- `npm run build` passed, with existing bundle/font/Browserslist warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a page-specific documentation link button that appears only when a page has a doc; it opens docs in an embedded drawer (iframe), respects dark mode and current language, and correctly handles enterprise vs public doc URLs.

* **Tests**
  * Added tests for documentation URL resolution, drawer option construction, and link visibility logic.

* **Style**
  * Standardized documentation button styling for consistent sizing and alignment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/n9e/fe/pull/2115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->