### PR TITLE
feat: render inline table actions as icons

### DIFF
--- a/src/components/EnhancedTable/index.test.ts
+++ b/src/components/EnhancedTable/index.test.ts
@@ -1,0 +1,93 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+jest.mock('./style.less', () => ({}));
+
+jest.mock('lucide-react', () => {
+  const icon =
+    (name: string) =>
+    ({ className }: { className?: string }) =>
+      React.createElement('svg', { className, 'data-icon': name });
+
+  return {
+    CheckCircle: icon('CheckCircle'),
+    Copy: icon('Copy'),
+    ExternalLink: icon('ExternalLink'),
+    Eye: icon('Eye'),
+    Link: icon('Link'),
+    MoreVertical: icon('MoreVertical'),
+    Network: icon('Network'),
+    Pencil: icon('Pencil'),
+    Play: icon('Play'),
+    Plus: icon('Plus'),
+    Search: icon('Search'),
+    Settings: icon('Settings'),
+    ShieldCheck: icon('ShieldCheck'),
+    Sparkles: icon('Sparkles'),
+    Trash2: icon('Trash2'),
+  };
+});
+
+jest.mock('antd', () => {
+  return {
+    Table: ({ columns, dataSource }: { columns: any[]; dataSource: any[] }) =>
+      React.createElement(
+        'div',
+        {},
+        dataSource.map((record, index) =>
+          React.createElement(
+            'div',
+            { key: record.id ?? index },
+            columns.map((column) =>
+              React.createElement('div', { key: column.key ?? column.dataIndex }, column.render ? column.render(undefined, record, index) : null),
+            ),
+          ),
+        ),
+      ),
+    Button: ({ children, className, icon }: any) => React.createElement('button', { className }, icon, children),
+    Tooltip: ({ children, title }: any) => React.createElement('span', { 'data-tooltip': title }, children),
+    Dropdown: ({ children }: any) => React.createElement('span', {}, children),
+    Menu: ({ children }: any) => React.createElement('menu', {}, children),
+  };
+});
+
+const antd = require('antd');
+antd.Menu.Item = ({ children }: any) => React.createElement('li', {}, children);
+antd.Menu.Divider = () => React.createElement('hr');
+
+import EnhancedTable from './index';
+
+describe('EnhancedTable row actions', () => {
+  it('renders inline text actions as icon-only buttons with the text in a tooltip', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(EnhancedTable, {
+        rowKey: 'id',
+        dataSource: [{ id: 1 }],
+        columns: [],
+        rowActions: () => ({
+          inline: [{ key: 'query', text: '查询' }],
+        }),
+      }),
+    );
+
+    expect(html).toContain('data-tooltip="查询"');
+    expect(html).toContain('data-icon="Search"');
+    expect(html).not.toContain('<button class="fc-table-action-inline-btn">查询</button>');
+  });
+
+  it('uses a default icon when an inline action has no icon mapping', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(EnhancedTable, {
+        rowKey: 'id',
+        dataSource: [{ id: 1 }],
+        columns: [],
+        rowActions: () => ({
+          inline: [{ key: 'custom-action', text: '自定义操作' }],
+        }),
+      }),
+    );
+
+    expect(html).toContain('data-tooltip="自定义操作"');
+    expect(html).toContain('data-icon="CheckCircle"');
+  });
+});

