### PR TITLE
feat(table): surface frequent row actions as inline icons beside the …

### DIFF
--- a/src/components/TableActionDropdown/index.tsx
+++ b/src/components/TableActionDropdown/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from 'antd';
+import { Button, Tooltip } from 'antd';
 import type { ButtonProps } from 'antd/lib/button';
 import {
   CheckCircle,
@@ -59,6 +59,23 @@ export function TableActionButton({ actionIcon, icon, className, type = 'link', 
       {...rest}
     />
   );
+}
+
+interface TableActionIconButtonProps extends Omit<ButtonProps, 'icon' | 'title'> {
+  actionIcon: TableActionIconName;
+  title: React.ReactNode;
+}
+
+export function TableActionIconButton({ actionIcon, title, className, type = 'text', ...rest }: TableActionIconButtonProps) {
+  return (
+    <Tooltip title={title}>
+      <Button type={type} className={classNames('fc-table-action-icon-btn', className)} icon={<TableActionIcon name={actionIcon} />} {...rest} />
+    </Tooltip>
+  );
+}
+
+export function TableActionCell({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={classNames('fc-table-action-cell', className)}>{children}</div>;
 }
 
 interface TableActionLinkProps extends LinkProps {

--- a/src/components/TableActionDropdown/style.less
+++ b/src/components/TableActionDropdown/style.less
@@ -75,3 +75,42 @@
     color: var(--fc-text-4);
   }
 }
+
+// 行内暴露的特色操作图标（与 3 个点的 dropdown 并排）
+.fc-table-action-cell {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+}
+
+.fc-table-action-icon-btn.ant-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  color: var(--fc-text-3);
+
+  .fc-table-action-menu-icon {
+    width: 16px;
+    height: 16px;
+    margin: 0;
+    stroke-width: 2;
+  }
+
+  &:hover,
+  &:focus {
+    color: var(--fc-text-2);
+  }
+
+  &.ant-btn-dangerous {
+    color: var(--fc-fill-error);
+  }
+
+  &[disabled],
+  &[disabled]:hover {
+    color: var(--fc-text-4);
+  }
+}

--- a/src/pages/aiConfig/skills/pages/ResourcesTable.tsx
+++ b/src/pages/aiConfig/skills/pages/ResourcesTable.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { NS } from '../constants';
 import { getItem, uploadFile, deleteFile } from '../services';
 import ResourceModal from './ResourceModal';
-import { TableActionButton, TableActionTrigger } from '@/components/TableActionDropdown';
+import { TableActionButton, TableActionTrigger, TableActionCell, TableActionIconButton } from '@/components/TableActionDropdown';
 
 interface Props {
   id: number;
@@ -146,51 +146,49 @@ export default function ResourcesTable(props: Props) {
           },
           {
             title: t('common:table.operations'),
-            width: 64,
+            width: 90,
             fixed: 'right' as const,
             render: (record) => {
               return (
-                <Dropdown
-                  trigger={['click']}
-                  align={{ points: ['tr', 'tl'], offset: [-2, 0] }}
-                  overlayClassName='fc-table-action-dropdown'
-                  overlay={
-                    <Menu>
-                      <Menu.Item>
-                        <TableActionButton
-                          actionIcon='view'
-                          onClick={() => {
-                            setResourceState({ visible: true, id: record.id, name: record.name });
-                          }}
-                        >
-                          {t('common:btn.view')}
-                        </TableActionButton>
-                      </Menu.Item>
-                      <Menu.Divider />
-                      <Menu.Item>
-                        <TableActionButton
-                          actionIcon='delete'
-                          danger
-                          onClick={() => {
-                            Modal.confirm({
-                              title: t('common:confirm.delete'),
-                              onOk: () => {
-                                deleteFile(record.id).then(() => {
-                                  message.success(t('common:success.delete'));
-                                  run();
-                                });
-                              },
-                            });
-                          }}
-                        >
-                          {t('common:btn.delete')}
-                        </TableActionButton>
-                      </Menu.Item>
-                    </Menu>
-                  }
-                >
-                  <TableActionTrigger />
-                </Dropdown>
+                <TableActionCell>
+                  <TableActionIconButton
+                    actionIcon='view'
+                    title={t('common:btn.view')}
+                    onClick={() => {
+                      setResourceState({ visible: true, id: record.id, name: record.name });
+                    }}
+                  />
+                  <Dropdown
+                    trigger={['click']}
+                    align={{ points: ['tr', 'tl'], offset: [-2, 0] }}
+                    overlayClassName='fc-table-action-dropdown'
+                    overlay={
+                      <Menu>
+                        <Menu.Item>
+                          <TableActionButton
+                            actionIcon='delete'
+                            danger
+                            onClick={() => {
+                              Modal.confirm({
+                                title: t('common:confirm.delete'),
+                                onOk: () => {
+                                  deleteFile(record.id).then(() => {
+                                    message.success(t('common:success.delete'));
+                                    run();
+                                  });
+                                },
+                              });
+                            }}
+                          >
+                            {t('common:btn.delete')}
+                          </TableActionButton>
+                        </Menu.Item>
+                      </Menu>
+                    }
+                  >
+                    <TableActionTrigger />
+                  </Dropdown>
+                </TableActionCell>
               );
             },
           },

--- a/src/pages/eventPipeline/pages/List/index.tsx
+++ b/src/pages/eventPipeline/pages/List/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Space, Table, Button, Input, Modal, Drawer, Select, Dropdown, Menu } from 'antd';
 import { SearchOutlined } from '@ant-design/icons';
