### PR TITLE
fix(logs): quote null chart category labels

### DIFF
--- a/src/pages/logExplorer/components/LogsViewer/components/TimeSeriesBarChart/index.tsx
+++ b/src/pages/logExplorer/components/LogsViewer/components/TimeSeriesBarChart/index.tsx
@@ -13,7 +13,7 @@ register('palette.custom', customPalette);
 export interface TimeSeriesDataPoint {
   time: number | string; // 时间戳或时间字符串
   value: number;
-  category?: string; // 用于堆叠图的分类
+  category?: string | null; // 用于堆叠图的分类
 }
 
 export interface TimeSeriesBarChartProps {
@@ -27,9 +27,10 @@ export interface TimeSeriesBarChartProps {
   stepMs?: number; // x 轴步长（毫秒），用于刻度格式化
 }
 
-function categoryFormatter(category: string | number | null | undefined) {
+function categoryFormatter(category: string | null | undefined) {
   if (category === undefined) return 'default';
   if (category === '') return '""';
+  if (category === null) return '"null"';
   return String(category);
 }
 

--- a/src/pages/logExplorer/components/LogsViewer/components/TimeSeriesBarChart/index.tsx
+++ b/src/pages/logExplorer/components/LogsViewer/components/TimeSeriesBarChart/index.tsx
@@ -29,9 +29,7 @@ export interface TimeSeriesBarChartProps {
 
 function categoryFormatter(category: string | null | undefined) {
   if (category === undefined) return 'default';
-  if (category === '') return '""';
-  if (category === null) return '"null"';
-  return String(category);
+  return category === null || category === '' ? `"${category}"` : category;
 }
 
 const TimeSeriesBarChart: React.FC<TimeSeriesBarChartProps> = ({ darkMode, data, width, height = 400, onBarClick, onBrushEnd, stacked = false, stepMs }) => {


### PR DESCRIPTION
Summary:
- Display null histogram categories as \"null\" in log explorer stacked charts.
- Keep missing categories as default, empty strings as \"\", and ordinary strings unquoted.

Review:
- Ran /cmt strict review for the scoped chart category formatter change; no blocker or warning findings.

Verification:
- git diff --check -- src/pages/logExplorer/components/LogsViewer/components/TimeSeriesBarChart/index.tsx
- npx tsc --noEmit

Notes/Risks:
- Current local worktree still has unrelated uncommitted SideMenu/AiChat files; they were not included in this commit or PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time series chart category handling to correctly display cases where the category is missing, explicitly empty, or set to a null value.
  * Updated formatting so all scenarios render consistently instead of producing incorrect or inconsistent labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->