### PR TITLE
fix(enhanced-table): close row action menu before action

### DIFF
--- a/src/components/EnhancedTable/RowActionCell.test.ts
+++ b/src/components/EnhancedTable/RowActionCell.test.ts
@@ -1,0 +1,22 @@
+import { runRowAction } from './RowActionCell';
+import type { RowAction } from './types';
+
+describe('runRowAction', () => {
+  it('stops row click propagation, closes the menu, then runs the action', () => {
+    const calls: string[] = [];
+    const event = {
+      stopPropagation: jest.fn(() => calls.push('stopPropagation')),
+    };
+    const closeMenu = jest.fn(() => calls.push('closeMenu'));
+    const action: RowAction = {
+      onClick: jest.fn(() => calls.push('action')),
+    };
+
+    runRowAction(action, event as any, closeMenu);
+
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(closeMenu).toHaveBeenCalledTimes(1);
+    expect(action.onClick).toHaveBeenCalledWith(event);
+    expect(calls).toEqual(['stopPropagation', 'closeMenu', 'action']);
+  });
+});

--- a/src/components/EnhancedTable/RowActionCell.tsx
+++ b/src/components/EnhancedTable/RowActionCell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Button, Dropdown, Menu, Tooltip } from 'antd';
 import { MoreVertical } from 'lucide-react';
 import classNames from 'classnames';
@@ -20,7 +20,25 @@ function getInlineTooltipTitle(action: RowAction) {
   );
 }
 
-function ActionButton({ action, className, withIcon, iconOnly }: { action: RowAction; className: string; withIcon?: boolean; iconOnly?: boolean }) {
+export function runRowAction(action: RowAction, event: React.MouseEvent, onAction?: () => void) {
+  event.stopPropagation();
+  onAction?.();
+  action.onClick?.(event);
+}
+
+function ActionButton({
+  action,
+  className,
+  withIcon,
+  iconOnly,
+  onAction,
+}: {
+  action: RowAction;
+  className: string;
+  withIcon?: boolean;
+  iconOnly?: boolean;
+  onAction?: () => void;
+}) {
   const Icon = withIcon ? resolveActionIcon(action, iconOnly) : undefined;
   return (
     <Button
@@ -31,8 +49,7 @@ function ActionButton({ action, className, withIcon, iconOnly }: { action: RowAc
       icon={Icon ? <Icon className='fc-table-action-menu-icon' /> : undefined}
       aria-label={typeof action.text === 'string' ? action.text : undefined}
       onClick={(e) => {
-        e.stopPropagation();
-        action.onClick?.(e);
+        runRowAction(action, e, onAction);
       }}
     >
       {iconOnly ? null : action.text}
@@ -56,7 +73,7 @@ function renderInlineAction(action: RowAction, key: string) {
 // and wrap the (possibly disabled) button in a span, so the hint still shows on
 // hover — a disabled button eats pointer events, and antd would also move the
 // button's className onto a wrapper span, dropping our styling.
-function renderMenuItem(action: RowAction, key: string) {
+function renderMenuItem(action: RowAction, key: string, onAction: () => void) {
   if (action.node) {
     return (
       <Menu.Item key={key} disabled={action.disabled}>
@@ -64,7 +81,7 @@ function renderMenuItem(action: RowAction, key: string) {
       </Menu.Item>
     );
   }
-  const btn = <ActionButton action={action} className='fc-table-action-menu-btn' withIcon />;
+  const btn = <ActionButton action={action} className='fc-table-action-menu-btn' withIcon onAction={onAction} />;
   if (action.tooltip) {
     return (
       <Menu.Item key={key}>
@@ -82,6 +99,7 @@ function renderMenuItem(action: RowAction, key: string) {
 }
 
 export function RowActionCell({ actions }: { actions: RowActions }) {
+  const [menuOpen, setMenuOpen] = useState(false);
   const inline = visibleOnly(actions.inline);
   const menu = visibleOnly(actions.menu);
   if (!inline.length && !menu.length) return null;
@@ -96,12 +114,14 @@ export function RowActionCell({ actions }: { actions: RowActions }) {
         <Dropdown
           trigger={['click']}
           placement='bottomRight'
+          visible={menuOpen}
+          onVisibleChange={setMenuOpen}
           overlayClassName='fc-table-action-dropdown'
           overlay={
             <Menu>
-              {normal.map((a, i) => renderMenuItem(a, a.key ?? `m-${i}`))}
+              {normal.map((a, i) => renderMenuItem(a, a.key ?? `m-${i}`, () => setMenuOpen(false)))}
               {normal.length > 0 && danger.length > 0 && <Menu.Divider />}
-              {danger.map((a, i) => renderMenuItem(a, a.key ?? `d-${i}`))}
+              {danger.map((a, i) => renderMenuItem(a, a.key ?? `d-${i}`, () => setMenuOpen(false)))}
             </Menu>
           }
         >


### PR DESCRIPTION
## Summary
- Control `EnhancedTable` row action dropdown visibility so menu actions close the kebab menu before running business logic.
- Add a regression test for the row action execution order: stop propagation, close menu, then invoke the action.

## Review
- Ran `/cmt strict` review on the scoped diff.
- No blocker or warning findings were found.

## Verification
- `pnpm test -- RowActionCell.test.ts --runInBand` passed.
- `pnpm exec tsc --noEmit` passed.
- `git diff --check` passed.

## Notes/Risks
- Rendered local verification was limited because `localhost:8765/log-extraction` redirects to `/login` and cannot reuse the `10.99.1.106:9000` session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Table row action menus now stay in sync with the dropdown state, closing properly after an action is selected.
  * Clicking a row action no longer allows the event to bubble unexpectedly, improving interaction reliability.
* **Tests**
  * Added coverage for row action click handling and menu-closing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->