### PR TITLE
feat(page-layout): support product doc links

### DIFF
--- a/src/components/pageLayout/PageLayoutWithTabs/DocLink.test.ts
+++ b/src/components/pageLayout/PageLayoutWithTabs/DocLink.test.ts
@@ -1,7 +1,7 @@
 jest.mock('@/components/IconFont', () => () => null);
 jest.mock('@/utils/constant', () => ({ IS_ENT: false }));
 
-import { getProductDocumentHref } from './DocLink';
+import { getProductDocumentHref, getProductDocumentLink } from './DocLink';
 
 describe('getProductDocumentHref', () => {
   it('opens the provided page document link and keeps ENT links relative', () => {
@@ -9,5 +9,24 @@ describe('getProductDocumentHref', () => {
 
     expect(getProductDocumentHref(pageDocumentUrl, false)).toBe(pageDocumentUrl);
     expect(getProductDocumentHref(pageDocumentUrl, true)).toBe('/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/rules/alert-rules/');
+  });
+});
+
+describe('getProductDocumentLink', () => {
+  it('uses product document link before page document and fallbacks', () => {
+    expect(
+      getProductDocumentLink({
+        productDocLink: '/docs/content/flashcat/polaris/what-is-polaris/',
+        doc: '/docs/content/flashcat/polaris/unused-page-doc/',
+        siteDocumentUrl: '/docs/content/site-doc/',
+      }),
+    ).toBe('/docs/content/flashcat/polaris/what-is-polaris/');
+  });
+
+  it('falls back from page document to site document and default document', () => {
+    expect(getProductDocumentLink({ doc: '/docs/content/page-doc/', siteDocumentUrl: '/docs/content/site-doc/' })).toBe('/docs/content/page-doc/');
+    expect(getProductDocumentLink({ siteDocumentUrl: '/docs/content/site-doc/' })).toBe('/docs/content/site-doc/');
+    expect(getProductDocumentLink({}, true)).toBe('/docs/content/flashcat/overview/');
+    expect(getProductDocumentLink({}, false)).toBe('https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/prologue/introduction/');
   });
 });

--- a/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/DocLink.tsx
@@ -4,6 +4,19 @@ import IconFont from '@/components/IconFont';
 import { useTranslation } from 'react-i18next';
 import { IS_ENT } from '@/utils/constant';
 
+export const DEFAULT_PRODUCT_DOCUMENT_URL_ENT = '/docs/content/flashcat/overview/';
+export const DEFAULT_PRODUCT_DOCUMENT_URL = 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/prologue/introduction/';
+
+interface ProductDocumentLinkOptions {
+  productDocLink?: string;
+  doc?: string;
+  siteDocumentUrl?: string;
+}
+
+export function getProductDocumentLink({ productDocLink, doc, siteDocumentUrl }: ProductDocumentLinkOptions, isEnt = IS_ENT) {
+  return productDocLink || doc || siteDocumentUrl || (isEnt ? DEFAULT_PRODUCT_DOCUMENT_URL_ENT : DEFAULT_PRODUCT_DOCUMENT_URL);
+}
+
 export function getProductDocumentHref(pageDocumentUrl: string, isEnt = IS_ENT) {
   return isEnt ? pageDocumentUrl.replace('https://flashcat.cloud', '') : pageDocumentUrl;
 }

--- a/src/components/pageLayout/PageLayoutWithTabs/index.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/index.tsx
@@ -28,7 +28,7 @@ import { findMenuByPath, getCurrentMenuList } from '@/components/SideMenu/utils'
 import { MenuMatchResult } from '@/components/SideMenu/types';
 import FlashAiButton from '@/components/AiChatNG/FlashAiButton';
 
-import DocLink from './DocLink';
+import DocLink, { getProductDocumentLink } from './DocLink';
 import PageDocLink, { shouldShowPageDocLink } from './PageDocLink';
 import { TabMenu } from './TabMenu';
 import Version from '../Version';
@@ -51,13 +51,11 @@ interface IPageLayoutProps {
   showBack?: Boolean;
   backPath?: string;
   doc?: string;
+  productDocLink?: string;
   tabGroup?: string;
 }
 
-const DEFAULT_DOCUMENT_URL_ENT = '/docs/content/flashcat/overview/';
-const DEFAULT_DOCUMENT_URL = 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/prologue/introduction/';
-
-const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introIcon, children, customArea, showBack, backPath, doc, tabGroup }) => {
+const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introIcon, children, customArea, showBack, backPath, doc, productDocLink, tabGroup }) => {
   const { t, i18n } = useTranslation('pageLayout');
   const history = useHistory();
   const location = useLocation();
@@ -66,7 +64,7 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
   const embed = localStorage.getItem('embed') === '1' && window.self !== window.top;
   const [currentMenu, setCurrentMenu] = useState<MenuMatchResult | null>(null);
   const menuList = getCurrentMenuList();
-  const documentUrl = doc || siteInfo?.document_url || (IS_ENT ? DEFAULT_DOCUMENT_URL_ENT : DEFAULT_DOCUMENT_URL);
+  const documentUrl = getProductDocumentLink({ productDocLink, doc, siteDocumentUrl: siteInfo?.document_url });
 
   useEffect(() => {
     const result = findMenuByPath(location.pathname, menuList);


### PR DESCRIPTION
## Summary
- Add productDocLink resolution for the top-right product docs link.
- Keep PageLayout doc behavior available for page-level inner documentation.
- Cover product docs link priority with focused tests.

## Review
- Reviewed diff against origin/main before opening the PR.
- No blocking issues found.

## Verification
- git diff --check
- npm test -- --runInBand src/components/pageLayout/PageLayoutWithTabs/DocLink.test.ts src/components/pageLayout/PageLayoutWithTabs/PageDocLink.test.ts

## Notes
- No pre merge performed; this PR targets main from feat-product-doc-link-0528.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced documentation link configuration options to the PageLayout component, including support for enterprise-specific default documentation URLs.
  * Introduced new optional properties for flexible documentation URL handling with intelligent fallback logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/n9e/fe/pull/2116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->