### PR TITLE
feat: support enhanced table update-by filters

### DIFF
--- a/src/components/Contacts/index.tsx
+++ b/src/components/Contacts/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
 import { CloseOutlined } from '@ant-design/icons';
 
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { getNotifyContacts, putNotifyContacts } from './services';
 import { ContactType } from './types';
 import { NS, CN } from './constants';
@@ -119,15 +119,16 @@ export default function ContactDrawer(props: Props) {
                 key: 'ident',
               },
               {
-                title: t('common:table.enabled'),
-                dataIndex: 'hide',
+                ...getEnabledStatusColumn({
+                  title: t('common:table.enabled'),
+                  dataIndex: 'hide',
+                  enabledText: t('common:table.enabled'),
+                  disabledText: t('disabled'),
+                  enabledValue: false,
+                  disabledValue: true,
+                }),
                 key: 'hide',
-                sorter: (a, b) => Number(a.hide) - Number(b.hide),
-                filters: [
-                  { text: t('common:table.enabled'), value: false },
-                  { text: t('disabled'), value: true },
-                ],
-                onFilter: (value, record) => record.hide === value,
+
                 render: (val: boolean, record) => {
                   return (
                     <Switch

--- a/src/components/EnhancedTable/columns.test.ts
+++ b/src/components/EnhancedTable/columns.test.ts
@@ -1,0 +1,38 @@
+jest.mock('@/components/TableTags/Tags', () => {
+  return {
+    __esModule: true,
+    default: () => null,
+  };
+});
+
+import { getUpdateByColumnFilterProps, updateByColumn } from './columns';
+
+describe('updateByColumn', () => {
+  it('lets EnhancedTable generate unique local filters from table dataSource', () => {
+    const column = updateByColumn({
+      title: '更新人',
+      dataIndex: 'updated_by',
+    });
+    const filterProps = getUpdateByColumnFilterProps(column, [{ updated_by: 'alice' }, { updated_by: 'bob' }, { updated_by: 'alice' }, { updated_by: '' }, {}]);
+
+    expect(column.filters).toBeUndefined();
+    expect(filterProps.filters).toEqual([
+      { text: 'alice', value: 'alice' },
+      { text: 'bob', value: 'bob' },
+    ]);
+    expect(filterProps.onFilter?.('alice', { updated_by: 'alice' })).toBe(true);
+    expect(filterProps.onFilter?.('alice', { updated_by: 'bob' })).toBe(false);
+  });
+
+  it('does not show a filter when filterMode is none', () => {
+    const column = updateByColumn({
+      title: '更新人',
+      dataIndex: 'updated_by',
+      filterMode: 'none',
+    });
+    const filterProps = getUpdateByColumnFilterProps(column, [{ updated_by: 'alice' }]);
+
+    expect(filterProps.filters).toBeUndefined();
+    expect(filterProps.onFilter).toBeUndefined();
+  });
+});

--- a/src/components/EnhancedTable/columns.tsx
+++ b/src/components/EnhancedTable/columns.tsx
@@ -10,6 +10,62 @@ import Tags from '@/components/TableTags/Tags';
  * title column) stay hand-written.
  */
 
+type UpdateByValue = string | number | null | undefined;
+export type UpdateByFilterMode = 'client' | 'server' | 'none';
+export const UPDATE_BY_COLUMN_META = '__fcUpdateByColumnMeta__';
+
+export type UpdateByColumnOptions<T = any> = {
+  title: React.ReactNode;
+  dataIndex: ColumnType<T>['dataIndex'];
+  nickname?: string;
+  getValue?: (record: T) => UpdateByValue;
+  filterMode?: UpdateByFilterMode;
+  onFilter?: ColumnType<T>['onFilter'] | false;
+} & Omit<Partial<ColumnType<T>>, 'onFilter' | 'filterMode'>;
+
+export type UpdateByColumnType<T = any> = ColumnType<T> & {
+  [UPDATE_BY_COLUMN_META]?: {
+    filterMode: UpdateByFilterMode;
+    getValue?: (record: T) => UpdateByValue;
+    onFilter?: ColumnType<T>['onFilter'] | false;
+  };
+};
+
+function getColumnValue<T = any>(record: T, dataIndex: ColumnType<T>['dataIndex']) {
+  if (Array.isArray(dataIndex)) {
+    return dataIndex.reduce((current: any, key) => current?.[key], record as any);
+  }
+  return (record as any)?.[dataIndex as any];
+}
+
+function getUpdateByFilters<T>(dataSource: T[] | undefined, readValue: (record: T) => UpdateByValue) {
+  if (!dataSource?.length) return undefined;
+
+  const valueMap = new Map<string, string | number>();
+  dataSource.forEach((record) => {
+    const value = readValue(record);
+    if (value === undefined || value === null || value === '') return;
+    valueMap.set(String(value), value);
+  });
+
+  const filters = Array.from(valueMap.entries()).map(([text, value]) => ({ text, value }));
+  return filters.length ? filters : undefined;
+}
+
+export function getUpdateByColumnFilterProps<T>(column: ColumnType<T>, dataSource: readonly T[] | undefined): Pick<ColumnType<T>, 'filters' | 'onFilter'> {
+  const meta = (column as UpdateByColumnType<T>)[UPDATE_BY_COLUMN_META];
+  if (!meta || meta.filterMode === 'none') return {};
+
+  const readValue = (record: T) => meta.getValue?.(record) ?? (getColumnValue(record, column.dataIndex) as UpdateByValue);
+  const filters = column.filters ?? (meta.filterMode === 'client' ? getUpdateByFilters(dataSource as T[] | undefined, readValue) : undefined);
+  if (!filters) return {};
+
+  return {
+    filters,
+    ...(meta.onFilter === false ? {} : { onFilter: meta.onFilter ?? ((value, record) => readValue(record) === value) }),
+  };
+}
+
 // Tags column (unified +N popover)
 export function tagsColumn<T = any>(
   opts: {
@@ -46,6 +102,26 @@ export function userColumn<T = any>(
       </div>
     ),
     ...rest,
+  };
+}
+
+// Update-by column: user rendering plus optional local/server filter support.
+export function updateByColumn<T = any>(opts: UpdateByColumnOptions<T>): UpdateByColumnType<T> {
+  const { nickname, getValue, filterMode = 'client', onFilter, ...rest } = opts;
+  return {
+    width: 120,
+    render: (value: any, record: any) => (
+      <div>
+        <div>{value || '-'}</div>
+        {nickname && record?.[nickname] && <div className='text-soft'>{record[nickname]}</div>}
+      </div>
+    ),
+    ...rest,
+    [UPDATE_BY_COLUMN_META]: {
+      filterMode,
+      getValue,
+      onFilter,
+    },
   };
 }
 

--- a/src/components/EnhancedTable/index.test.ts
+++ b/src/components/EnhancedTable/index.test.ts
@@ -1,0 +1,82 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+jest.mock('./style.less', () => ({}));
+
+jest.mock('./columns', () => ({
+  getUpdateByColumnFilterProps: () => ({}),
+}));
+
+jest.mock('lucide-react', () => {
+  const icon =
+    (name: string) =>
+    ({ className }: { className?: string }) =>
+      React.createElement('svg', { className, 'data-icon': name });
+
+  return {
+    CheckCircle: icon('CheckCircle'),
+    Copy: icon('Copy'),
+    ExternalLink: icon('ExternalLink'),
+    Eye: icon('Eye'),
+    Link: icon('Link'),
+    MoreVertical: icon('MoreVertical'),
+    Network: icon('Network'),
+    Pencil: icon('Pencil'),
+    Play: icon('Play'),
+    Plus: icon('Plus'),
+    Search: icon('Search'),
+    Settings: icon('Settings'),
+    ShieldCheck: icon('ShieldCheck'),
+    Sparkles: icon('Sparkles'),
+    Trash2: icon('Trash2'),
+  };
+});
+
+jest.mock('antd', () => {
+  return {
+    Table: ({ columns, dataSource }: { columns: any[]; dataSource: any[] }) =>
+      React.createElement(
+        'div',
+        {},
+        dataSource.map((record, index) =>
+          React.createElement(
+            'div',
+            { key: record.id ?? index },
+            columns.map((column) =>
+              React.createElement('div', { key: column.key ?? column.dataIndex }, column.render ? column.render(undefined, record, index) : null),
+            ),
+          ),
+        ),
+      ),
+    Button: ({ children, className, icon, title }: any) =>
+      React.createElement('button', { className, title }, icon, children),
+    Tooltip: ({ children, title }: any) => React.createElement('span', { 'data-tooltip': title }, children),
+    Dropdown: ({ children }: any) => React.createElement('span', {}, children),
+    Menu: ({ children }: any) => React.createElement('menu', {}, children),
+  };
+});
+
+const antd = require('antd');
+antd.Menu.Item = ({ children }: any) => React.createElement('li', {}, children);
+antd.Menu.Divider = () => React.createElement('hr');
+
+import EnhancedTable from './index';
+
+describe('EnhancedTable row actions', () => {
+  it('renders inline text actions as icon-only buttons with the text in a tooltip', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(EnhancedTable, {
+        rowKey: 'id',
+        dataSource: [{ id: 1 }],
+        columns: [],
+        rowActions: () => ({
+          inline: [{ key: 'query', text: '查询' }],
+        }),
+      }),
+    );
+
+    expect(html).toContain('data-tooltip="查询"');
+    expect(html).toContain('data-icon="Search"');
+    expect(html).not.toContain('<button class="fc-table-action-inline-btn">查询</button>');
+  });
+});

