### PR TITLE
fix(page-layout): restore page doc divider

### DIFF
--- a/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Button } from 'antd';
+import { Button, Divider } from 'antd';
 import DocumentDrawer from '@/components/DocumentDrawer';
 import IconFont from '@/components/IconFont';
 import { useTranslation } from 'react-i18next';
@@ -27,16 +27,19 @@ export default function PageDocLink({ link }: { link: string }) {
   const { darkMode } = useContext(CommonStateContext);
 
   return (
-    <Button
-      className='document-open-button page-layout-page-doc-button'
-      size='small'
-      type='link'
-      icon={<IconFont type='icon-ic_book_one' />}
-      onClick={() => {
-        DocumentDrawer(getPageDocumentDrawerOptions(link, t(PAGE_DOCUMENT_LABEL_KEY), i18n.language, darkMode));
-      }}
-    >
-      {t(PAGE_DOCUMENT_LABEL_KEY)}
-    </Button>
+    <>
+      <Divider type='vertical' style={{ margin: '0 0 0 12px' }} />
+      <Button
+        className='document-open-button page-layout-page-doc-button'
+        size='small'
+        type='link'
+        icon={<IconFont type='icon-ic_book_one' />}
+        onClick={() => {
+          DocumentDrawer(getPageDocumentDrawerOptions(link, t(PAGE_DOCUMENT_LABEL_KEY), i18n.language, darkMode));
+        }}
+      >
+        {t(PAGE_DOCUMENT_LABEL_KEY)}
+      </Button>
+    </>
   );
 }

--- a/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/PageDocLink.tsx
@@ -28,7 +28,7 @@ export default function PageDocLink({ link }: { link: string }) {
 
   return (
     <>
-      <Divider type='vertical' style={{ margin: '0 0 0 12px' }} />
+      <Divider type='vertical' />
       <Button
         className='document-open-button page-layout-page-doc-button'
         size='small'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added a vertical divider next to the document button in page layouts to improve visual separation of document controls.
  * Visual layout updated; the document button's appearance and the document panel interaction remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->