### PR TITLE
refactor(aichat): unify content block cards with shared ContentCard

### DIFF
--- a/src/components/AiChatNG/ContentRenderer/AlertRuleContentBlock.tsx
+++ b/src/components/AiChatNG/ContentRenderer/AlertRuleContentBlock.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { Tooltip, message as antdMessage } from 'antd';
-import { CopyOutlined, ExportOutlined } from '@ant-design/icons';
+import { AlertOutlined, CopyOutlined, ExportOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 
 import { copy2ClipBoard } from '@/utils';
 import { NAME_SPACE } from '../constants';
+import ContentCard from './ContentCard';
+import RowItem from './RowItem';
 
 interface IAlertRulePayload {
   cate?: string;
@@ -51,15 +53,6 @@ function SeverityText(props: { severity?: number; levelName?: string }) {
     <span className={`inline-flex items-center gap-2 ${colorClass}`}>
       <span>{text}</span>
     </span>
-  );
-}
-
-function RowItem(props: { label: string; value: React.ReactNode }) {
-  return (
-    <div className='grid grid-cols-[120px_1fr] gap-3 border-t border-fc-200 py-2 first:border-t-0'>
-      <div className='text-sm font-medium text-title'>{props.label}</div>
-      <div className='min-w-0 text-sm text-main'>{props.value}</div>
-    </div>
   );
 }
 
@@ -122,20 +115,16 @@ export default function AlertRuleContentBlock(props: { responseContent: string }
   );
 
   return (
-    <div className='rounded-lg border border-fc-200 bg-fc-100 px-4 py-3'>
-      <div className='text-sm font-medium text-title'>{t('alert_rule.title')}</div>
-
-      <div className='mt-2'>
-        <RowItem label={t('alert_rule.field.id')} value={idNode} />
-        <RowItem label={t('alert_rule.field.name')} value={nameNode} />
-        <RowItem label={t('alert_rule.field.group')} value={groupText} />
-        <RowItem label={t('alert_rule.field.datasource')} value={datasourceText} />
-        <RowItem label={t('alert_rule.field.cate')} value={payload.cate || '--'} />
-        <RowItem label={t('alert_rule.field.severity')} value={<SeverityText severity={payload.severity} levelName={severityLevelName} />} />
-        {payload.metric ? <RowItem label={t('alert_rule.field.metric')} value={payload.metric} /> : null}
-        <RowItem label={t('alert_rule.field.condition')} value={conditionText} />
-        <RowItem label={t('alert_rule.field.note')} value={<div className='whitespace-pre-wrap break-words'>{payload.note || '--'}</div>} />
-      </div>
-    </div>
+    <ContentCard icon={<AlertOutlined />} title={t('alert_rule.title')} bodyClassName='px-4 py-2'>
+      <RowItem label={t('alert_rule.field.id')} value={idNode} />
+      <RowItem label={t('alert_rule.field.name')} value={nameNode} />
+      <RowItem label={t('alert_rule.field.group')} value={groupText} />
+      <RowItem label={t('alert_rule.field.datasource')} value={datasourceText} />
+      <RowItem label={t('alert_rule.field.cate')} value={payload.cate || '--'} />
+      <RowItem label={t('alert_rule.field.severity')} value={<SeverityText severity={payload.severity} levelName={severityLevelName} />} />
+      {payload.metric ? <RowItem label={t('alert_rule.field.metric')} value={payload.metric} /> : null}
+      <RowItem label={t('alert_rule.field.condition')} value={conditionText} />
+      <RowItem label={t('alert_rule.field.note')} value={<div className='whitespace-pre-wrap break-words'>{payload.note || '--'}</div>} />
+    </ContentCard>
   );
 }

--- a/src/components/AiChatNG/ContentRenderer/ContentCard.tsx
+++ b/src/components/AiChatNG/ContentRenderer/ContentCard.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface IContentCardProps {
+  /** 头部标题前的图标，颜色已统一为 text-primary */
+  icon: React.ReactNode;
+  title: React.ReactNode;
+  children: React.ReactNode;
+  /** body 容器的 className，各卡片内边距不同，默认 px-4 py-4 */
+  bodyClassName?: string;
+}
+
+/**
+ * AI Chat 消息卡片的统一外壳：白底、圆角、浅边框 + 软阴影，头部为「图标 + 标题 + 分隔线」。
+ * form_select / dashboard / alert_rule / query 等内容块共用，样式调整只需改这一处。
+ */
+export default function ContentCard(props: IContentCardProps) {
+  const { icon, title, children, bodyClassName = 'px-4 py-4' } = props;
+
+  return (
+    <div className='rounded-xl border border-fc-200 bg-white shadow-mf'>
+      <div className='flex items-center gap-2 border-b border-fc-200 px-4 py-3'>
+        <span className='inline-flex text-primary' style={{ fontSize: 16 }}>
+          {icon}
+        </span>
+        <div className='text-sm font-semibold text-title'>{title}</div>
+      </div>
+      <div className={bodyClassName}>{children}</div>
+    </div>
+  );
+}

