### PR TITLE
fix(aiChat): ContentCard 暗黑模式卡片底色

### DIFF
--- a/src/components/AiChatNG/ContentRenderer/ContentCard.tsx
+++ b/src/components/AiChatNG/ContentRenderer/ContentCard.tsx
@@ -10,14 +10,14 @@ interface IContentCardProps {
 }
 
 /**
- * AI Chat 消息卡片的统一外壳：白底、圆角、浅边框 + 软阴影，头部为「图标 + 标题 + 分隔线」。
+ * AI Chat 消息卡片的统一外壳：卡片底色随主题自适应、圆角、浅边框 + 软阴影，头部为「图标 + 标题 + 分隔线」。
  * form_select / dashboard / alert_rule / query 等内容块共用，样式调整只需改这一处。
  */
 export default function ContentCard(props: IContentCardProps) {
   const { icon, title, children, bodyClassName = 'px-4 py-4' } = props;
 
   return (
-    <div className='rounded-xl border border-fc-200 bg-white shadow-mf'>
+    <div className='rounded-xl border border-fc-200 bg-fc-100 shadow-mf'>
       <div className='flex items-center gap-2 border-b border-fc-200 px-4 py-3'>
         <span className='inline-flex text-primary' style={{ fontSize: 16 }}>
           {icon}


### PR DESCRIPTION
## Summary
- AiChatNG 消息卡片统一外壳 `ContentCard` 硬编码 `bg-white`，暗黑模式下卡片仍为纯白、文字 token 变浅导致对比度过低
- 改为 `bg-fc-100`（`--fc-fill-2`：浅色模式仍为白色，深色模式为 `rgb(22 22 24)` 提升表面），明暗自适应
- 同一外壳被 form_select / dashboard / alert_rule / query 各内容块共用，改一处即可

## Review
- 经 /cmt strict 与 /cr 思路自查；diff 仅 2 行（含注释）

## Verification
- 浅色模式视觉与改动前一致（`--fc-fill-2` 浅色即 `#fff`）
- 待测试环境构建验证暗黑模式对比度（feat-aichat-card-dark-0603）

## Notes
- 对应 flashcatcloud/srm-fe 仓库有同名分支同步修复（重复组件）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated UI component background styling to be theme-adaptive, ensuring consistent appearance across different color themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->