### PR TITLE
feat: add team_ids multi-select field to AiChatNG form_select block

### DIFF
--- a/src/components/AiChatNG/ContentRenderer/FormSelectContentBlock.tsx
+++ b/src/components/AiChatNG/ContentRenderer/FormSelectContentBlock.tsx
@@ -45,18 +45,24 @@ function getDefaultCandidateId(candidates?: IFormSelectCandidate[]) {
   return candidates.find((c) => c.is_default)?.id;
 }
 
-function buildContentText(params: { busiGroupName?: string; datasourceName?: string }) {
-  const { busiGroupName, datasourceName } = params;
-  if (busiGroupName && datasourceName) return `业务组：${busiGroupName} 数据源：${datasourceName}`;
-  if (busiGroupName) return `业务组：${busiGroupName}`;
-  if (datasourceName) return `数据源：${datasourceName}`;
-  return '';
+function getDefaultCandidateIds(candidates?: IFormSelectCandidate[]) {
+  return (candidates || []).filter((c) => c.is_default).map((c) => c.id);
+}
+
+function buildContentText(params: { busiGroupName?: string; datasourceName?: string; teamNames?: string[] }) {
+  const { busiGroupName, datasourceName, teamNames } = params;
+  const parts: string[] = [];
+  if (busiGroupName) parts.push(`业务组：${busiGroupName}`);
+  if (datasourceName) parts.push(`数据源：${datasourceName}`);
+  if (teamNames?.length) parts.push(`团队：${teamNames.join('、')}`);
+  return parts.join(' ');
 }
 
 export interface IFormSelectConfirmResult {
   param: {
     busi_group_id?: number;
     datasource_id?: number;
+    team_ids?: number[];
     approval?: number;
   };
   content: string;
@@ -135,9 +141,24 @@ function FormFieldsView(props: { payload?: IFormSelectPayload; onConfirm: (resul
   const selectedBusiGroupName = React.useMemo(() => busiGroupOptions.find((o) => o.value === busiGroupId)?.label, [busiGroupId, busiGroupOptions]);
   const selectedDatasourceName = React.useMemo(() => datasourceOptions.find((o) => o.value === datasourceId)?.label, [datasourceId, datasourceOptions]);
 
-  const disabled = (!!busiGroupField && !busiGroupId) || (!!datasourceField && !datasourceId) || (!busiGroupField && !datasourceField) || !payload;
+  const teamField = React.useMemo(() => payload?.fields?.find((f) => f.key === 'team_ids'), [payload?.fields]);
+  const teamOptions = React.useMemo(() => (teamField?.candidates || []).map((c) => ({ value: c.id, label: c.name })), [teamField?.candidates]);
+  const [teamIds, setTeamIds] = React.useState<number[]>(() => getDefaultCandidateIds(teamField?.candidates));
 
-  if (!payload || (!busiGroupField && !datasourceField)) {
+  React.useEffect(() => {
+    setTeamIds(getDefaultCandidateIds(teamField?.candidates));
+  }, [teamField?.candidates]);
+
+  const selectedTeamNames = React.useMemo(() => teamOptions.filter((o) => teamIds.includes(o.value)).map((o) => o.label), [teamIds, teamOptions]);
+
+  const disabled =
+    (!!busiGroupField && !busiGroupId) ||
+    (!!datasourceField && !datasourceId) ||
+    (!!teamField && !teamIds.length) ||
+    (!busiGroupField && !datasourceField && !teamField) ||
+    !payload;
+
+  if (!payload || (!busiGroupField && !datasourceField && !teamField)) {
     return <div className='rounded-lg border border-dashed border-fc-200 bg-fc-50 px-4 py-3 text-sm text-hint'>{t('message.unsupported_type', { type: 'form_select' })}</div>;
   }
 
@@ -173,6 +194,22 @@ function FormFieldsView(props: { payload?: IFormSelectPayload; onConfirm: (resul
             />
           </>
         ) : null}
+
+        {teamField ? (
+          <>
+            <div className='shrink-0 text-right text-sm text-title'>{t('form_select.team')}</div>
+            <Select
+              className='w-full min-w-0'
+              mode='multiple'
+              placeholder={t('form_select.placeholder_select')}
+              value={teamIds}
+              onChange={(value) => setTeamIds(value)}
+              options={teamOptions}
+              showSearch
+              optionFilterProp='label'
+            />
+          </>
+        ) : null}
       </div>
 
       <div className='mt-4 flex justify-end'>
@@ -180,15 +217,17 @@ function FormFieldsView(props: { payload?: IFormSelectPayload; onConfirm: (resul
           type='primary'
           disabled={disabled}
           onClick={() => {
-            const param: { busi_group_id?: number; datasource_id?: number } = {};
+            const param: IFormSelectConfirmResult['param'] = {};
             if (busiGroupField && busiGroupId) param.busi_group_id = busiGroupId;
             if (datasourceField && datasourceId) param.datasource_id = datasourceId;
+            if (teamField && teamIds.length) param.team_ids = teamIds;
 
             props.onConfirm({
               param,
               content: buildContentText({
                 busiGroupName: selectedBusiGroupName,
                 datasourceName: selectedDatasourceName,
+                teamNames: selectedTeamNames,
               }),
             });
           }}

--- a/src/components/AiChatNG/locale/en_US.ts
+++ b/src/components/AiChatNG/locale/en_US.ts
@@ -50,6 +50,7 @@ const en_US = {
     approval_title: 'Please confirm the action above:',
     busi_group: 'Business Group',
     datasource: 'Datasource',
+    team: 'Teams',
     placeholder_select: 'Please select',
     confirm: 'Confirm',
   },

--- a/src/components/AiChatNG/locale/ja_JP.ts
+++ b/src/components/AiChatNG/locale/ja_JP.ts
@@ -50,6 +50,7 @@ const ja_JP = {
     approval_title: '上記の操作を実行してもよろしいですか:',
     busi_group: 'ビジネスグループ',
     datasource: 'データソース',
+    team: 'チーム',
     placeholder_select: '選択してください',
     confirm: '確定',
   },

--- a/src/components/AiChatNG/locale/ru_RU.ts
+++ b/src/components/AiChatNG/locale/ru_RU.ts
@@ -50,6 +50,7 @@ const ru_RU = {
     approval_title: 'Пожалуйста, подтвердите указанное выше действие:',
     busi_group: 'Группа бизнеса',
     datasource: 'Источник данных',
+    team: 'Команды',
     placeholder_select: 'Выберите',
     confirm: 'Подтвердить',
   },

--- a/src/components/AiChatNG/locale/zh_CN.ts
+++ b/src/components/AiChatNG/locale/zh_CN.ts
@@ -50,6 +50,7 @@ const zh_CN = {
     approval_title: '请确认是否执行以上操作：',
     busi_group: '业务组',
     datasource: '数据源',
+    team: '团队',
     placeholder_select: '请选择',
     confirm: '确定',
   },

--- a/src/components/AiChatNG/locale/zh_HK.ts
+++ b/src/components/AiChatNG/locale/zh_HK.ts
@@ -50,6 +50,7 @@ const zh_HK = {
     approval_title: '請確認是否執行以上操作：',
     busi_group: '業務組',
     datasource: '數據源',
+    team: '團隊',
     placeholder_select: '請選擇',
     confirm: '確定',
   },


### PR DESCRIPTION
<img width="1734" height="324" alt="image" src="https://github.com/user-attachments/assets/2b5fde9b-56ca-45a5-8563-c48645a3f7d7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for team selection in forms. Users can now select one or more teams when completing form submissions that include a team field.

* **Localization**
  * Added "Teams" label translations in English, Japanese, Russian, Simplified Chinese, and Traditional Chinese (Hong Kong).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->