--- a/src/components/AiChatNG/ContentRenderer/DashboardContentBlock.tsx
+++ b/src/components/AiChatNG/ContentRenderer/DashboardContentBlock.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { message as antdMessage } from 'antd';
-import { CopyOutlined, ExportOutlined } from '@ant-design/icons';
+import { CopyOutlined, DashboardOutlined, ExportOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 
 import { copy2ClipBoard } from '@/utils';
 import { NAME_SPACE } from '../constants';
+import ContentCard from './ContentCard';
+import RowItem from './RowItem';
 
 interface IDashboardPayload {
   datasource_id?: number;
@@ -27,15 +29,6 @@ function safeParsePayload(raw: string): IDashboardPayload | undefined {
   } catch {
     return undefined;
   }
-}
-
-function RowItem(props: { label: string; value: React.ReactNode }) {
-  return (
-    <div className='grid grid-cols-[120px_1fr] gap-3 border-t border-fc-200 py-2 first:border-t-0'>
-      <div className='text-sm font-medium text-title'>{props.label}</div>
-      <div className='min-w-0 text-sm text-main'>{props.value}</div>
-    </div>
-  );
 }
 
 export default function DashboardContentBlock(props: { responseContent: string }) {
@@ -79,18 +72,14 @@ export default function DashboardContentBlock(props: { responseContent: string }
     );
 
   return (
-    <div className='rounded-lg border border-fc-200 bg-fc-100 px-4 py-3'>
-      <div className='text-sm font-medium text-title'>{t('dashboard.title')}</div>
-
-      <div className='mt-2'>
-        <RowItem label={t('dashboard.field.id')} value={idNode} />
-        <RowItem label={t('dashboard.field.name')} value={nameNode} />
-        <RowItem label={t('dashboard.field.group')} value={groupText} />
-        <RowItem label={t('dashboard.field.datasource')} value={datasourceText} />
-        <RowItem label={t('dashboard.field.panels_count')} value={payload.panels_count !== undefined ? String(payload.panels_count) : '--'} />
-        <RowItem label={t('dashboard.field.variables_count')} value={payload.variables_count !== undefined ? String(payload.variables_count) : '--'} />
-        <RowItem label={t('dashboard.field.tags')} value={payload.tags || '--'} />
-      </div>
-    </div>
+    <ContentCard icon={<DashboardOutlined />} title={t('dashboard.title')} bodyClassName='px-4 py-2'>
+      <RowItem label={t('dashboard.field.id')} value={idNode} />
+      <RowItem label={t('dashboard.field.name')} value={nameNode} />
+      <RowItem label={t('dashboard.field.group')} value={groupText} />
+      <RowItem label={t('dashboard.field.datasource')} value={datasourceText} />
+      <RowItem label={t('dashboard.field.panels_count')} value={payload.panels_count !== undefined ? String(payload.panels_count) : '--'} />
+      <RowItem label={t('dashboard.field.variables_count')} value={payload.variables_count !== undefined ? String(payload.variables_count) : '--'} />
+      <RowItem label={t('dashboard.field.tags')} value={payload.tags || '--'} />
+    </ContentCard>
   );
 }

--- a/src/components/AiChatNG/ContentRenderer/FormSelectContentBlock.tsx
+++ b/src/components/AiChatNG/ContentRenderer/FormSelectContentBlock.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Button, Select } from 'antd';
+import { ProfileOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { NAME_SPACE } from '../constants';
+import ContentCard from './ContentCard';
 
 type FieldKey = 'busi_group_id' | 'datasource_id' | string;
 
@@ -86,15 +88,13 @@ export default function FormSelectContentBlock(props: { responseContent: string;
   }
 
   return (
-    <div className='rounded-lg border border-fc-200 bg-fc-100 px-4 py-3'>
-      <div className='text-sm font-medium text-title'>{t('form_select.title')}</div>
-
-      <div className='mt-3 space-y-3'>
+    <ContentCard icon={<ProfileOutlined />} title={t('form_select.title')}>
+      <div className='grid grid-cols-[auto_1fr] items-center gap-x-3 gap-y-3'>
         {busiGroupField ? (
-          <div className='flex items-center gap-3'>
-            <div className='w-20 shrink-0 text-sm text-title'>{t('form_select.busi_group')}</div>
+          <>
+            <div className='shrink-0 text-right text-sm text-title'>{t('form_select.busi_group')}</div>
             <Select
-              className='min-w-0 flex-1'
+              className='w-full min-w-0'
               placeholder={t('form_select.placeholder_select')}
               value={busiGroupId}
               onChange={(value) => setBusiGroupId(value)}
@@ -102,14 +102,14 @@ export default function FormSelectContentBlock(props: { responseContent: string;
               showSearch
               optionFilterProp='label'
             />
-          </div>
+          </>
         ) : null}
 
         {datasourceField ? (
-          <div className='flex items-center gap-3'>
-            <div className='w-20 shrink-0 text-sm text-title'>{t('form_select.datasource')}</div>
+          <>
+            <div className='shrink-0 text-right text-sm text-title'>{t('form_select.datasource')}</div>
             <Select
-              className='min-w-0 flex-1'
+              className='w-full min-w-0'
               placeholder={t('form_select.placeholder_select')}
               value={datasourceId}
               onChange={(value) => setDatasourceId(value)}
@@ -117,7 +117,7 @@ export default function FormSelectContentBlock(props: { responseContent: string;
               showSearch
               optionFilterProp='label'
             />
-          </div>
+          </>
         ) : null}
       </div>
 
@@ -142,6 +142,6 @@ export default function FormSelectContentBlock(props: { responseContent: string;
           {t('form_select.confirm')}
         </Button>
       </div>
-    </div>
+    </ContentCard>
   );
 }

--- a/src/components/AiChatNG/ContentRenderer/QueryContentBlock.tsx
+++ b/src/components/AiChatNG/ContentRenderer/QueryContentBlock.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Button, Space, Tooltip, message as antdMessage } from 'antd';
-import { CopyOutlined, PlayCircleOutlined } from '@ant-design/icons';
+import { ConsoleSqlOutlined, CopyOutlined, PlayCircleOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 
 import PromQLInput from '@/components/PromQLInput';
 import { copy2ClipBoard } from '@/utils';
 import { NAME_SPACE } from '../constants';
+import ContentCard from './ContentCard';
 
 export default function QueryContentBlock(props: { query: string; onExecute?: () => void }) {
   const { t } = useTranslation(NAME_SPACE);
@@ -13,7 +14,7 @@ export default function QueryContentBlock(props: { query: string; onExecute?: ()
   const canExecute = Boolean(onExecute);
 
   return (
-    <div className='border border-fc-200 rounded-lg p-2'>
+    <ContentCard icon={<ConsoleSqlOutlined />} title={t('query.title')} bodyClassName='p-3'>
       <PromQLInput value={query} readonly />
       <div
         className='my-2'
@@ -46,6 +47,6 @@ export default function QueryContentBlock(props: { query: string; onExecute?: ()
           </Button>
         </Tooltip>
       </Space>
-    </div>
+    </ContentCard>
   );
 }

--- a/src/components/AiChatNG/ContentRenderer/RowItem.tsx
+++ b/src/components/AiChatNG/ContentRenderer/RowItem.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface IRowItemProps {
+  label: string;
+  value: React.ReactNode;
+}
+
+/** 卡片内的「标签 - 值」行，dashboard / alert_rule 等卡片共用，行间以浅分隔线区分。 */
+export default function RowItem(props: IRowItemProps) {
+  return (
+    <div className='grid grid-cols-[120px_1fr] gap-3 border-t border-fc-200 py-2 first:border-t-0'>
+      <div className='text-sm font-medium text-title'>{props.label}</div>
+      <div className='min-w-0 text-sm text-main'>{props.value}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 背景

AI Chat 的几类内容卡片（form_select / dashboard / alert_rule / query）各自维护卡片外壳样式，重复且不一致；在聊天流里和「思考过程」等提示块混在一起，缺少"卡片感"，不够突出。

## 改动

- **抽取公共组件**
  - `ContentCard`：统一卡片外壳 —— `rounded-xl` 白底 + 浅边框 + `shadow-mf` 软阴影，头部为「主色图标 + 分隔线 + `font-semibold` 标题」。后续调整卡片外观只需改这一处。
  - `RowItem`：dashboard / alert_rule 共用的「标签-值」行（此前两个文件各自重复定义）。
- **四张卡片接入 ContentCard**：form_select（`ProfileOutlined`）、dashboard（`DashboardOutlined`）、alert_rule（`AlertOutlined`）、query（`ConsoleSqlOutlined`）。
- **form_select 对齐优化**：标签列由写死的 `w-20` 改为 `grid-cols-[auto_1fr]` 自适应宽度，修复短标签（如"业务组"）右对齐导致 body 整体偏右的问题。
- **query**：补上此前未渲染的标题头（`query.title` 已有文案）。

## 影响范围

纯前端样式重构，无接口/逻辑改动；内容块的 props 与渲染数据保持不变。