--- a/src/components/EnhancedTable/index.tsx
+++ b/src/components/EnhancedTable/index.tsx
@@ -1,23 +1,9 @@
 import React from 'react';
 import { Table, Dropdown, Menu, Button, Tooltip } from 'antd';
 import type { TableProps, ColumnType, ColumnsType } from 'antd/lib/table';
-import {
-  CheckCircle,
-  Copy,
-  ExternalLink,
-  Eye,
-  Link as LinkIcon,
-  MoreVertical,
-  Network,
-  Pencil,
-  Play,
-  Search,
-  Settings,
-  ShieldCheck,
-  Sparkles,
-  Trash2,
-} from 'lucide-react';
+import { CheckCircle, Copy, ExternalLink, Eye, Link as LinkIcon, MoreVertical, Network, Pencil, Play, Plus, Search, Settings, ShieldCheck, Sparkles, Trash2 } from 'lucide-react';
 import classNames from 'classnames';
+import { getUpdateByColumnFilterProps } from './columns';
 import './style.less';
 
 const actionIconMap = {
@@ -30,6 +16,7 @@ const actionIconMap = {
   copy: Copy,
   delete: Trash2,
   run: Play,
+  create: Plus,
   search: Search,
   open: ExternalLink,
   link: LinkIcon,
@@ -44,6 +31,7 @@ export interface RowAction {
   icon?: ActionIconName;
   onClick?: (e: React.MouseEvent) => void;
   disabled?: boolean;
+  loading?: boolean;
   danger?: boolean;
   /** false to hide this action (e.g. by permission) */
   visible?: boolean;
@@ -111,21 +99,65 @@ export function getEnabledStatusColumn<ValueType extends EnabledStatusValue = En
 
 const visibleOnly = (list?: RowAction[]) => (list || []).filter((a) => a.visible !== false);
 
-function ActionButton({ action, className, withIcon }: { action: RowAction; className: string; withIcon?: boolean }) {
-  const Icon = withIcon && action.icon ? actionIconMap[action.icon] : undefined;
+const fallbackInlineIconMap: Record<string, ActionIconName> = {
+  query: 'search',
+  trace: 'search',
+  executions: 'view',
+  execRecord: 'view',
+  create: 'create',
+  config: 'settings',
+  execute: 'run',
+  exec: 'run',
+  fire: 'run',
+  'ai-inspection': 'ai',
+};
+
+function resolveActionIcon(action: RowAction, fallbackToKey = false) {
+  const iconName = action.icon ?? (fallbackToKey && action.key ? fallbackInlineIconMap[action.key] : undefined);
+  return iconName ? actionIconMap[iconName] : undefined;
+}
+
+function getInlineTooltipTitle(action: RowAction) {
+  if (!action.tooltip) return action.text;
+  if (!action.text) return action.tooltip;
+  return (
+    <>
+      {action.text}
+      <br />
+      {action.tooltip}
+    </>
+  );
+}
+
+function ActionButton({ action, className, withIcon, iconOnly }: { action: RowAction; className: string; withIcon?: boolean; iconOnly?: boolean }) {
+  const Icon = withIcon ? resolveActionIcon(action, iconOnly) : undefined;
   return (
     <Button
       type='link'
-      className={classNames(className, { 'is-danger': action.danger })}
+      className={classNames(className, { 'is-danger': action.danger, 'is-icon-only': iconOnly })}
       disabled={action.disabled}
+      loading={action.loading}
       icon={Icon ? <Icon className='fc-table-action-menu-icon' /> : undefined}
+      aria-label={typeof action.text === 'string' ? action.text : undefined}
       onClick={(e) => {
         e.stopPropagation();
         action.onClick?.(e);
       }}
     >
-      {action.text}
+      {iconOnly ? null : action.text}
     </Button>
+  );
+}
+
+function renderInlineAction(action: RowAction, key: string) {
+  if (action.node) {
+    return <React.Fragment key={key}>{action.node}</React.Fragment>;
+  }
+  const btn = <ActionButton action={action} className='fc-table-action-inline-btn' withIcon iconOnly />;
+  return (
+    <Tooltip key={key} title={getInlineTooltipTitle(action)}>
+      <span className='fc-table-action-inline-btn-wrap'>{btn}</span>
+    </Tooltip>
   );
 }
 
@@ -168,13 +200,7 @@ function RowActionCell({ actions }: { actions: RowActions }) {
 
   return (
     <div className='fc-table-action-cell'>
-      {inline.map((a, i) =>
-        a.node ? (
-          <React.Fragment key={a.key ?? `inline-${i}`}>{a.node}</React.Fragment>
-        ) : (
-          <ActionButton key={a.key ?? `inline-${i}`} action={a} className='fc-table-action-inline-btn' />
-        ),
-      )}
+      {inline.map((a, i) => renderInlineAction(a, a.key ?? `inline-${i}`))}
       {menu.length > 0 && (
         <Dropdown
           trigger={['click']}
@@ -188,16 +214,32 @@ function RowActionCell({ actions }: { actions: RowActions }) {
             </Menu>
           }
         >
-          <Button
-            type='text'
-            className='fc-table-action-trigger'
-            icon={<MoreVertical size={16} />}
-            onClick={(e) => e.stopPropagation()}
-          />
+          <Button type='text' className='fc-table-action-trigger' icon={<MoreVertical size={16} />} onClick={(e) => e.stopPropagation()} />
         </Dropdown>
       )}
     </div>
   );
+}
+
+function injectColumnFilters<RecordType extends object>(
+  columns: ColumnsType<RecordType> | undefined,
+  dataSource: readonly RecordType[] | undefined,
+): ColumnsType<RecordType> | undefined {
+  if (!columns) return columns;
+
+  return columns.map((column) => {
+    if ('children' in column && column.children) {
+      return {
+        ...column,
+        children: injectColumnFilters(column.children as ColumnsType<RecordType>, dataSource),
+      };
+    }
+
+    return {
+      ...column,
+      ...getUpdateByColumnFilterProps(column as ColumnType<RecordType>, dataSource),
+    };
+  }) as ColumnsType<RecordType>;
 }
 
 /**
@@ -206,9 +248,9 @@ function RowActionCell({ actions }: { actions: RowActions }) {
  * Visual baseline (sort/filter icons, fixed-column bg, …) lives in global theme/table.less.
  */
 export default function EnhancedTable<RecordType extends object = any>(props: EnhancedTableProps<RecordType>) {
-  const { rowActions, actionColumn, columns, className, ...rest } = props;
+  const { rowActions, actionColumn, columns, className, dataSource, ...rest } = props;
 
-  let finalColumns: ColumnsType<RecordType> | undefined = columns;
+  let finalColumns: ColumnsType<RecordType> | undefined = injectColumnFilters(columns, Array.isArray(dataSource) ? dataSource : undefined);
   if (rowActions) {
     const opColumn: ColumnType<RecordType> = {
       title: '操作',
@@ -221,8 +263,8 @@ export default function EnhancedTable<RecordType extends object = any>(props: En
         return cfg ? <RowActionCell actions={cfg} /> : null;
       },
     };
-    finalColumns = [...(columns || []), opColumn];
+    finalColumns = [...(finalColumns || []), opColumn];
   }
 
-  return <Table<RecordType> {...rest} columns={finalColumns} className={classNames('fc-enhanced-table', className)} />;
+  return <Table<RecordType> {...rest} dataSource={dataSource} columns={finalColumns} className={classNames('fc-enhanced-table', className)} />;
 }

--- a/src/components/EnhancedTable/index.tsx
+++ b/src/components/EnhancedTable/index.tsx
@@ -67,6 +67,48 @@ export interface EnhancedTableProps<RecordType> extends TableProps<RecordType> {
   actionColumn?: Partial<ColumnType<RecordType>>;
 }
 
+type EnabledStatusFilterValue = boolean | number | string;
+type EnabledStatusValue = EnabledStatusFilterValue | null | undefined;
+
+export interface EnabledStatusColumnOptions<ValueType extends EnabledStatusValue = EnabledStatusValue> {
+  title: React.ReactNode;
+  dataIndex: ColumnType<any>['dataIndex'];
+  enabledText: React.ReactNode;
+  disabledText: React.ReactNode;
+  enabledValue: EnabledStatusFilterValue;
+  disabledValue: EnabledStatusFilterValue;
+  getValue?: (record: any) => ValueType;
+  sorter?: ColumnType<any>['sorter'];
+  onFilter?: ColumnType<any>['onFilter'] | false;
+}
+
+function getColumnValue<ValueType extends EnabledStatusValue>(record: any, dataIndex: ColumnType<any>['dataIndex']): ValueType {
+  if (Array.isArray(dataIndex)) {
+    return dataIndex.reduce((current, key) => current?.[key], record) as ValueType;
+  }
+  return record[dataIndex as keyof typeof record] as ValueType;
+}
+
+export function getEnabledStatusColumn<ValueType extends EnabledStatusValue = EnabledStatusValue>(
+  options: EnabledStatusColumnOptions<ValueType>,
+): Pick<ColumnType<any>, 'title' | 'dataIndex' | 'width' | 'sorter' | 'filters' | 'onFilter'> {
+  const { title, dataIndex, enabledText, disabledText, enabledValue, disabledValue, getValue, sorter, onFilter } = options;
+  const readValue = (record: any) => (getValue ? getValue(record) : getColumnValue<ValueType>(record, dataIndex));
+  const rank = (value: ValueType) => (value === enabledValue ? 0 : value === disabledValue ? 1 : 2);
+
+  return {
+    title,
+    dataIndex,
+    width: 100,
+    sorter: sorter ?? ((a, b) => rank(readValue(a)) - rank(readValue(b))),
+    filters: [
+      { text: enabledText, value: enabledValue },
+      { text: disabledText, value: disabledValue },
+    ],
+    ...(onFilter === false ? {} : { onFilter: onFilter ?? ((value, record) => readValue(record) === value) }),
+  };
+}
+
 const visibleOnly = (list?: RowAction[]) => (list || []).filter((a) => a.visible !== false);
 
 function ActionButton({ action, className, withIcon }: { action: RowAction; className: string; withIcon?: boolean }) {

--- a/src/components/EnhancedTable/style.less
+++ b/src/components/EnhancedTable/style.less
@@ -7,14 +7,29 @@
   gap: 4px;
 }
 
-// inline action: text link
+.fc-table-action-inline-btn-wrap {
+  display: inline-flex;
+}
+
+// inline action: icon button
 .fc-table-action-inline-btn.ant-btn {
-  height: 24px;
-  padding: 0 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
   border-radius: 6px;
   color: var(--fc-violet-11);
   font-size: inherit;
-  line-height: 22px;
+  line-height: 1;
+
+  .fc-table-action-menu-icon {
+    width: 16px;
+    height: 16px;
+    margin: 0;
+    stroke-width: 2;
+  }
 
   &:hover,
   &:focus {

--- a/src/pages/aiConfig/agents/pages/List.tsx
+++ b/src/pages/aiConfig/agents/pages/List.tsx
@@ -5,7 +5,7 @@ import { useRequest } from 'ahooks';
 
 import PageLayout from '@/components/pageLayout';
 import usePagination from '@/components/usePagination';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import EllipsisText from '@/components/EllipsisText';
 
 import { NS } from '../constants';
@@ -78,14 +78,15 @@ export default function List() {
                     title: t('use_case'),
                   },
                   {
-                    dataIndex: 'enabled',
-                    title: t('enabled'),
-                    sorter: (a, b) => Number(a.enabled) - Number(b.enabled),
-                    filters: [
-                      { text: t('enabled'), value: true },
-                      { text: t('disabled'), value: false },
-                    ],
-                    onFilter: (value, record) => record.enabled === value,
+                    ...getEnabledStatusColumn({
+                      title: t('enabled'),
+                      dataIndex: 'enabled',
+                      enabledText: t('enabled'),
+                      disabledText: t('disabled'),
+                      enabledValue: true,
+                      disabledValue: false,
+                    }),
+
                     render: (val, record) => {
                       return (
                         <Switch

--- a/src/pages/aiConfig/llmConfigs/pages/List.tsx
+++ b/src/pages/aiConfig/llmConfigs/pages/List.tsx
@@ -6,7 +6,7 @@ import { useRequest } from 'ahooks';
 
 import PageLayout from '@/components/pageLayout';
 import usePagination from '@/components/usePagination';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import EllipsisText from '@/components/EllipsisText';
 
 import { NS } from '../constants';
@@ -103,14 +103,15 @@ export default function List() {
                     title: t('model'),
                   },
                   {
-                    dataIndex: 'enabled',
-                    title: t('enabled'),
-                    sorter: (a, b) => Number(a.enabled) - Number(b.enabled),
-                    filters: [
-                      { text: t('enabled'), value: true },
-                      { text: t('disabled'), value: false },
-                    ],
-                    onFilter: (value, record) => record.enabled === value,
+                    ...getEnabledStatusColumn({
+                      title: t('enabled'),
+                      dataIndex: 'enabled',
+                      enabledText: t('enabled'),
+                      disabledText: t('disabled'),
+                      enabledValue: true,
+                      disabledValue: false,
+                    }),
+
                     render: (val, record) => (
                       <Switch
                         size='small'

--- a/src/pages/aiConfig/mcpServers/pages/List.tsx
+++ b/src/pages/aiConfig/mcpServers/pages/List.tsx
@@ -6,7 +6,7 @@ import { useRequest } from 'ahooks';
 
 import PageLayout from '@/components/pageLayout';
 import usePagination from '@/components/usePagination';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import EllipsisText from '@/components/EllipsisText';
 
 import { NS } from '../constants';
@@ -88,14 +88,15 @@ export default function List() {
                     title: t('url'),
                   },
                   {
-                    dataIndex: 'enabled',
-                    title: t('enabled'),
-                    sorter: (a, b) => Number(a.enabled) - Number(b.enabled),
-                    filters: [
-                      { text: t('enabled'), value: true },
-                      { text: t('disabled'), value: false },
-                    ],
-                    onFilter: (value, record) => record.enabled === value,
+                    ...getEnabledStatusColumn({
+                      title: t('enabled'),
+                      dataIndex: 'enabled',
+                      enabledText: t('enabled'),
+                      disabledText: t('disabled'),
+                      enabledValue: true,
+                      disabledValue: false,
+                    }),
+
                     render: (val, record) => (
                       <Switch
                         size='small'

--- a/src/pages/alertRules/List/ListNG.tsx
+++ b/src/pages/alertRules/List/ListNG.tsx
@@ -17,7 +17,7 @@ import DatasourceSelect from '@/components/DatasourceSelect/DatasourceSelect';
 import OrganizeColumns, { getDefaultColumnsConfigs, setDefaultColumnsConfigs, ajustColumns } from '@/components/OrganizeColumns';
 import usePagination from '@/components/usePagination';
 import Tags from '@/components/TableTags/Tags';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { dateColumn, userColumn } from '@/components/EnhancedTable/columns';
 import localeCompare from '@/pages/dashboard/Renderer/utils/localeCompare';
 import { getItems as getNotificationRules, RuleItem as NotificationRuleItem } from '@/pages/notificationRules/services';
@@ -251,14 +251,15 @@ export default function AlertRules(props: Props) {
     readonly
       ? [
           {
-            title: t('table.disabled'),
-            dataIndex: 'disabled',
-            sorter: (a, b) => a.disabled - b.disabled,
-            filters: [
-              { text: t('filter_disabled.0'), value: 0 },
-              { text: t('filter_disabled.1'), value: 1 },
-            ],
-            onFilter: (value, record) => record.disabled === value,
+            ...getEnabledStatusColumn({
+              title: t('table.disabled'),
+              dataIndex: 'disabled',
+              enabledText: t('filter_disabled.0'),
+              disabledText: t('filter_disabled.1'),
+              enabledValue: 0,
+              disabledValue: 1,
+            }),
+
             render: (status) => {
               return (
                 <Tag className='mr-0' color={status === AlertRuleStatus.Enable ? 'success' : 'error'}>
@@ -270,14 +271,15 @@ export default function AlertRules(props: Props) {
         ]
       : ([
           {
-            title: t('table.disabled'),
-            dataIndex: 'disabled',
-            sorter: (a, b) => a.disabled - b.disabled,
-            filters: [
-              { text: t('filter_disabled.0'), value: 0 },
-              { text: t('filter_disabled.1'), value: 1 },
-            ],
-            onFilter: (value, record) => record.disabled === value,
+            ...getEnabledStatusColumn({
+              title: t('table.disabled'),
+              dataIndex: 'disabled',
+              enabledText: t('filter_disabled.0'),
+              disabledText: t('filter_disabled.1'),
+              enabledValue: 0,
+              disabledValue: 1,
+            }),
+
             render: (disabled, record) => (
               <Switch
                 checked={disabled === AlertRuleStatus.Enable}

--- a/src/pages/builtInComponents/AlertRules/index.tsx
+++ b/src/pages/builtInComponents/AlertRules/index.tsx
@@ -11,7 +11,7 @@ import AuthorizationWrapper, { useIsAuthorized } from '@/components/Authorizatio
 import { CommonStateContext } from '@/App';
 import { HelpLink } from '@/components/pageLayout';
 import EnhancedTable from '@/components/EnhancedTable';
-import { tagsColumn } from '@/components/EnhancedTable/columns';
+import { tagsColumn, updateByColumn } from '@/components/EnhancedTable/columns';
 import Tags from '@/components/TableTags/Tags';
 import { RuleType } from './types';
 import Import from './Import';
@@ -224,7 +224,7 @@ export default function index(props: Props) {
               );
             },
           }),
-          {
+          updateByColumn({
             title: t('common:table.update_by'),
             dataIndex: 'updated_by',
             key: 'updated_by',
@@ -235,7 +235,7 @@ export default function index(props: Props) {
               }
               return value;
             },
-          },
+          }),
         ]}
         pagination={pagination}
         rowActions={(record) => ({

--- a/src/pages/builtInComponents/CollectTpls/index.tsx
+++ b/src/pages/builtInComponents/CollectTpls/index.tsx
@@ -7,6 +7,7 @@ import { useDebounceEffect } from 'ahooks';
 import { CommonStateContext } from '@/App';
 import usePagination from '@/components/usePagination';
 import EnhancedTable from '@/components/EnhancedTable';
+import { updateByColumn } from '@/components/EnhancedTable/columns';
 import AuthorizationWrapper from '@/components/AuthorizationWrapper';
 import { HelpLink } from '@/components/pageLayout';
 import { getPayloads, deletePayloads, getCates } from '../services';
@@ -140,7 +141,7 @@ export default function index(props: Props) {
             dataIndex: 'name',
             key: 'name',
           },
-          {
+          updateByColumn({
             title: t('common:table.update_by'),
             dataIndex: 'updated_by',
             key: 'updated_by',
@@ -151,7 +152,7 @@ export default function index(props: Props) {
               }
               return value;
             },
-          },
+          }),
         ]}
         pagination={pagination}
         rowActions={(record: any) => ({

--- a/src/pages/builtInComponents/Dashboards/index.tsx
+++ b/src/pages/builtInComponents/Dashboards/index.tsx
@@ -11,7 +11,7 @@ import Export from '@/pages/dashboard/List/Export';
 import AuthorizationWrapper from '@/components/AuthorizationWrapper';
 import { HelpLink } from '@/components/pageLayout';
 import EnhancedTable from '@/components/EnhancedTable';
-import { tagsColumn } from '@/components/EnhancedTable/columns';
+import { tagsColumn, updateByColumn } from '@/components/EnhancedTable/columns';
 import EllipsisText from '@/components/EllipsisText';
 import Tags from '@/components/TableTags/Tags';
 import { getPayloads, deletePayloads } from '../services';
@@ -250,7 +250,7 @@ export default function index(props: Props) {
             ellipsis: { showTitle: false },
             render: (val) => <EllipsisText text={val} />,
           },
-          {
+          updateByColumn({
             title: t('common:table.update_by'),
             dataIndex: 'updated_by',
             key: 'updated_by',
@@ -261,7 +261,7 @@ export default function index(props: Props) {
               }
               return value;
             },
-          },
+          }),
         ]}
         pagination={pagination}
       />

--- a/src/pages/builtInComponents/Metrics/index.tsx
+++ b/src/pages/builtInComponents/Metrics/index.tsx
@@ -24,6 +24,7 @@ import { Copy, Pencil } from 'lucide-react';
 import { ColumnType } from 'antd/lib/table';
 import usePagination from '@/components/usePagination';
 import EnhancedTable from '@/components/EnhancedTable';
+import { updateByColumn } from '@/components/EnhancedTable/columns';
 import EllipsisText from '@/components/EllipsisText';
 import RefreshIcon from '@/components/RefreshIcon';
 import OrganizeColumns, { getDefaultColumnsConfigs, setDefaultColumnsConfigs, ajustColumns } from '@/components/OrganizeColumns';
@@ -132,10 +133,11 @@ export default function index(props: Props) {
       ellipsis: { showTitle: false },
       render: (val) => <EllipsisText text={val} />,
     },
-    {
+    updateByColumn({
       title: t('common:table.update_by'),
       dataIndex: 'updated_by',
       key: 'updated_by',
+      filterMode: 'none',
       render: (value) => {
         if (!value) return '-';
         if (value === 'system') {
@@ -143,7 +145,7 @@ export default function index(props: Props) {
         }
         return value;
       },
-    },
+    }),
   ];
 
   const { run: queryChange } = useDebounceFn(

--- a/src/pages/contacts/pages/List.tsx
+++ b/src/pages/contacts/pages/List.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
 
 import PageLayout, { HelpLink } from '@/components/pageLayout';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 
 import { getNotifyContacts, putNotifyContacts } from '../services';
 import { ContactType } from '../types';
@@ -65,15 +65,16 @@ export default function Channels() {
                 key: 'ident',
               },
               {
-                title: t('common:table.enabled'),
-                dataIndex: 'hide',
+                ...getEnabledStatusColumn({
+                  title: t('common:table.enabled'),
+                  dataIndex: 'hide',
+                  enabledText: t('common:table.enabled'),
+                  disabledText: t('disabled'),
+                  enabledValue: false,
+                  disabledValue: true,
+                }),
                 key: 'hide',
-                sorter: (a, b) => Number(a.hide) - Number(b.hide),
-                filters: [
-                  { text: t('common:table.enabled'), value: false },
-                  { text: t('disabled'), value: true },
-                ],
-                onFilter: (value, record) => record.hide === value,
+
                 render: (val: boolean, record) => {
                   return (
                     <Switch

--- a/src/pages/datasource/components/TableSource/index.tsx
+++ b/src/pages/datasource/components/TableSource/index.tsx
@@ -6,7 +6,7 @@ import { ColumnProps } from 'antd/es/table';
 import { CheckCircleFilled, MinusCircleFilled, WarningOutlined } from '@ant-design/icons';
 import { CommonStateContext } from '@/App';
 import usePagination from '@/components/usePagination';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { allCates } from '@/components/AdvancedWrap/utils';
 import localeCompare from '@/pages/dashboard/Renderer/utils/localeCompare';
 
@@ -156,21 +156,15 @@ const TableSource = (props: IPropsType) => {
       },
     },
     {
-      title: t('status.title'),
+      ...getEnabledStatusColumn({
+        title: t('status.title'),
+        dataIndex: 'status',
+        enabledText: t('status.enabled'),
+        disabledText: t('status.disabled'),
+        enabledValue: 'enabled',
+        disabledValue: 'disabled',
+      }),
       width: 300,
-      dataIndex: 'status',
-      sorter: (a, b) => localeCompare(a.status, b.status),
-      filters: [
-        {
-          text: t('status.enabled'),
-          value: 'enabled',
-        },
-        {
-          text: t('status.disabled'),
-          value: 'disabled',
-        },
-      ],
-      onFilter: (value: string, record) => record.status === value,
       render: (text) => {
         return text === 'enabled' ? (
           <>

--- a/src/pages/embeddedProduct/pages/List/index.tsx
+++ b/src/pages/embeddedProduct/pages/List/index.tsx
@@ -12,6 +12,7 @@ import { arrayMoveImmutable } from 'array-move';
 import { getTeamInfoList } from '@/services/manage';
 import PageLayout from '@/components/pageLayout';
 import EnhancedTable from '@/components/EnhancedTable';
+import { updateByColumn } from '@/components/EnhancedTable/columns';
 import Tags from '@/components/TableTags/Tags';
 import { eventBus, EVENT_KEYS } from '@/pages/embeddedProduct/eventBus';
 
@@ -75,10 +76,10 @@ export default function Index() {
           return !val ? t('common:public') : t('common:private');
         },
       },
-      {
+      updateByColumn({
         title: <span style={{ whiteSpace: 'nowrap' }}>{t('common:table.update_by')}</span>,
         dataIndex: 'update_by',
-      },
+      }),
       {
         title: t('common:table.update_at'),
         dataIndex: 'update_at',

--- a/src/pages/eventPipeline/pages/List/index.tsx
+++ b/src/pages/eventPipeline/pages/List/index.tsx
@@ -8,7 +8,7 @@ import _ from 'lodash';
 import usePagination from '@/components/usePagination';
 import Tags from '@/components/TableTags/Tags';
 import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
-import { tagsColumn, userColumn, dateColumn } from '@/components/EnhancedTable/columns';
+import { tagsColumn, updateByColumn, dateColumn } from '@/components/EnhancedTable/columns';
 import EllipsisText from '@/components/EllipsisText';
 
 import { NS } from '../../constants';
@@ -69,6 +69,31 @@ export default function List() {
   useEffect(() => {
     featchData();
   }, []);
+
+  const filteredData = _.filter(data.list, (item) => {
+    let pass = true;
+    if (filter?.search) {
+      if (!_.includes(item.name, filter.search)) {
+        pass = false;
+      }
+    }
+    if (filter?.use_case) {
+      if (item.use_case !== filter.use_case) {
+        pass = false;
+      }
+    }
+    if (filter?.trigger_mode) {
+      if (item.trigger_mode !== filter.trigger_mode) {
+        pass = false;
+      }
+    }
+    if (filter?.disabled !== undefined) {
+      if (item.disabled !== filter.disabled) {
+        pass = false;
+      }
+    }
+    return pass;
+  });
 
   return (
     <>
@@ -222,33 +247,10 @@ export default function List() {
             },
           },
           tagsColumn({ title: t('teams'), dataIndex: 'team_names', maxWidth: 180 }),
-          userColumn({ title: t('common:table.update_by'), dataIndex: 'update_by', nickname: 'update_by_nickname' }),
+          updateByColumn({ title: t('common:table.update_by'), dataIndex: 'update_by', nickname: 'update_by_nickname' }),
           dateColumn({ title: t('common:table.update_at'), dataIndex: 'update_at', unix: true }),
         ]}
-        dataSource={_.filter(data.list, (item) => {
-          let pass = true;
-          if (filter?.search) {
-            if (!_.includes(item.name, filter.search)) {
-              pass = false;
-            }
-          }
-          if (filter?.use_case) {
-            if (item.use_case !== filter.use_case) {
-              pass = false;
-            }
-          }
-          if (filter?.trigger_mode) {
-            if (item.trigger_mode !== filter.trigger_mode) {
-              pass = false;
-            }
-          }
-          if (filter?.disabled !== undefined) {
-            if (item.disabled !== filter.disabled) {
-              pass = false;
-            }
-          }
-          return pass;
-        })}
+        dataSource={filteredData}
         loading={data.loading}
         pagination={pagination}
         rowSelection={{

--- a/src/pages/eventPipeline/pages/List/index.tsx
+++ b/src/pages/eventPipeline/pages/List/index.tsx
@@ -7,7 +7,7 @@ import _ from 'lodash';
 
 import usePagination from '@/components/usePagination';
 import Tags from '@/components/TableTags/Tags';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { tagsColumn, userColumn, dateColumn } from '@/components/EnhancedTable/columns';
 import EllipsisText from '@/components/EllipsisText';
 
@@ -199,16 +199,17 @@ export default function List() {
             },
           },
           {
-            title: t('disabled.label'),
-            dataIndex: 'disabled',
+            ...getEnabledStatusColumn({
+              title: t('disabled.label'),
+              dataIndex: 'disabled',
+              enabledText: t('disabled.false'),
+              disabledText: t('disabled.true'),
+              enabledValue: false,
+              disabledValue: true,
+            }),
             key: 'disabled',
             width: 100,
-            sorter: (a, b) => Number(a.disabled) - Number(b.disabled),
-            filters: [
-              { text: t('disabled.false'), value: false },
-              { text: t('disabled.true'), value: true },
-            ],
-            onFilter: (value, record) => record.disabled === value,
+
             render: (value) => {
               return (
                 <Tags

--- a/src/pages/help/NotificationSettings/Channels/index.tsx
+++ b/src/pages/help/NotificationSettings/Channels/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Switch, Space, Button, Modal, message } from 'antd';
 import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import DocumentDrawer from '@/components/DocumentDrawer';
 import { getNotifyChannels, putNotifyChannels } from '../services';
 import { ChannelType } from '../types';
@@ -75,15 +75,16 @@ export default function Channels() {
             key: 'ident',
           },
           {
-            title: t('channels.enabled'),
-            dataIndex: 'hide',
+            ...getEnabledStatusColumn({
+              title: t('channels.enabled'),
+              dataIndex: 'hide',
+              enabledText: t('channels.enabled'),
+              disabledText: t('disabled'),
+              enabledValue: false,
+              disabledValue: true,
+            }),
             key: 'hide',
-            sorter: (a, b) => Number(a.hide) - Number(b.hide),
-            filters: [
-              { text: t('channels.enabled'), value: false },
-              { text: t('disabled'), value: true },
-            ],
-            onFilter: (value, record) => record.hide === value,
+
             render: (val: boolean, record) => {
               return (
                 <Switch

--- a/src/pages/help/NotificationSettings/Contacts/index.tsx
+++ b/src/pages/help/NotificationSettings/Contacts/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Switch, Space, Button, Modal, message } from 'antd';
 import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import DocumentDrawer from '@/components/DocumentDrawer';
 import { getNotifyContacts, putNotifyContacts } from '../services';
 import { ContactType } from '../types';
@@ -75,15 +75,16 @@ export default function Channels() {
             key: 'ident',
           },
           {
-            title: t('channels.enabled'),
-            dataIndex: 'hide',
+            ...getEnabledStatusColumn({
+              title: t('channels.enabled'),
+              dataIndex: 'hide',
+              enabledText: t('channels.enabled'),
+              disabledText: t('disabled'),
+              enabledValue: false,
+              disabledValue: true,
+            }),
             key: 'hide',
-            sorter: (a, b) => Number(a.hide) - Number(b.hide),
-            filters: [
-              { text: t('channels.enabled'), value: false },
-              { text: t('disabled'), value: true },
-            ],
-            onFilter: (value, record) => record.hide === value,
+
             render: (val: boolean, record) => {
               return (
                 <Switch

--- a/src/pages/metricsBuiltin/List.tsx
+++ b/src/pages/metricsBuiltin/List.tsx
@@ -27,6 +27,7 @@ import Markdown from '@/components/Markdown';
 import PageLayout from '@/components/pageLayout';
 import usePagination from '@/components/usePagination';
 import EnhancedTable from '@/components/EnhancedTable';
+import { updateByColumn } from '@/components/EnhancedTable/columns';
 import EllipsisText from '@/components/EllipsisText';
 import Tags from '@/components/TableTags/Tags';
 import RefreshIcon from '@/components/RefreshIcon';
@@ -244,10 +245,11 @@ export default function index() {
         return <EllipsisText text={value} />;
       },
     },
-    {
+    updateByColumn({
       title: t('common:table.update_by'),
       dataIndex: 'updated_by',
       key: 'updated_by',
+      filterMode: 'none',
       render: (value) => {
         if (!value) return '-';
         if (value === 'system') {
@@ -255,7 +257,7 @@ export default function index() {
         }
         return value;
       },
-    },
+    }),
   ];
 
   const { run: queryChange } = useDebounceFn(

--- a/src/pages/notificationChannels/pages/List/index.tsx
+++ b/src/pages/notificationChannels/pages/List/index.tsx
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom';
 import usePagination from '@/components/usePagination';
 import PageLayout from '@/components/pageLayout';
 import { Import, Export } from '@/components/ExportImport';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 
 import { getItems, putItem, deleteItems, postItems } from '../../services';
 import { NS } from '../../constants';
@@ -153,15 +153,15 @@ export default function List() {
               },
             },
             {
-              title: t('common:table.enabled'),
+              ...getEnabledStatusColumn({
+                title: t('common:table.enabled'),
+                dataIndex: 'enable',
+                enabledText: t('common:table.enabled'),
+                disabledText: t('disabled'),
+                enabledValue: true,
+                disabledValue: false,
+              }),
               width: 100,
-              dataIndex: 'enable',
-              sorter: (a, b) => Number(a.enable) - Number(b.enable),
-              filters: [
-                { text: t('common:table.enabled'), value: true },
-                { text: t('disabled'), value: false },
-              ],
-              onFilter: (value, record) => record.enable === value,
               render: (val, record) => (
                 <Switch
                   checked={val}

--- a/src/pages/notificationChannels/pages/List/index.tsx
+++ b/src/pages/notificationChannels/pages/List/index.tsx
@@ -10,6 +10,7 @@ import usePagination from '@/components/usePagination';
 import PageLayout from '@/components/pageLayout';
 import { Import, Export } from '@/components/ExportImport';
 import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
+import { updateByColumn } from '@/components/EnhancedTable/columns';
 
 import { getItems, putItem, deleteItems, postItems } from '../../services';
 import { NS } from '../../constants';
@@ -141,10 +142,10 @@ export default function List() {
                 );
               },
             },
-            {
+            updateByColumn({
               title: t('common:table.update_by'),
               dataIndex: 'update_by',
-            },
+            }),
             {
               title: t('common:table.update_at'),
               dataIndex: 'update_at',

--- a/src/pages/notificationChannels/pages/ListNG/index.tsx
+++ b/src/pages/notificationChannels/pages/ListNG/index.tsx
@@ -10,7 +10,7 @@ import moment from 'moment';
 import usePagination from '@/components/usePagination';
 import PageLayout from '@/components/pageLayout';
 import { Import, Export } from '@/components/ExportImport';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 
 import { NS, NOTIFICATION_CHANNEL_TYPES } from '../../constants';
 import { getItems, putItem, deleteItems, postItems } from '../../services';
@@ -270,15 +270,15 @@ export default function index() {
                     },
                   },
                   {
-                    title: t('common:table.enabled'),
+                    ...getEnabledStatusColumn({
+                      title: t('common:table.enabled'),
+                      dataIndex: 'enable',
+                      enabledText: t('common:table.enabled'),
+                      disabledText: t('disabled'),
+                      enabledValue: true,
+                      disabledValue: false,
+                    }),
                     width: 100,
-                    dataIndex: 'enable',
-                    sorter: (a, b) => Number(a.enable) - Number(b.enable),
-                    filters: [
-                      { text: t('common:table.enabled'), value: true },
-                      { text: t('disabled'), value: false },
-                    ],
-                    onFilter: (value, record) => record.enable === value,
                     render: (val, record) => (
                       <Switch
                         checked={val}

--- a/src/pages/notificationChannels/pages/ListNG/index.tsx
+++ b/src/pages/notificationChannels/pages/ListNG/index.tsx
@@ -11,6 +11,7 @@ import usePagination from '@/components/usePagination';
 import PageLayout from '@/components/pageLayout';
 import { Import, Export } from '@/components/ExportImport';
 import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
+import { updateByColumn } from '@/components/EnhancedTable/columns';
 
 import { NS, NOTIFICATION_CHANNEL_TYPES } from '../../constants';
 import { getItems, putItem, deleteItems, postItems } from '../../services';
@@ -258,10 +259,10 @@ export default function index() {
                       );
                     },
                   },
-                  {
+                  updateByColumn({
                     title: t('common:table.update_by'),
                     dataIndex: 'update_by',
-                  },
+                  }),
                   {
                     title: t('common:table.update_at'),
                     dataIndex: 'update_at',

--- a/src/pages/notificationRules/pages/List.tsx
+++ b/src/pages/notificationRules/pages/List.tsx
@@ -7,7 +7,7 @@ import { Link, useHistory } from 'react-router-dom';
 
 import { IS_PLUS } from '@/utils/constant';
 import PageLayout from '@/components/pageLayout';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { userColumn, dateColumn } from '@/components/EnhancedTable/columns';
 import Tags from '@/components/TableTags/Tags';
 import { getSimplifiedItems as getNotificationChannels } from '@/pages/notificationChannels/services';
@@ -179,15 +179,15 @@ export default function List() {
             userColumn({ title: t('common:table.update_by'), dataIndex: 'update_by', nickname: 'update_by_nickname' }),
             dateColumn({ title: t('common:table.update_at'), dataIndex: 'update_at', unix: true }),
             {
-              title: t('common:table.enabled'),
+              ...getEnabledStatusColumn({
+                title: t('common:table.enabled'),
+                dataIndex: 'enable',
+                enabledText: t('common:table.enabled'),
+                disabledText: t('disabled'),
+                enabledValue: true,
+                disabledValue: false,
+              }),
               width: 100,
-              dataIndex: 'enable',
-              sorter: (a, b) => Number(a.enable) - Number(b.enable),
-              filters: [
-                { text: t('common:table.enabled'), value: true },
-                { text: t('disabled'), value: false },
-              ],
-              onFilter: (value, record) => record.enable === value,
               render: (val, record) => (
                 <Switch
                   checked={val}

--- a/src/pages/notificationRules/pages/List.tsx
+++ b/src/pages/notificationRules/pages/List.tsx
@@ -8,7 +8,7 @@ import { Link, useHistory } from 'react-router-dom';
 import { IS_PLUS } from '@/utils/constant';
 import PageLayout from '@/components/pageLayout';
 import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
-import { userColumn, dateColumn } from '@/components/EnhancedTable/columns';
+import { updateByColumn, dateColumn } from '@/components/EnhancedTable/columns';
 import Tags from '@/components/TableTags/Tags';
 import { getSimplifiedItems as getNotificationChannels } from '@/pages/notificationChannels/services';
 import { getTeamInfoList } from '@/services/manage';
@@ -176,7 +176,7 @@ export default function List() {
                 );
               },
             },
-            userColumn({ title: t('common:table.update_by'), dataIndex: 'update_by', nickname: 'update_by_nickname' }),
+            updateByColumn({ title: t('common:table.update_by'), dataIndex: 'update_by', nickname: 'update_by_nickname' }),
             dateColumn({ title: t('common:table.update_at'), dataIndex: 'update_at', unix: true }),
             {
               ...getEnabledStatusColumn({

--- a/src/pages/recordingRules/PageTable.tsx
+++ b/src/pages/recordingRules/PageTable.tsx
@@ -12,7 +12,7 @@ import { strategyItem, strategyStatus } from '@/store/warningInterface';
 import { deleteRecordingRule } from '@/services/recording';
 import { CommonStateContext } from '@/App';
 import localeCompare from '@/pages/dashboard/Renderer/utils/localeCompare';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { tagsColumn, dateColumn } from '@/components/EnhancedTable/columns';
 import Tags from '@/components/TableTags/Tags';
 import EditModal from './components/editModal';
@@ -175,14 +175,15 @@ const PageTable: React.FC<Props> = ({ gids }) => {
       },
     }),
     {
-      title: t('disabled'),
-      dataIndex: 'disabled',
-      sorter: (a, b) => a.disabled - b.disabled,
-      filters: [
-        { text: t('filter_disabled.0'), value: 0 },
-        { text: t('filter_disabled.1'), value: 1 },
-      ],
-      onFilter: (value, record) => record.disabled === value,
+      ...getEnabledStatusColumn({
+        title: t('disabled'),
+        dataIndex: 'disabled',
+        enabledText: t('filter_disabled.0'),
+        disabledText: t('filter_disabled.1'),
+        enabledValue: 0,
+        disabledValue: 1,
+      }),
+
       render: (disabled, record) => (
         <Switch
           checked={disabled === strategyStatus.Enable}

--- a/src/pages/warning/shield/index.tsx
+++ b/src/pages/warning/shield/index.tsx
@@ -24,7 +24,7 @@ import { useTranslation } from 'react-i18next';
 import { useHistory, Link } from 'react-router-dom';
 
 import Tags from '@/components/TableTags/Tags';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { dateColumn } from '@/components/EnhancedTable/columns';
 import PageLayout from '@/components/pageLayout';
 import { getBusiGroupsAlertMutes, deleteShields, updateShields } from '@/services/shield';
@@ -237,14 +237,15 @@ const Shield: React.FC = () => {
         dataIndex: 'update_by',
       },
       {
-        title: t('common:table.enabled'),
-        dataIndex: 'disabled',
-        sorter: (a, b) => a.disabled - b.disabled,
-        filters: [
-          { text: t('filter_disabled.0'), value: 0 },
-          { text: t('filter_disabled.1'), value: 1 },
-        ],
-        onFilter: (value, record) => record.disabled === value,
+        ...getEnabledStatusColumn({
+          title: t('common:table.enabled'),
+          dataIndex: 'disabled',
+          enabledText: t('filter_disabled.0'),
+          disabledText: t('filter_disabled.1'),
+          enabledValue: 0,
+          disabledValue: 1,
+        }),
+
         render: (disabled, record) => (
           <Switch
             checked={disabled === strategyStatus.Enable}

--- a/src/pages/warning/shield/index.tsx
+++ b/src/pages/warning/shield/index.tsx
@@ -25,7 +25,7 @@ import { useHistory, Link } from 'react-router-dom';
 
 import Tags from '@/components/TableTags/Tags';
 import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
-import { dateColumn } from '@/components/EnhancedTable/columns';
+import { dateColumn, updateByColumn } from '@/components/EnhancedTable/columns';
 import PageLayout from '@/components/pageLayout';
 import { getBusiGroupsAlertMutes, deleteShields, updateShields } from '@/services/shield';
 import { shieldItem, strategyStatus } from '@/store/warningInterface';
@@ -232,10 +232,10 @@ const Shield: React.FC = () => {
         },
       },
       dateColumn({ title: t('common:table.update_at'), dataIndex: 'update_at', unix: true }),
-      {
+      updateByColumn({
         title: t('common:table.update_by'),
         dataIndex: 'update_by',
-      },
+      }),
       {
         ...getEnabledStatusColumn({
           title: t('common:table.enabled'),

--- a/src/pages/warning/subscribe/ListNG.tsx
+++ b/src/pages/warning/subscribe/ListNG.tsx
@@ -15,7 +15,7 @@ import { DatasourceSelect } from '@/components/DatasourceSelect';
 import { strategyStatus } from '@/store/warningInterface';
 import Tags from '@/components/TableTags/Tags';
 import { allCates, getCateDisplayLabel } from '@/components/AdvancedWrap/utils';
-import EnhancedTable from '@/components/EnhancedTable';
+import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { userColumn } from '@/components/EnhancedTable/columns';
 import OrganizeColumns, { getDefaultColumnsConfigs, setDefaultColumnsConfigs, ajustColumns } from '@/components/OrganizeColumns';
 import usePagination from '@/components/usePagination';
@@ -227,14 +227,15 @@ const Subscribe = (props: Props) => {
     readonly
       ? [
           {
-            title: t('common:table.enabled'),
-            dataIndex: 'disabled',
-            sorter: (a, b) => a.disabled - b.disabled,
-            filters: [
-              { text: t('filter_disabled.0'), value: 0 },
-              { text: t('filter_disabled.1'), value: 1 },
-            ],
-            onFilter: (value, record) => record.disabled === value,
+            ...getEnabledStatusColumn({
+              title: t('common:table.enabled'),
+              dataIndex: 'disabled',
+              enabledText: t('filter_disabled.0'),
+              disabledText: t('filter_disabled.1'),
+              enabledValue: 0,
+              disabledValue: 1,
+            }),
+
             render: (status) => {
               return (
                 <Tag className='mr-0' color={status === strategyStatus.Enable ? 'success' : 'error'}>
@@ -246,14 +247,15 @@ const Subscribe = (props: Props) => {
         ]
       : [
           {
-            title: t('common:table.enabled'),
-            dataIndex: 'disabled',
-            sorter: (a, b) => a.disabled - b.disabled,
-            filters: [
-              { text: t('filter_disabled.0'), value: 0 },
-              { text: t('filter_disabled.1'), value: 1 },
-            ],
-            onFilter: (value, record) => record.disabled === value,
+            ...getEnabledStatusColumn({
+              title: t('common:table.enabled'),
+              dataIndex: 'disabled',
+              enabledText: t('filter_disabled.0'),
+              disabledText: t('filter_disabled.1'),
+              enabledValue: 0,
+              disabledValue: 1,
+            }),
+
             render: (disabled, record: any) => (
               <Switch
                 checked={disabled === strategyStatus.Enable}

--- a/src/pages/warning/subscribe/components/ruleModal.tsx
+++ b/src/pages/warning/subscribe/components/ruleModal.tsx
@@ -18,6 +18,7 @@ import React, { useState, useEffect, useCallback, useContext } from 'react';
 import { Input, Table, Switch, Tag, Select, Modal, Space, Button } from 'antd';
 import { SearchOutlined } from '@ant-design/icons';
 import { Link } from 'react-router-dom';
+import { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { useTranslation } from 'react-i18next';
 import { ColumnType } from 'antd/lib/table';
 import moment from 'moment';
@@ -222,14 +223,15 @@ const ruleModal: React.FC<props> = (props) => {
       },
     },
     {
-      title: t('common:table.enabled'),
-      dataIndex: 'disabled',
-      sorter: (a, b) => a.disabled - b.disabled,
-      filters: [
-        { text: t('filter_disabled.0'), value: 0 },
-        { text: t('filter_disabled.1'), value: 1 },
-      ],
-      onFilter: (value, record) => record.disabled === value,
+      ...getEnabledStatusColumn({
+        title: t('common:table.enabled'),
+        dataIndex: 'disabled',
+        enabledText: t('filter_disabled.0'),
+        disabledText: t('filter_disabled.1'),
+        enabledValue: 0,
+        disabledValue: 1,
+      }),
+
       render: (disabled, record) => (
         <Switch
           checked={disabled === strategyStatus.Enable}


### PR DESCRIPTION
## Summary
- add updateByColumn metadata helper and inject update-by filters inside EnhancedTable from table dataSource
- migrate FE enhanced table 更新人 columns to the helper, with unsupported server-paginated cases hidden via filterMode none
- keep existing inline action icon changes and add EnhancedTable helper/action tests

## Verification
- npm test -- columns.test.ts --runInBand
- npm test -- columns.test.ts index.test.ts --runInBand
- npx tsc --noEmit --pretty false