### PR TITLE
feat: add "book meeting" scheduler button in page header for zh locales

### DIFF
--- a/src/components/pageLayout/PageLayoutWithTabs/index.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/index.tsx
@@ -19,7 +19,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import querystring from 'query-string';
 import { useTranslation } from 'react-i18next';
 import { Space, Button } from 'antd';
-import { RollbackOutlined, HistoryOutlined, GithubOutlined } from '@ant-design/icons';
+import { RollbackOutlined, HistoryOutlined, GithubOutlined, CalendarOutlined } from '@ant-design/icons';
 
 import AdvancedWrap, { License } from '@/components/AdvancedWrap';
 import { CommonStateContext } from '@/App';
@@ -143,6 +143,17 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
                     {!IS_ENT && !IS_PLUS && (
                       <Button className='text-hint text-[11px]' target='_blank' href='https://github.com/ccfos/nightingale/issues' size='small' icon={<GithubOutlined />}>
                         {t('submit_issue')}
+                      </Button>
+                    )}
+                    {!IS_ENT && !IS_PLUS && ['zh_CN', 'zh_HK'].includes(i18n.language) && (
+                      <Button
+                        className='text-hint text-[11px]'
+                        target='_blank'
+                        href='https://c9xudyniiq.feishu.cn/scheduler/00d06ce64941261b'
+                        size='small'
+                        icon={<CalendarOutlined />}
+                      >
+                        {t('book_meeting')}
                       </Button>
                     )}
                     <AdvancedWrap var='VITE_IS_PRO,VITE_IS_ENT'>

--- a/src/components/pageLayout/locale/zh_CN.ts
+++ b/src/components/pageLayout/locale/zh_CN.ts
@@ -7,6 +7,7 @@ const zh_CN = {
   docsCenter: '文档中心',
   viewDemo: '查看 DEMO',
   submit_issue: '提交问题',
+  book_meeting: '预约交流',
   theme: {
     title: '主题配置',
     title_help: '配置仅对当前用户生效',

--- a/src/components/pageLayout/locale/zh_HK.ts
+++ b/src/components/pageLayout/locale/zh_HK.ts
@@ -7,6 +7,7 @@ const zh_HK = {
   docsCenter: '文檔中心',
   viewDemo: '查看 DEMO',
   submit_issue: '提交問題',
+  book_meeting: '預約交流',
   theme: {
     title: '主題配置',
     title_help: '配置僅對當前用戶生效',


### PR DESCRIPTION
<img width="800" height="148" alt="image" src="https://github.com/user-attachments/assets/d08b889c-ce9b-44f1-b9f2-83be1bc77f3f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Book meeting” action in the page header for supported Chinese languages.
  * Included matching translations in Simplified and Traditional Chinese.

* **Bug Fixes**
  * The new action now appears only for eligible accounts and opens the scheduling page in a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->