### PR TITLE
fix(logs): remove quotes from chart category labels

### DIFF
--- a/src/pages/logExplorer/components/LogsViewer/components/TimeSeriesBarChart/index.tsx
+++ b/src/pages/logExplorer/components/LogsViewer/components/TimeSeriesBarChart/index.tsx
@@ -29,7 +29,7 @@ export interface TimeSeriesBarChartProps {
 
 function categoryFormatter(category: string | number | null | undefined) {
   if (category === undefined) return 'default';
-  if (typeof category === 'string') return `"${category}"`;
+  if (category === '') return '""';
   return String(category);
 }
 


### PR DESCRIPTION
Summary:
- Stop wrapping non-empty string histogram categories in quotes for log explorer stacked charts.
- Keep empty string categories visible as \"\" and preserve undefined as default.

Review:
- Ran /cmt strict review for the scoped chart label change; no blocker or warning findings.

Verification:
- git diff --check -- src/pages/logExplorer/components/LogsViewer/components/TimeSeriesBarChart/index.tsx
- npx tsc --noEmit

Notes/Risks:
- Current local worktree still has unrelated uncommitted SideMenu/AiChat files; they were not included in this commit or PR.