### PR TITLE
抽取启用状态列表格配置

### DIFF
--- a/src/components/Contacts/index.tsx
+++ b/src/components/Contacts/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
 import { CloseOutlined } from '@ant-design/icons';
 
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { getNotifyContacts, putNotifyContacts } from './services';
 import { ContactType } from './types';
 import { NS, CN } from './constants';
@@ -119,15 +119,16 @@ export default function ContactDrawer(props: Props) {
                 key: 'ident',
               },
               {
-                title: t('common:table.enabled'),
-                dataIndex: 'hide',
+                ...getEnabledStatusColumn({
+                  title: t('common:table.enabled'),
+                  dataIndex: 'hide',
+                  enabledText: t('common:table.enabled'),
+                  disabledText: t('disabled'),
+                  enabledValue: false,
+                  disabledValue: true,
+                }),
                 key: 'hide',
-                sorter: (a, b) => Number(a.hide) - Number(b.hide),
-                filters: [
-                  { text: t('common:table.enabled'), value: false },
-                  { text: t('disabled'), value: true },
-                ],
-                onFilter: (value, record) => record.hide === value,
+
                 render: (val: boolean, record) => {
                   return (
                     <Switch

--- a/src/components/EnhancedTable/index.tsx
+++ b/src/components/EnhancedTable/index.tsx
@@ -67,6 +67,47 @@ export interface EnhancedTableProps<RecordType> extends TableProps<RecordType> {
   actionColumn?: Partial<ColumnType<RecordType>>;
 }
 
+type EnabledStatusFilterValue = boolean | number | string;
+type EnabledStatusValue = EnabledStatusFilterValue | null | undefined;
+
+export interface EnabledStatusColumnOptions<ValueType extends EnabledStatusValue = EnabledStatusValue> {
+  title: React.ReactNode;
+  dataIndex: ColumnType<any>['dataIndex'];
+  enabledText: React.ReactNode;
+  disabledText: React.ReactNode;
+  enabledValue: EnabledStatusFilterValue;
+  disabledValue: EnabledStatusFilterValue;
+  getValue?: (record: any) => ValueType;
+  sorter?: ColumnType<any>['sorter'];
+  onFilter?: ColumnType<any>['onFilter'] | false;
+}
+
+function getColumnValue<ValueType extends EnabledStatusValue>(record: any, dataIndex: ColumnType<any>['dataIndex']): ValueType {
+  if (Array.isArray(dataIndex)) {
+    return dataIndex.reduce((current, key) => current?.[key], record) as ValueType;
+  }
+  return record[dataIndex as keyof typeof record] as ValueType;
+}
+
+export function getEnabledStatusColumn<ValueType extends EnabledStatusValue = EnabledStatusValue>(
+  options: EnabledStatusColumnOptions<ValueType>,
+): Pick<ColumnType<any>, 'title' | 'dataIndex' | 'sorter' | 'filters' | 'onFilter'> {
+  const { title, dataIndex, enabledText, disabledText, enabledValue, disabledValue, getValue, sorter, onFilter } = options;
+  const readValue = (record: any) => (getValue ? getValue(record) : getColumnValue<ValueType>(record, dataIndex));
+  const rank = (value: ValueType) => (value === enabledValue ? 0 : value === disabledValue ? 1 : 2);
+
+  return {
+    title,
+    dataIndex,
+    sorter: sorter ?? ((a, b) => rank(readValue(a)) - rank(readValue(b))),
+    filters: [
+      { text: enabledText, value: enabledValue },
+      { text: disabledText, value: disabledValue },
+    ],
+    ...(onFilter === false ? {} : { onFilter: onFilter ?? ((value, record) => readValue(record) === value) }),
+  };
+}
+
 const visibleOnly = (list?: RowAction[]) => (list || []).filter((a) => a.visible !== false);
 
 function ActionButton({ action, className, withIcon }: { action: RowAction; className: string; withIcon?: boolean }) {

--- a/src/pages/aiConfig/agents/pages/List.tsx
+++ b/src/pages/aiConfig/agents/pages/List.tsx
@@ -5,7 +5,7 @@ import { useRequest } from 'ahooks';
 
 import PageLayout from '@/components/pageLayout';
 import usePagination from '@/components/usePagination';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import EllipsisText from '@/components/EllipsisText';
 
 import { NS } from '../constants';
@@ -78,14 +78,15 @@ export default function List() {
                     title: t('use_case'),
                   },
                   {
-                    dataIndex: 'enabled',
-                    title: t('enabled'),
-                    sorter: (a, b) => Number(a.enabled) - Number(b.enabled),
-                    filters: [
-                      { text: t('enabled'), value: true },
-                      { text: t('disabled'), value: false },
-                    ],
-                    onFilter: (value, record) => record.enabled === value,
+                    ...getEnabledStatusColumn({
+                      title: t('enabled'),
+                      dataIndex: 'enabled',
+                      enabledText: t('enabled'),
+                      disabledText: t('disabled'),
+                      enabledValue: true,
+                      disabledValue: false,
+                    }),
+
                     render: (val, record) => {
                       return (
                         <Switch

--- a/src/pages/aiConfig/llmConfigs/pages/List.tsx
+++ b/src/pages/aiConfig/llmConfigs/pages/List.tsx
@@ -6,7 +6,7 @@ import { useRequest } from 'ahooks';
 
 import PageLayout from '@/components/pageLayout';
 import usePagination from '@/components/usePagination';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import EllipsisText from '@/components/EllipsisText';
 
 import { NS } from '../constants';
@@ -103,14 +103,15 @@ export default function List() {
                     title: t('model'),
                   },
                   {
-                    dataIndex: 'enabled',
-                    title: t('enabled'),
-                    sorter: (a, b) => Number(a.enabled) - Number(b.enabled),
-                    filters: [
-                      { text: t('enabled'), value: true },
-                      { text: t('disabled'), value: false },
-                    ],
-                    onFilter: (value, record) => record.enabled === value,
+                    ...getEnabledStatusColumn({
+                      title: t('enabled'),
+                      dataIndex: 'enabled',
+                      enabledText: t('enabled'),
+                      disabledText: t('disabled'),
+                      enabledValue: true,
+                      disabledValue: false,
+                    }),
+
                     render: (val, record) => (
                       <Switch
                         size='small'

--- a/src/pages/aiConfig/mcpServers/pages/List.tsx
+++ b/src/pages/aiConfig/mcpServers/pages/List.tsx
@@ -6,7 +6,7 @@ import { useRequest } from 'ahooks';
 
 import PageLayout from '@/components/pageLayout';
 import usePagination from '@/components/usePagination';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import EllipsisText from '@/components/EllipsisText';
 
 import { NS } from '../constants';
@@ -88,14 +88,15 @@ export default function List() {
                     title: t('url'),
                   },
                   {
-                    dataIndex: 'enabled',
-                    title: t('enabled'),
-                    sorter: (a, b) => Number(a.enabled) - Number(b.enabled),
-                    filters: [
-                      { text: t('enabled'), value: true },
-                      { text: t('disabled'), value: false },
-                    ],
-                    onFilter: (value, record) => record.enabled === value,
+                    ...getEnabledStatusColumn({
+                      title: t('enabled'),
+                      dataIndex: 'enabled',
+                      enabledText: t('enabled'),
+                      disabledText: t('disabled'),
+                      enabledValue: true,
+                      disabledValue: false,
+                    }),
+
                     render: (val, record) => (
                       <Switch
                         size='small'

--- a/src/pages/alertRules/List/ListNG.tsx
+++ b/src/pages/alertRules/List/ListNG.tsx
@@ -17,7 +17,7 @@ import DatasourceSelect from '@/components/DatasourceSelect/DatasourceSelect';
 import OrganizeColumns, { getDefaultColumnsConfigs, setDefaultColumnsConfigs, ajustColumns } from '@/components/OrganizeColumns';
 import usePagination from '@/components/usePagination';
 import Tags from '@/components/TableTags/Tags';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { dateColumn, userColumn } from '@/components/EnhancedTable/columns';
 import localeCompare from '@/pages/dashboard/Renderer/utils/localeCompare';
 import { getItems as getNotificationRules, RuleItem as NotificationRuleItem } from '@/pages/notificationRules/services';
@@ -251,14 +251,15 @@ export default function AlertRules(props: Props) {
     readonly
       ? [
           {
-            title: t('table.disabled'),
-            dataIndex: 'disabled',
-            sorter: (a, b) => a.disabled - b.disabled,
-            filters: [
-              { text: t('filter_disabled.0'), value: 0 },
-              { text: t('filter_disabled.1'), value: 1 },
-            ],
-            onFilter: (value, record) => record.disabled === value,
+            ...getEnabledStatusColumn({
+              title: t('table.disabled'),
+              dataIndex: 'disabled',
+              enabledText: t('filter_disabled.0'),
+              disabledText: t('filter_disabled.1'),
+              enabledValue: 0,
+              disabledValue: 1,
+            }),
+
             render: (status) => {
               return (
                 <Tag className='mr-0' color={status === AlertRuleStatus.Enable ? 'success' : 'error'}>
@@ -270,14 +271,15 @@ export default function AlertRules(props: Props) {
         ]
       : ([
           {
-            title: t('table.disabled'),
-            dataIndex: 'disabled',
-            sorter: (a, b) => a.disabled - b.disabled,
-            filters: [
-              { text: t('filter_disabled.0'), value: 0 },
-              { text: t('filter_disabled.1'), value: 1 },
-            ],
-            onFilter: (value, record) => record.disabled === value,
+            ...getEnabledStatusColumn({
+              title: t('table.disabled'),
+              dataIndex: 'disabled',
+              enabledText: t('filter_disabled.0'),
+              disabledText: t('filter_disabled.1'),
+              enabledValue: 0,
+              disabledValue: 1,
+            }),
+
             render: (disabled, record) => (
               <Switch
                 checked={disabled === AlertRuleStatus.Enable}

--- a/src/pages/contacts/pages/List.tsx
+++ b/src/pages/contacts/pages/List.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
 
 import PageLayout, { HelpLink } from '@/components/pageLayout';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 
 import { getNotifyContacts, putNotifyContacts } from '../services';
 import { ContactType } from '../types';
@@ -65,15 +65,16 @@ export default function Channels() {
                 key: 'ident',
               },
               {
-                title: t('common:table.enabled'),
-                dataIndex: 'hide',
+                ...getEnabledStatusColumn({
+                  title: t('common:table.enabled'),
+                  dataIndex: 'hide',
+                  enabledText: t('common:table.enabled'),
+                  disabledText: t('disabled'),
+                  enabledValue: false,
+                  disabledValue: true,
+                }),
                 key: 'hide',
-                sorter: (a, b) => Number(a.hide) - Number(b.hide),
-                filters: [
-                  { text: t('common:table.enabled'), value: false },
-                  { text: t('disabled'), value: true },
-                ],
-                onFilter: (value, record) => record.hide === value,
+
                 render: (val: boolean, record) => {
                   return (
                     <Switch

--- a/src/pages/datasource/components/TableSource/index.tsx
+++ b/src/pages/datasource/components/TableSource/index.tsx
@@ -6,7 +6,7 @@ import { ColumnProps } from 'antd/es/table';
 import { CheckCircleFilled, MinusCircleFilled, WarningOutlined } from '@ant-design/icons';
 import { CommonStateContext } from '@/App';
 import usePagination from '@/components/usePagination';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { allCates } from '@/components/AdvancedWrap/utils';
 import localeCompare from '@/pages/dashboard/Renderer/utils/localeCompare';
 
@@ -156,21 +156,15 @@ const TableSource = (props: IPropsType) => {
       },
     },
     {
-      title: t('status.title'),
+      ...getEnabledStatusColumn({
+        title: t('status.title'),
+        dataIndex: 'status',
+        enabledText: t('status.enabled'),
+        disabledText: t('status.disabled'),
+        enabledValue: 'enabled',
+        disabledValue: 'disabled',
+      }),
       width: 300,
-      dataIndex: 'status',
-      sorter: (a, b) => localeCompare(a.status, b.status),
-      filters: [
-        {
-          text: t('status.enabled'),
-          value: 'enabled',
-        },
-        {
-          text: t('status.disabled'),
-          value: 'disabled',
-        },
-      ],
-      onFilter: (value: string, record) => record.status === value,
       render: (text) => {
         return text === 'enabled' ? (
           <>

--- a/src/pages/eventPipeline/pages/List/index.tsx
+++ b/src/pages/eventPipeline/pages/List/index.tsx
@@ -7,7 +7,7 @@ import _ from 'lodash';
 
 import usePagination from '@/components/usePagination';
 import Tags from '@/components/TableTags/Tags';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { tagsColumn, userColumn, dateColumn } from '@/components/EnhancedTable/columns';
 import EllipsisText from '@/components/EllipsisText';
 
@@ -199,16 +199,17 @@ export default function List() {
             },
           },
           {
-            title: t('disabled.label'),
-            dataIndex: 'disabled',
+            ...getEnabledStatusColumn({
+              title: t('disabled.label'),
+              dataIndex: 'disabled',
+              enabledText: t('disabled.false'),
+              disabledText: t('disabled.true'),
+              enabledValue: false,
+              disabledValue: true,
+            }),
             key: 'disabled',
             width: 100,
-            sorter: (a, b) => Number(a.disabled) - Number(b.disabled),
-            filters: [
-              { text: t('disabled.false'), value: false },
-              { text: t('disabled.true'), value: true },
-            ],
-            onFilter: (value, record) => record.disabled === value,
+
             render: (value) => {
               return (
                 <Tags

--- a/src/pages/help/NotificationSettings/Channels/index.tsx
+++ b/src/pages/help/NotificationSettings/Channels/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Switch, Space, Button, Modal, message } from 'antd';
 import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import DocumentDrawer from '@/components/DocumentDrawer';
 import { getNotifyChannels, putNotifyChannels } from '../services';
 import { ChannelType } from '../types';
@@ -75,15 +75,16 @@ export default function Channels() {
             key: 'ident',
           },
           {
-            title: t('channels.enabled'),
-            dataIndex: 'hide',
+            ...getEnabledStatusColumn({
+              title: t('channels.enabled'),
+              dataIndex: 'hide',
+              enabledText: t('channels.enabled'),
+              disabledText: t('disabled'),
+              enabledValue: false,
+              disabledValue: true,
+            }),
             key: 'hide',
-            sorter: (a, b) => Number(a.hide) - Number(b.hide),
-            filters: [
-              { text: t('channels.enabled'), value: false },
-              { text: t('disabled'), value: true },
-            ],
-            onFilter: (value, record) => record.hide === value,
+
             render: (val: boolean, record) => {
               return (
                 <Switch

--- a/src/pages/help/NotificationSettings/Contacts/index.tsx
+++ b/src/pages/help/NotificationSettings/Contacts/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Switch, Space, Button, Modal, message } from 'antd';
 import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import DocumentDrawer from '@/components/DocumentDrawer';
 import { getNotifyContacts, putNotifyContacts } from '../services';
 import { ContactType } from '../types';
@@ -75,15 +75,16 @@ export default function Channels() {
             key: 'ident',
           },
           {
-            title: t('channels.enabled'),
-            dataIndex: 'hide',
+            ...getEnabledStatusColumn({
+              title: t('channels.enabled'),
+              dataIndex: 'hide',
+              enabledText: t('channels.enabled'),
+              disabledText: t('disabled'),
+              enabledValue: false,
+              disabledValue: true,
+            }),
             key: 'hide',
-            sorter: (a, b) => Number(a.hide) - Number(b.hide),
-            filters: [
-              { text: t('channels.enabled'), value: false },
-              { text: t('disabled'), value: true },
-            ],
-            onFilter: (value, record) => record.hide === value,
+
             render: (val: boolean, record) => {
               return (
                 <Switch

--- a/src/pages/notificationChannels/pages/List/index.tsx
+++ b/src/pages/notificationChannels/pages/List/index.tsx
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom';
 import usePagination from '@/components/usePagination';
 import PageLayout from '@/components/pageLayout';
 import { Import, Export } from '@/components/ExportImport';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 
 import { getItems, putItem, deleteItems, postItems } from '../../services';
 import { NS } from '../../constants';
@@ -153,15 +153,15 @@ export default function List() {
               },
             },
             {
-              title: t('common:table.enabled'),
+              ...getEnabledStatusColumn({
+                title: t('common:table.enabled'),
+                dataIndex: 'enable',
+                enabledText: t('common:table.enabled'),
+                disabledText: t('disabled'),
+                enabledValue: true,
+                disabledValue: false,
+              }),
               width: 100,
-              dataIndex: 'enable',
-              sorter: (a, b) => Number(a.enable) - Number(b.enable),
-              filters: [
-                { text: t('common:table.enabled'), value: true },
-                { text: t('disabled'), value: false },
-              ],
-              onFilter: (value, record) => record.enable === value,
               render: (val, record) => (
                 <Switch
                   checked={val}

--- a/src/pages/notificationChannels/pages/ListNG/index.tsx
+++ b/src/pages/notificationChannels/pages/ListNG/index.tsx
@@ -10,7 +10,7 @@ import moment from 'moment';
 import usePagination from '@/components/usePagination';
 import PageLayout from '@/components/pageLayout';
 import { Import, Export } from '@/components/ExportImport';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 
 import { NS, NOTIFICATION_CHANNEL_TYPES } from '../../constants';
 import { getItems, putItem, deleteItems, postItems } from '../../services';
@@ -270,15 +270,15 @@ export default function index() {
                     },
                   },
                   {
-                    title: t('common:table.enabled'),
+                    ...getEnabledStatusColumn({
+                      title: t('common:table.enabled'),
+                      dataIndex: 'enable',
+                      enabledText: t('common:table.enabled'),
+                      disabledText: t('disabled'),
+                      enabledValue: true,
+                      disabledValue: false,
+                    }),
                     width: 100,
-                    dataIndex: 'enable',
-                    sorter: (a, b) => Number(a.enable) - Number(b.enable),
-                    filters: [
-                      { text: t('common:table.enabled'), value: true },
-                      { text: t('disabled'), value: false },
-                    ],
-                    onFilter: (value, record) => record.enable === value,
                     render: (val, record) => (
                       <Switch
                         checked={val}

--- a/src/pages/notificationRules/pages/List.tsx
+++ b/src/pages/notificationRules/pages/List.tsx
@@ -7,7 +7,7 @@ import { Link, useHistory } from 'react-router-dom';
 
 import { IS_PLUS } from '@/utils/constant';
 import PageLayout from '@/components/pageLayout';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { userColumn, dateColumn } from '@/components/EnhancedTable/columns';
 import Tags from '@/components/TableTags/Tags';
 import { getSimplifiedItems as getNotificationChannels } from '@/pages/notificationChannels/services';
@@ -179,15 +179,15 @@ export default function List() {
             userColumn({ title: t('common:table.update_by'), dataIndex: 'update_by', nickname: 'update_by_nickname' }),
             dateColumn({ title: t('common:table.update_at'), dataIndex: 'update_at', unix: true }),
             {
-              title: t('common:table.enabled'),
+              ...getEnabledStatusColumn({
+                title: t('common:table.enabled'),
+                dataIndex: 'enable',
+                enabledText: t('common:table.enabled'),
+                disabledText: t('disabled'),
+                enabledValue: true,
+                disabledValue: false,
+              }),
               width: 100,
-              dataIndex: 'enable',
-              sorter: (a, b) => Number(a.enable) - Number(b.enable),
-              filters: [
-                { text: t('common:table.enabled'), value: true },
-                { text: t('disabled'), value: false },
-              ],
-              onFilter: (value, record) => record.enable === value,
               render: (val, record) => (
                 <Switch
                   checked={val}

--- a/src/pages/recordingRules/PageTable.tsx
+++ b/src/pages/recordingRules/PageTable.tsx
@@ -12,7 +12,7 @@ import { strategyItem, strategyStatus } from '@/store/warningInterface';
 import { deleteRecordingRule } from '@/services/recording';
 import { CommonStateContext } from '@/App';
 import localeCompare from '@/pages/dashboard/Renderer/utils/localeCompare';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { tagsColumn, dateColumn } from '@/components/EnhancedTable/columns';
 import Tags from '@/components/TableTags/Tags';
 import EditModal from './components/editModal';
@@ -175,14 +175,15 @@ const PageTable: React.FC<Props> = ({ gids }) => {
       },
     }),
     {
-      title: t('disabled'),
-      dataIndex: 'disabled',
-      sorter: (a, b) => a.disabled - b.disabled,
-      filters: [
-        { text: t('filter_disabled.0'), value: 0 },
-        { text: t('filter_disabled.1'), value: 1 },
-      ],
-      onFilter: (value, record) => record.disabled === value,
+      ...getEnabledStatusColumn({
+        title: t('disabled'),
+        dataIndex: 'disabled',
+        enabledText: t('filter_disabled.0'),
+        disabledText: t('filter_disabled.1'),
+        enabledValue: 0,
+        disabledValue: 1,
+      }),
+
       render: (disabled, record) => (
         <Switch
           checked={disabled === strategyStatus.Enable}

--- a/src/pages/warning/shield/index.tsx
+++ b/src/pages/warning/shield/index.tsx
@@ -24,7 +24,7 @@ import { useTranslation } from 'react-i18next';
 import { useHistory, Link } from 'react-router-dom';
 
 import Tags from '@/components/TableTags/Tags';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { dateColumn } from '@/components/EnhancedTable/columns';
 import PageLayout from '@/components/pageLayout';
 import { getBusiGroupsAlertMutes, deleteShields, updateShields } from '@/services/shield';
@@ -237,14 +237,15 @@ const Shield: React.FC = () => {
         dataIndex: 'update_by',
       },
       {
-        title: t('common:table.enabled'),
-        dataIndex: 'disabled',
-        sorter: (a, b) => a.disabled - b.disabled,
-        filters: [
-          { text: t('filter_disabled.0'), value: 0 },
-          { text: t('filter_disabled.1'), value: 1 },
-        ],
-        onFilter: (value, record) => record.disabled === value,
+        ...getEnabledStatusColumn({
+          title: t('common:table.enabled'),
+          dataIndex: 'disabled',
+          enabledText: t('filter_disabled.0'),
+          disabledText: t('filter_disabled.1'),
+          enabledValue: 0,
+          disabledValue: 1,
+        }),
+
         render: (disabled, record) => (
           <Switch
             checked={disabled === strategyStatus.Enable}

--- a/src/pages/warning/subscribe/ListNG.tsx
+++ b/src/pages/warning/subscribe/ListNG.tsx
@@ -15,7 +15,7 @@ import { DatasourceSelect } from '@/components/DatasourceSelect';
 import { strategyStatus } from '@/store/warningInterface';
 import Tags from '@/components/TableTags/Tags';
 import { allCates, getCateDisplayLabel } from '@/components/AdvancedWrap/utils';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { userColumn } from '@/components/EnhancedTable/columns';
 import OrganizeColumns, { getDefaultColumnsConfigs, setDefaultColumnsConfigs, ajustColumns } from '@/components/OrganizeColumns';
 import usePagination from '@/components/usePagination';
@@ -227,14 +227,15 @@ const Subscribe = (props: Props) => {
     readonly
       ? [
           {
-            title: t('common:table.enabled'),
-            dataIndex: 'disabled',
-            sorter: (a, b) => a.disabled - b.disabled,
-            filters: [
-              { text: t('filter_disabled.0'), value: 0 },
-              { text: t('filter_disabled.1'), value: 1 },
-            ],
-            onFilter: (value, record) => record.disabled === value,
+            ...getEnabledStatusColumn({
+              title: t('common:table.enabled'),
+              dataIndex: 'disabled',
+              enabledText: t('filter_disabled.0'),
+              disabledText: t('filter_disabled.1'),
+              enabledValue: 0,
+              disabledValue: 1,
+            }),
+
             render: (status) => {
               return (
                 <Tag className='mr-0' color={status === strategyStatus.Enable ? 'success' : 'error'}>
@@ -246,14 +247,15 @@ const Subscribe = (props: Props) => {
         ]
       : [
           {
-            title: t('common:table.enabled'),
-            dataIndex: 'disabled',
-            sorter: (a, b) => a.disabled - b.disabled,
-            filters: [
-              { text: t('filter_disabled.0'), value: 0 },
-              { text: t('filter_disabled.1'), value: 1 },
-            ],
-            onFilter: (value, record) => record.disabled === value,
+            ...getEnabledStatusColumn({
+              title: t('common:table.enabled'),
+              dataIndex: 'disabled',
+              enabledText: t('filter_disabled.0'),
+              disabledText: t('filter_disabled.1'),
+              enabledValue: 0,
+              disabledValue: 1,
+            }),
+
             render: (disabled, record: any) => (
               <Switch
                 checked={disabled === strategyStatus.Enable}

--- a/src/pages/warning/subscribe/components/ruleModal.tsx
+++ b/src/pages/warning/subscribe/components/ruleModal.tsx
@@ -18,6 +18,7 @@ import React, { useState, useEffect, useCallback, useContext } from 'react';
 import { Input, Table, Switch, Tag, Select, Modal, Space, Button } from 'antd';
 import { SearchOutlined } from '@ant-design/icons';
 import { Link } from 'react-router-dom';
+import { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { useTranslation } from 'react-i18next';
 import { ColumnType } from 'antd/lib/table';
 import moment from 'moment';
@@ -222,14 +223,15 @@ const ruleModal: React.FC<props> = (props) => {
       },
     },
     {
-      title: t('common:table.enabled'),
-      dataIndex: 'disabled',
-      sorter: (a, b) => a.disabled - b.disabled,
-      filters: [
-        { text: t('filter_disabled.0'), value: 0 },
-        { text: t('filter_disabled.1'), value: 1 },
-      ],
-      onFilter: (value, record) => record.disabled === value,
+      ...getEnabledStatusColumn({
+        title: t('common:table.enabled'),
+        dataIndex: 'disabled',
+        enabledText: t('filter_disabled.0'),
+        disabledText: t('filter_disabled.1'),
+        enabledValue: 0,
+        disabledValue: 1,
+      }),
+
       render: (disabled, record) => (
         <Switch
           checked={disabled === strategyStatus.Enable}


### PR DESCRIPTION
## 变更内容

- 新增 `getEnabledStatusColumn` 表格 helper，统一启用状态列的 title / sorter / filters / onFilter 配置
- 将已合入 0601 的启用列配置替换为 helper 调用
- 保留各业务列显式传入字段和值映射，避免 EnhancedTable 自动猜测业务含义
- datasource 继续复用原有 `status.title / status.enabled / status.disabled` key，仅通过 helper 统一列配置

## 验证

- `git diff --check` 通过
- `npx tsc --noEmit` 通过
- `rg` 复核本次改动文件中不再保留手写启用列 sorter/filter/onFilter 三件套，除 helper 自身定义外

## 说明

- base: `feat-table-design-0601`
- 这是 #2129 合并后的 follow-up PR，只包含 helper 抽取增量。