### PR TITLE
fix(eventPipeline): let remark column ellipsis fill cell width

### DIFF
--- a/src/pages/eventPipeline/pages/List/index.tsx
+++ b/src/pages/eventPipeline/pages/List/index.tsx
@@ -205,7 +205,7 @@ export default function List() {
             title: t('common:table.note'),
             dataIndex: 'description',
             // 不用列 ellipsis：它会把 tableLayout 切成 fixed，页面变窄时无宽度列被无限压缩
-            render: (val) => <EllipsisText style={{ maxWidth: 280 }} text={val} />,
+            render: (val) => <EllipsisText style={{ width: '100%' }} text={val} />,
           },
           {
             title: t('use_case.label'),


### PR DESCRIPTION
## Summary
- 工作流列表备注列去掉 `EllipsisText` 固定 `maxWidth: 280`，改为 `width: 100%`
- 省略宽度与列实际可用宽度一致，避免列内留白但文字已截断

## Review
- `/cmt strict` 与 `/cr` 审查已完成，无 blocker

## Verification
- `git diff --check` 通过
- 改动范围 1 行，未跑全量 `tsc`（基线存在无关报错）

## Notes/Risks
- 已合并入 `pre` 并推送

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how note text is displayed in the event pipeline list table, making truncated content fit the available column width more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->