@@ -12,11 +13,12 @@ import { Item, getList, deleteItems } from '../../services';
 import Add from '../Add';
 import Edit from '../Edit';
 import MoreOperations from './MoreOperations';
-import { TableActionButton, TableActionLink, TableActionTrigger } from '@/components/TableActionDropdown';
+import { TableActionButton, TableActionLink, TableActionTrigger, TableActionCell, TableActionIconButton } from '@/components/TableActionDropdown';
 import Tags from '@/components/TableTags/Tags';
 
 export default function List() {
   const { t } = useTranslation(NS);
+  const history = useHistory();
   const [filter, setFilter] = useState<{
     search?: string;
     use_case?: string;
@@ -240,73 +242,77 @@ export default function List() {
           },
           {
             title: t('common:table.operations'),
-            width: 64,
+            width: 90,
             fixed: 'right' as const,
             render: (item: Item) => {
               return (
-                <Dropdown
-                  trigger={['click']}
-                  align={{ points: ['tr', 'tl'], offset: [-2, 0] }}
-                  overlayClassName='fc-table-action-dropdown'
-                  overlay={
-                    <Menu>
-                      <Menu.Item>
-                        <TableActionButton
-                          actionIcon='copy'
-                          onClick={() => {
-                            setEventPipelineDrawerState({
-                              visible: true,
-                              action: 'clone',
-                              data: _.omit(item, 'id'),
-                            });
-                          }}
-                        >
-                          {t('common:btn.clone')}
-                        </TableActionButton>
-                      </Menu.Item>
-                      <Menu.Item>
-                        <TableActionButton
-                          actionIcon='edit'
-                          onClick={() => {
-                            setEventPipelineDrawerState({
-                              visible: true,
-                              action: 'edit',
-                              id: item.id,
-                            });
-                          }}
-                        >
-                          {t('common:btn.edit')}
-                        </TableActionButton>
-                      </Menu.Item>
-                      <Menu.Item>
-                        <TableActionLink actionIcon='open' to={`/event-pipelines-executions?pipeline_id=${item.id}`}>
-                          {t('executions.title')}
-                        </TableActionLink>
-                      </Menu.Item>
-                      <Menu.Divider />
-                      <Menu.Item>
-                        <TableActionButton
-                          actionIcon='delete'
-                          danger
-                          onClick={() => {
-                            Modal.confirm({
-                              title: t('common:confirm.delete'),
-                              onOk: () => {
-                                deleteItems([item.id]).then(() => {
-                                  featchData();
-                                });
-                              },
-                            });
-                          }}
-                        >
-                          {t('common:btn.delete')}
-                        </TableActionButton>
-                      </Menu.Item>
-                    </Menu>
-                  }
-                >
-                  <TableActionTrigger />
-                </Dropdown>
+                <TableActionCell>
+                  <TableActionIconButton
+                    actionIcon='open'
+                    title={t('executions.title')}
+                    onClick={() => {
+                      history.push(`/event-pipelines-executions?pipeline_id=${item.id}`);
+                    }}
+                  />
+                  <Dropdown
+                    trigger={['click']}
+                    align={{ points: ['tr', 'tl'], offset: [-2, 0] }}
+                    overlayClassName='fc-table-action-dropdown'
+                    overlay={
+                      <Menu>
+                        <Menu.Item>
+                          <TableActionButton
+                            actionIcon='copy'
+                            onClick={() => {
+                              setEventPipelineDrawerState({
+                                visible: true,
+                                action: 'clone',
+                                data: _.omit(item, 'id'),
+                              });
+                            }}
+                          >
+                            {t('common:btn.clone')}
+                          </TableActionButton>
+                        </Menu.Item>
+                        <Menu.Item>
+                          <TableActionButton
+                            actionIcon='edit'
+                            onClick={() => {
+                              setEventPipelineDrawerState({
+                                visible: true,
+                                action: 'edit',
+                                id: item.id,
+                              });
+                            }}
+                          >
+                            {t('common:btn.edit')}
+                          </TableActionButton>
+                        </Menu.Item>
+                        <Menu.Divider />
+                        <Menu.Item>
+                          <TableActionButton
+                            actionIcon='delete'
+                            danger
+                            onClick={() => {
+                              Modal.confirm({
+                                title: t('common:confirm.delete'),
+                                onOk: () => {
+                                  deleteItems([item.id]).then(() => {
+                                    featchData();
+                                  });
+                                },
+                              });
+                            }}
+                          >
+                            {t('common:btn.delete')}
+                          </TableActionButton>
+                        </Menu.Item>
+                      </Menu>
+                    }
+                  >
+                    <TableActionTrigger />
+                  </Dropdown>
+                </TableActionCell>
               );
             },
           },

--- a/src/pages/log/IndexPatterns/index.tsx
+++ b/src/pages/log/IndexPatterns/index.tsx
@@ -30,7 +30,7 @@ import './locale';
 import { SearchOutlined } from '@ant-design/icons';
 import EditField from './EditField';
 import { useQuery } from '@/utils';
-import { TableActionButton, TableActionTrigger } from '@/components/TableActionDropdown';
+import { TableActionButton, TableActionTrigger, TableActionCell, TableActionIconButton } from '@/components/TableActionDropdown';
 
 export default function Servers() {
   const { t } = useTranslation('es-index-patterns');
@@ -143,47 +143,45 @@ export default function Servers() {
                   },
                   {
                     title: t('common:table.operations'),
-                    width: 64,
+                    width: 90,
                     fixed: 'right' as const,
                     render: (record) => {
                       return (
-                        <Dropdown
-                          trigger={['click']}
-                          align={{ points: ['tr', 'tl'], offset: [-2, 0] }}
-                          overlayClassName='fc-table-action-dropdown'
-                          overlay={
-                            <Menu>
-                              <Menu.Item>
-                                <TableActionButton
-                                  actionIcon='settings'
-                                  onClick={() => {
-                                    if (record) {
-                                      EditField({
-                                        id: record.id,
-                                        datasourceList,
-                                        onOk(values, name) {
-                                          console.log('values', values);
-                                          const newFieldConfig = {
-                                            ...values,
-                                            version: 2,
-                                          };
-                                          putESIndexPattern(record.id, {
-                                            ..._.omit(record, ['fieldConfig', 'id']),
-                                            fields_format: JSON.stringify(newFieldConfig),
-                                            name,
-                                          }).then(() => {
-                                            fetchData();
-                                            message.success(t('common:success.save'));
-                                          });
-                                        },
-                                      });
-                                    }
-                                  }}
-                                >
-                                  {t('common:btn.config')}
-                                </TableActionButton>
-                              </Menu.Item>
-                              <Menu.Item>
+                        <TableActionCell>
+                          <TableActionIconButton
+                            actionIcon='settings'
+                            title={t('common:btn.config')}
+                            onClick={() => {
+                              if (record) {
+                                EditField({
+                                  id: record.id,
+                                  datasourceList,
+                                  onOk(values, name) {
+                                    console.log('values', values);
+                                    const newFieldConfig = {
+                                      ...values,
+                                      version: 2,
+                                    };
+                                    putESIndexPattern(record.id, {
+                                      ..._.omit(record, ['fieldConfig', 'id']),
+                                      fields_format: JSON.stringify(newFieldConfig),
+                                      name,
+                                    }).then(() => {
+                                      fetchData();
+                                      message.success(t('common:success.save'));
+                                    });
+                                  },
+                                });
+                              }
+                            }}
+                          />
+                          <Dropdown
+                            trigger={['click']}
+                            align={{ points: ['tr', 'tl'], offset: [-2, 0] }}
+                            overlayClassName='fc-table-action-dropdown'
+                            overlay={
+                              <Menu>
+                                <Menu.Item>
                                 <TableActionButton
                                   actionIcon='edit'
                                   onClick={() => {
@@ -224,8 +222,9 @@ export default function Servers() {
                             </Menu>
                           }
                         >
-                          <TableActionTrigger />
-                        </Dropdown>
+                            <TableActionTrigger />
+                          </Dropdown>
+                        </TableActionCell>
                       );
                     },
                   },

--- a/src/pages/task/index.tsx
+++ b/src/pages/task/index.tsx
@@ -23,7 +23,7 @@ import _ from 'lodash';
 import moment from 'moment';
 import { useTranslation } from 'react-i18next';
 import { useAntdTable } from 'ahooks';
-import { TableActionButton, TableActionLink, TableActionTrigger } from '@/components/TableActionDropdown';
+import { TableActionButton, TableActionLink, TableActionTrigger, TableActionCell, TableActionIconButton } from '@/components/TableActionDropdown';
 
 import request from '@/utils/request';
 import api from '@/utils/api';
@@ -168,31 +168,29 @@ const index = (_props: any) => {
       },
       {
         title: t('table.operations'),
-        width: 64,
+        width: 90,
         fixed: 'right' as const,
         render: (_text, record) => {
           return (
-            <Dropdown
-              trigger={['click']}
-              align={{ points: ['tr', 'tl'], offset: [-2, 0] }}
-              overlayClassName='fc-table-action-dropdown'
-              overlay={
-                <Menu>
-                  <Menu.Item>
-                    <TableActionLink actionIcon='copy' to={{ pathname: '/job-tasks/add', search: `task=${record.id}` }}>
-                      {t('task.clone')}
-                    </TableActionLink>
-                  </Menu.Item>
-                  <Menu.Item>
-                    <TableActionButton actionIcon='view' onClick={() => handleOpenMetaDrawer(record)}>
-                      {t('task.meta')}
-                    </TableActionButton>
-                  </Menu.Item>
-                </Menu>
-              }
-            >
-              <TableActionTrigger />
-            </Dropdown>
+            <TableActionCell>
+              <TableActionIconButton actionIcon='view' title={t('task.meta')} onClick={() => handleOpenMetaDrawer(record)} />
+              <Dropdown
+                trigger={['click']}
+                align={{ points: ['tr', 'tl'], offset: [-2, 0] }}
+                overlayClassName='fc-table-action-dropdown'
+                overlay={
+                  <Menu>
+                    <Menu.Item>
+                      <TableActionLink actionIcon='copy' to={{ pathname: '/job-tasks/add', search: `task=${record.id}` }}>
+                        {t('task.clone')}
+                      </TableActionLink>
+                    </Menu.Item>
+                  </Menu>
+                }
+              >
+                <TableActionTrigger />
+              </Dropdown>
+            </TableActionCell>
           );
         },
       },

--- a/src/pages/taskTpl/index.tsx
+++ b/src/pages/taskTpl/index.tsx
@@ -15,7 +15,7 @@
  *
  */
 import React, { useState, useContext, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { Table, Modal, Tag, Row, Col, Button, Dropdown, Menu, message, Space } from 'antd';
 import { DownOutlined, CodeOutlined } from '@ant-design/icons';
 import { ColumnProps } from 'antd/lib/table';
@@ -23,7 +23,7 @@ import _ from 'lodash';
 import moment from 'moment';
 import { useAntdTable } from 'ahooks';
 import { useTranslation } from 'react-i18next';
-import { TableActionButton, TableActionLink, TableActionTrigger } from '@/components/TableActionDropdown';
+import { TableActionButton, TableActionLink, TableActionTrigger, TableActionCell, TableActionIconButton } from '@/components/TableActionDropdown';
 import Tags from '@/components/TableTags/Tags';
 
 import request from '@/utils/request';
@@ -62,6 +62,7 @@ function getTableData(options: any, gids: string | undefined, query: string) {
 
 const index = (_props: any) => {
   const { t, i18n } = useTranslation('common');
+  const history = useHistory();
   const [query, setQuery] = useState(() => sessionStorage.getItem(SEARCH_SESSION_KEY) || '');
   const { busiGroups, businessGroup } = useContext(CommonStateContext);
   const [selectedIds, setSelectedIds] = useState([] as any[]);
@@ -171,58 +172,62 @@ const index = (_props: any) => {
       },
       {
         title: t('table.operations'),
-        width: 64,
+        width: 90,
         fixed: 'right' as const,
         render: (_text, record) => {
           return (
-            <Dropdown
-              trigger={['click']}
-              align={{ points: ['tr', 'tl'], offset: [-2, 0] }}
-              overlayClassName='fc-table-action-dropdown'
-              overlay={
-                <Menu>
-                  <Menu.Item>
-                    <TableActionLink actionIcon='run' to={{ pathname: `/job-tpls/add/task`, search: `tpl=${record.id}` }}>
-                      {t('task.create')}
-                    </TableActionLink>
-                  </Menu.Item>
-                  <Menu.Item>
-                    <TableActionLink actionIcon='edit' to={{ pathname: `/job-tpls/${record.id}/modify` }}>
-                      {t('common:btn.edit')}
-                    </TableActionLink>
-                  </Menu.Item>
-                  <Menu.Item>
-                    <TableActionLink actionIcon='copy' to={{ pathname: `/job-tpls/${record.id}/clone` }}>
-                      {t('common:btn.clone')}
-                    </TableActionLink>
-                  </Menu.Item>
-                  <Menu.Divider />
-                  <Menu.Item>
-                    <TableActionButton
-                      actionIcon='delete'
-                      danger
-                      onClick={() => {
-                        Modal.confirm({
-                          title: t('common:confirm.delete'),
-                          onOk: () => {
-                            return request(`${api.tasktpl(record.group_id)}/${record.id}`, {
-                              method: 'DELETE',
-                            }).then(() => {
-                              message.success(t('msg.delete.success'));
-                              refresh();
-                            });
-                          },
-                        });
-                      }}
-                    >
-                      {t('common:btn.delete')}
-                    </TableActionButton>
-                  </Menu.Item>
-                </Menu>
-              }
-            >
-              <TableActionTrigger />
-            </Dropdown>
+            <TableActionCell>
+              <TableActionIconButton
+                actionIcon='run'
+                title={t('task.create')}
+                onClick={() => {
+                  history.push({ pathname: `/job-tpls/add/task`, search: `tpl=${record.id}` });
+                }}
+              />
+              <Dropdown
+                trigger={['click']}
+                align={{ points: ['tr', 'tl'], offset: [-2, 0] }}
+                overlayClassName='fc-table-action-dropdown'
+                overlay={
+                  <Menu>
+                    <Menu.Item>
+                      <TableActionLink actionIcon='edit' to={{ pathname: `/job-tpls/${record.id}/modify` }}>
+                        {t('common:btn.edit')}
+                      </TableActionLink>
+                    </Menu.Item>
+                    <Menu.Item>
+                      <TableActionLink actionIcon='copy' to={{ pathname: `/job-tpls/${record.id}/clone` }}>
+                        {t('common:btn.clone')}
+                      </TableActionLink>
+                    </Menu.Item>
+                    <Menu.Divider />
+                    <Menu.Item>
+                      <TableActionButton
+                        actionIcon='delete'
+                        danger
+                        onClick={() => {
+                          Modal.confirm({
+                            title: t('common:confirm.delete'),
+                            onOk: () => {
+                              return request(`${api.tasktpl(record.group_id)}/${record.id}`, {
+                                method: 'DELETE',
+                              }).then(() => {
+                                message.success(t('msg.delete.success'));
+                                refresh();
+                              });
+                            },
+                          });
+                        }}
+                      >
+                        {t('common:btn.delete')}
+                      </TableActionButton>
+                    </Menu.Item>
+                  </Menu>
+                }
+              >
+                <TableActionTrigger />
+              </Dropdown>
+            </TableActionCell>
           );
         },
       },


### PR DESCRIPTION
…kebab

把高频/特色行操作从三点菜单放出为行内图标（icon+tooltip，置于三点左侧），并从菜单中移除不重复。

新增共享 TableActionIconButton + TableActionCell（含 style.less 行内图标样式）。

放 1 个图标 + 三点留 CRUD：技能资源文件（查看）、事件管道（执行记录）、自愈任务（详情）、自愈脚本（立即执行）、ES 索引模式（配置）。

注：事件管道「执行记录」、自愈脚本「立即执行」原为路由 Link，放成图标按钮后改用 history.push（跳转一致，失去 cmd+点击开新标签）。待议表保持收起。