--- a/src/components/EnhancedTable/index.tsx
+++ b/src/components/EnhancedTable/index.tsx
@@ -11,6 +11,7 @@ import {
   Network,
   Pencil,
   Play,
+  Plus,
   Search,
   Settings,
   ShieldCheck,
@@ -30,6 +31,7 @@ const actionIconMap = {
   copy: Copy,
   delete: Trash2,
   run: Play,
+  create: Plus,
   search: Search,
   open: ExternalLink,
   link: LinkIcon,
@@ -44,6 +46,7 @@ export interface RowAction {
   icon?: ActionIconName;
   onClick?: (e: React.MouseEvent) => void;
   disabled?: boolean;
+  loading?: boolean;
   danger?: boolean;
   /** false to hide this action (e.g. by permission) */
   visible?: boolean;
@@ -110,21 +113,66 @@ export function getEnabledStatusColumn<ValueType extends EnabledStatusValue = En
 
 const visibleOnly = (list?: RowAction[]) => (list || []).filter((a) => a.visible !== false);
 
-function ActionButton({ action, className, withIcon }: { action: RowAction; className: string; withIcon?: boolean }) {
-  const Icon = withIcon && action.icon ? actionIconMap[action.icon] : undefined;
+const fallbackInlineIconMap: Record<string, ActionIconName> = {
+  query: 'search',
+  trace: 'search',
+  executions: 'view',
+  execRecord: 'view',
+  create: 'create',
+  config: 'settings',
+  execute: 'run',
+  exec: 'run',
+  fire: 'run',
+  'ai-inspection': 'ai',
+};
+
+function resolveActionIcon(action: RowAction, fallbackToKey = false) {
+  const iconName = action.icon ?? (fallbackToKey && action.key ? fallbackInlineIconMap[action.key] : undefined);
+  if (iconName) return actionIconMap[iconName];
+  return fallbackToKey ? actionIconMap.default : undefined;
+}
+
+function getInlineTooltipTitle(action: RowAction) {
+  if (!action.tooltip) return action.text;
+  if (!action.text) return action.tooltip;
+  return (
+    <>
+      {action.text}
+      <br />
+      {action.tooltip}
+    </>
+  );
+}
+
+function ActionButton({ action, className, withIcon, iconOnly }: { action: RowAction; className: string; withIcon?: boolean; iconOnly?: boolean }) {
+  const Icon = withIcon ? resolveActionIcon(action, iconOnly) : undefined;
   return (
     <Button
       type='link'
-      className={classNames(className, { 'is-danger': action.danger })}
+      className={classNames(className, { 'is-danger': action.danger, 'is-icon-only': iconOnly })}
       disabled={action.disabled}
+      loading={action.loading}
       icon={Icon ? <Icon className='fc-table-action-menu-icon' /> : undefined}
+      aria-label={typeof action.text === 'string' ? action.text : undefined}
       onClick={(e) => {
         e.stopPropagation();
         action.onClick?.(e);
       }}
     >
-      {action.text}
+      {iconOnly ? null : action.text}
     </Button>
+  );
+}
+
+function renderInlineAction(action: RowAction, key: string) {
+  if (action.node) {
+    return <React.Fragment key={key}>{action.node}</React.Fragment>;
+  }
+  const btn = <ActionButton action={action} className='fc-table-action-inline-btn' withIcon iconOnly />;
+  return (
+    <Tooltip key={key} title={getInlineTooltipTitle(action)}>
+      <span className='fc-table-action-inline-btn-wrap'>{btn}</span>
+    </Tooltip>
   );
 }
 
@@ -168,11 +216,7 @@ function RowActionCell({ actions }: { actions: RowActions }) {
   return (
     <div className='fc-table-action-cell'>
       {inline.map((a, i) =>
-        a.node ? (
-          <React.Fragment key={a.key ?? `inline-${i}`}>{a.node}</React.Fragment>
-        ) : (
-          <ActionButton key={a.key ?? `inline-${i}`} action={a} className='fc-table-action-inline-btn' />
-        ),
+        renderInlineAction(a, a.key ?? `inline-${i}`),
       )}
       {menu.length > 0 && (
         <Dropdown

--- a/src/components/EnhancedTable/style.less
+++ b/src/components/EnhancedTable/style.less
@@ -7,14 +7,29 @@
   gap: 4px;
 }
 
-// inline action: text link
+.fc-table-action-inline-btn-wrap {
+  display: inline-flex;
+}
+
+// inline action: icon button
 .fc-table-action-inline-btn.ant-btn {
-  height: 24px;
-  padding: 0 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
   border-radius: 6px;
   color: var(--fc-violet-11);
   font-size: inherit;
-  line-height: 22px;
+  line-height: 1;
+
+  .fc-table-action-menu-icon {
+    width: 16px;
+    height: 16px;
+    margin: 0;
+    stroke-width: 2;
+  }
 
   &:hover,
   &:focus {


### PR DESCRIPTION
## Summary
- Converts EnhancedTable inline row actions to icon-only buttons.
- Adds tooltips that preserve the original visible action text.
- Adds a default icon fallback for unmapped inline action keys.
- Adds focused tests for inline icon rendering and fallback behavior.

## Verification
- `git diff --check origin/feat-table-design-0601...HEAD`
- `npm test -- --runTestsByPath src/components/EnhancedTable/index.test.ts`
- `npx tsc --noEmit --pretty false` currently fails on existing `updateByColumn` imports outside this PR diff; this PR intentionally does not include the update-column helper changes.
