### PR TITLE
fix(alert-events): persist tag expansion state

### DIFF
--- a/src/pages/alertCurEvent/pages/List/index.tsx
+++ b/src/pages/alertCurEvent/pages/List/index.tsx
@@ -21,6 +21,7 @@ import { parseRange } from '@/components/TimeRangePicker';
 import { NS, MY_GRPUPS_CACHE_KEY } from '../../constants';
 import getFilterByURLQuery from '../../utils/getFilter';
 import deleteAlertEventsModal from '../../utils/deleteAlertEventsModal';
+import { readAlertEventTagsExpanded, writeAlertEventTagsExpanded } from '../../utils/eventColumnExpandedStorage';
 import getProdOptions from '../../utils/getProdOptions';
 import getRequestParamsByFilter from '../../utils/getRequestParamsByFilter';
 import { ackEvents } from '../../services';
@@ -110,7 +111,7 @@ const AlertCurEvent: React.FC = () => {
   );
   const [refreshFlag, setRefreshFlag] = useState<string>(_.uniqueId('refresh_'));
   const [selectedRowKeys, setSelectedRowKeys] = useState<number[]>([]);
-  const [eventColumnExpanded, setEventColumnExpanded] = useState(false);
+  const [eventColumnExpanded, setEventColumnExpanded] = useState(readAlertEventTagsExpanded);
   const params = getRequestParamsByFilter(filter);
 
   type RuleCardsRequestParams = {
@@ -331,7 +332,11 @@ const AlertCurEvent: React.FC = () => {
                             className='alert-event-expand-btn'
                             icon={eventColumnExpanded ? <ListChevronsDownUp size={14} /> : <ListChevronsUpDown size={14} />}
                             onClick={() => {
-                              setEventColumnExpanded(!eventColumnExpanded);
+                              setEventColumnExpanded((expanded) => {
+                                const next = !expanded;
+                                writeAlertEventTagsExpanded(next);
+                                return next;
+                              });
                             }}
                           />
                         </Tooltip>

--- a/src/pages/alertCurEvent/pages/List/index.tsx
+++ b/src/pages/alertCurEvent/pages/List/index.tsx
@@ -21,7 +21,7 @@ import { parseRange } from '@/components/TimeRangePicker';
 import { NS, MY_GRPUPS_CACHE_KEY } from '../../constants';
 import getFilterByURLQuery from '../../utils/getFilter';
 import deleteAlertEventsModal from '../../utils/deleteAlertEventsModal';
-import { readAlertEventTagsExpanded, writeAlertEventTagsExpanded } from '../../utils/eventColumnExpandedStorage';
+import { ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY, readAlertEventTagsExpanded, writeAlertEventTagsExpanded } from '../../utils/eventColumnExpandedStorage';
 import getProdOptions from '../../utils/getProdOptions';
 import getRequestParamsByFilter from '../../utils/getRequestParamsByFilter';
 import { ackEvents } from '../../services';
@@ -111,7 +111,7 @@ const AlertCurEvent: React.FC = () => {
   );
   const [refreshFlag, setRefreshFlag] = useState<string>(_.uniqueId('refresh_'));
   const [selectedRowKeys, setSelectedRowKeys] = useState<number[]>([]);
-  const [eventColumnExpanded, setEventColumnExpanded] = useState(readAlertEventTagsExpanded);
+  const [eventColumnExpanded, setEventColumnExpanded] = useState(() => readAlertEventTagsExpanded(ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY));
   const params = getRequestParamsByFilter(filter);
 
   type RuleCardsRequestParams = {
@@ -334,7 +334,7 @@ const AlertCurEvent: React.FC = () => {
                             onClick={() => {
                               setEventColumnExpanded((expanded) => {
                                 const next = !expanded;
-                                writeAlertEventTagsExpanded(next);
+                                writeAlertEventTagsExpanded(ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY, next);
                                 return next;
                               });
                             }}

--- a/src/pages/alertCurEvent/utils/eventColumnExpandedStorage.test.ts
+++ b/src/pages/alertCurEvent/utils/eventColumnExpandedStorage.test.ts
@@ -1,5 +1,7 @@
 import {
-  ALERT_EVENT_TAGS_EXPANDED_STORAGE_KEY,
+  ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY,
+  HISTORY_EVENT_TAGS_EXPANDED_TABLE_KEY,
+  getAlertEventTagsExpandedStorageKey,
   readAlertEventTagsExpanded,
   writeAlertEventTagsExpanded,
 } from './eventColumnExpandedStorage';
@@ -29,28 +31,45 @@ describe('alert event tag expansion storage', () => {
     delete (globalThis as any).localStorage;
   });
 
-  it('defaults collapsed and persists expanded state', () => {
-    expect(readAlertEventTagsExpanded()).toBe(false);
+  it('defaults collapsed and persists expanded state per table', () => {
+    expect(readAlertEventTagsExpanded(ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY)).toBe(false);
+    expect(readAlertEventTagsExpanded(HISTORY_EVENT_TAGS_EXPANDED_TABLE_KEY)).toBe(false);
 
-    writeAlertEventTagsExpanded(true);
+    writeAlertEventTagsExpanded(ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY, true);
 
-    expect(globalThis.localStorage.setItem).toHaveBeenCalledWith(ALERT_EVENT_TAGS_EXPANDED_STORAGE_KEY, '1');
-    expect(readAlertEventTagsExpanded()).toBe(true);
+    expect(globalThis.localStorage.setItem).toHaveBeenCalledWith(getAlertEventTagsExpandedStorageKey(ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY), '1');
+    expect(readAlertEventTagsExpanded(ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY)).toBe(true);
+    expect(readAlertEventTagsExpanded(HISTORY_EVENT_TAGS_EXPANDED_TABLE_KEY)).toBe(false);
 
-    writeAlertEventTagsExpanded(false);
+    writeAlertEventTagsExpanded(HISTORY_EVENT_TAGS_EXPANDED_TABLE_KEY, true);
 
-    expect(globalThis.localStorage.setItem).toHaveBeenCalledWith(ALERT_EVENT_TAGS_EXPANDED_STORAGE_KEY, '0');
-    expect(readAlertEventTagsExpanded()).toBe(false);
+    expect(globalThis.localStorage.setItem).toHaveBeenCalledWith(getAlertEventTagsExpandedStorageKey(HISTORY_EVENT_TAGS_EXPANDED_TABLE_KEY), '1');
+    expect(readAlertEventTagsExpanded(ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY)).toBe(true);
+    expect(readAlertEventTagsExpanded(HISTORY_EVENT_TAGS_EXPANDED_TABLE_KEY)).toBe(true);
+
+    writeAlertEventTagsExpanded(ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY, false);
+
+    expect(globalThis.localStorage.setItem).toHaveBeenCalledWith(getAlertEventTagsExpandedStorageKey(ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY), '0');
+    expect(readAlertEventTagsExpanded(ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY)).toBe(false);
+    expect(readAlertEventTagsExpanded(HISTORY_EVENT_TAGS_EXPANDED_TABLE_KEY)).toBe(true);
   });
 });
 
 describe('alert event pages using tag expansion', () => {
   const root = path.resolve(__dirname, '../../../..');
 
-  it.each(['src/pages/alertCurEvent/pages/List/index.tsx', 'src/pages/historyEvents/ListNG/index.tsx'])('%s persists tag expansion toggles', (file) => {
+  it.each([
+    ['src/pages/alertCurEvent/pages/List/index.tsx', 'ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY'],
+    ['src/pages/historyEvents/ListNG/index.tsx', 'HISTORY_EVENT_TAGS_EXPANDED_TABLE_KEY'],
+  ])('%s persists tag expansion toggles with its own table key', (file, tableKey) => {
     const source = readFileSync(path.join(root, file), 'utf8');
 
     expect(source).toContain('readAlertEventTagsExpanded');
     expect(source).toContain('writeAlertEventTagsExpanded');
+    expect(source).toContain(tableKey);
+    expect(source).toContain(`readAlertEventTagsExpanded(${tableKey})`);
+    expect(source).toContain(`writeAlertEventTagsExpanded(${tableKey}, next)`);
+    expect(source).not.toContain('useState(readAlertEventTagsExpanded)');
+    expect(source).not.toContain('writeAlertEventTagsExpanded(next)');
   });
 });

--- a/src/pages/alertCurEvent/utils/eventColumnExpandedStorage.test.ts
+++ b/src/pages/alertCurEvent/utils/eventColumnExpandedStorage.test.ts
@@ -1,0 +1,56 @@
+import {
+  ALERT_EVENT_TAGS_EXPANDED_STORAGE_KEY,
+  readAlertEventTagsExpanded,
+  writeAlertEventTagsExpanded,
+} from './eventColumnExpandedStorage';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function mockLocalStorage() {
+  const values = new Map<string, string>();
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: jest.fn((key: string) => values.get(key) ?? null),
+      setItem: jest.fn((key: string, value: string) => {
+        values.set(key, value);
+      }),
+    },
+  });
+}
+
+describe('alert event tag expansion storage', () => {
+  beforeEach(() => {
+    mockLocalStorage();
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).localStorage;
+  });
+
+  it('defaults collapsed and persists expanded state', () => {
+    expect(readAlertEventTagsExpanded()).toBe(false);
+
+    writeAlertEventTagsExpanded(true);
+
+    expect(globalThis.localStorage.setItem).toHaveBeenCalledWith(ALERT_EVENT_TAGS_EXPANDED_STORAGE_KEY, '1');
+    expect(readAlertEventTagsExpanded()).toBe(true);
+
+    writeAlertEventTagsExpanded(false);
+
+    expect(globalThis.localStorage.setItem).toHaveBeenCalledWith(ALERT_EVENT_TAGS_EXPANDED_STORAGE_KEY, '0');
+    expect(readAlertEventTagsExpanded()).toBe(false);
+  });
+});
+
+describe('alert event pages using tag expansion', () => {
+  const root = path.resolve(__dirname, '../../../..');
+
+  it.each(['src/pages/alertCurEvent/pages/List/index.tsx', 'src/pages/historyEvents/ListNG/index.tsx'])('%s persists tag expansion toggles', (file) => {
+    const source = readFileSync(path.join(root, file), 'utf8');
+
+    expect(source).toContain('readAlertEventTagsExpanded');
+    expect(source).toContain('writeAlertEventTagsExpanded');
+  });
+});

--- a/src/pages/alertCurEvent/utils/eventColumnExpandedStorage.ts
+++ b/src/pages/alertCurEvent/utils/eventColumnExpandedStorage.ts
@@ -1,4 +1,10 @@
-export const ALERT_EVENT_TAGS_EXPANDED_STORAGE_KEY = 'alert-event-tags-expanded';
+export const ALERT_EVENT_TAGS_EXPANDED_STORAGE_PREFIX = 'alert-event-tags-expanded';
+export const ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY = 'alert-cur-events';
+export const HISTORY_EVENT_TAGS_EXPANDED_TABLE_KEY = 'history-events';
+
+export function getAlertEventTagsExpandedStorageKey(tableKey: string) {
+  return `${ALERT_EVENT_TAGS_EXPANDED_STORAGE_PREFIX}:${tableKey}`;
+}
 
 function getLocalStorage(): Storage | undefined {
   try {
@@ -8,9 +14,9 @@ function getLocalStorage(): Storage | undefined {
   }
 }
 
-export function readAlertEventTagsExpanded(defaultValue = false): boolean {
+export function readAlertEventTagsExpanded(tableKey: string, defaultValue = false): boolean {
   try {
-    const value = getLocalStorage()?.getItem(ALERT_EVENT_TAGS_EXPANDED_STORAGE_KEY);
+    const value = getLocalStorage()?.getItem(getAlertEventTagsExpandedStorageKey(tableKey));
     if (value === undefined || value === null) return defaultValue;
     return value === '1';
   } catch {
@@ -18,9 +24,9 @@ export function readAlertEventTagsExpanded(defaultValue = false): boolean {
   }
 }
 
-export function writeAlertEventTagsExpanded(expanded: boolean) {
+export function writeAlertEventTagsExpanded(tableKey: string, expanded: boolean) {
   try {
-    getLocalStorage()?.setItem(ALERT_EVENT_TAGS_EXPANDED_STORAGE_KEY, expanded ? '1' : '0');
+    getLocalStorage()?.setItem(getAlertEventTagsExpandedStorageKey(tableKey), expanded ? '1' : '0');
   } catch {
     // Ignore storage failures, for example in private mode.
   }

--- a/src/pages/alertCurEvent/utils/eventColumnExpandedStorage.ts
+++ b/src/pages/alertCurEvent/utils/eventColumnExpandedStorage.ts
@@ -1,0 +1,27 @@
+export const ALERT_EVENT_TAGS_EXPANDED_STORAGE_KEY = 'alert-event-tags-expanded';
+
+function getLocalStorage(): Storage | undefined {
+  try {
+    return globalThis.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+export function readAlertEventTagsExpanded(defaultValue = false): boolean {
+  try {
+    const value = getLocalStorage()?.getItem(ALERT_EVENT_TAGS_EXPANDED_STORAGE_KEY);
+    if (value === undefined || value === null) return defaultValue;
+    return value === '1';
+  } catch {
+    return defaultValue;
+  }
+}
+
+export function writeAlertEventTagsExpanded(expanded: boolean) {
+  try {
+    getLocalStorage()?.setItem(ALERT_EVENT_TAGS_EXPANDED_STORAGE_KEY, expanded ? '1' : '0');
+  } catch {
+    // Ignore storage failures, for example in private mode.
+  }
+}

--- a/src/pages/historyEvents/ListNG/index.tsx
+++ b/src/pages/historyEvents/ListNG/index.tsx
@@ -24,7 +24,7 @@ import { getEventById } from '@/pages/alertCurEvent/services';
 import deleteAlertEventsModal from '@/pages/alertCurEvent/utils/deleteAlertEventsModal';
 import EnhancedTable from '@/components/EnhancedTable';
 import Tags from '@/components/TableTags/Tags';
-import { readAlertEventTagsExpanded, writeAlertEventTagsExpanded } from '@/pages/alertCurEvent/utils/eventColumnExpandedStorage';
+import { HISTORY_EVENT_TAGS_EXPANDED_TABLE_KEY, readAlertEventTagsExpanded, writeAlertEventTagsExpanded } from '@/pages/alertCurEvent/utils/eventColumnExpandedStorage';
 
 import exportEvents, { downloadFile } from '../exportEvents';
 import { SeverityColor } from '../../event';
@@ -74,7 +74,7 @@ const Event = (props: Props) => {
     showClaimant = false,
   } = props;
   const [refreshFlag, setRefreshFlag] = useState<string>(_.uniqueId('refresh_'));
-  const [eventColumnExpanded, setEventColumnExpanded] = useState(readAlertEventTagsExpanded);
+  const [eventColumnExpanded, setEventColumnExpanded] = useState(() => readAlertEventTagsExpanded(HISTORY_EVENT_TAGS_EXPANDED_TABLE_KEY));
   const [eventDetailDrawerData, setEventDetailDrawerData] = useState<{
     visible: boolean;
     data?: any;
@@ -377,7 +377,7 @@ const Event = (props: Props) => {
                 onClick={() => {
                   setEventColumnExpanded((expanded) => {
                     const next = !expanded;
-                    writeAlertEventTagsExpanded(next);
+                    writeAlertEventTagsExpanded(HISTORY_EVENT_TAGS_EXPANDED_TABLE_KEY, next);
                     return next;
                   });
                 }}

--- a/src/pages/historyEvents/ListNG/index.tsx
+++ b/src/pages/historyEvents/ListNG/index.tsx
@@ -24,6 +24,7 @@ import { getEventById } from '@/pages/alertCurEvent/services';
 import deleteAlertEventsModal from '@/pages/alertCurEvent/utils/deleteAlertEventsModal';
 import EnhancedTable from '@/components/EnhancedTable';
 import Tags from '@/components/TableTags/Tags';
+import { readAlertEventTagsExpanded, writeAlertEventTagsExpanded } from '@/pages/alertCurEvent/utils/eventColumnExpandedStorage';
 
 import exportEvents, { downloadFile } from '../exportEvents';
 import { SeverityColor } from '../../event';
@@ -73,7 +74,7 @@ const Event = (props: Props) => {
     showClaimant = false,
   } = props;
   const [refreshFlag, setRefreshFlag] = useState<string>(_.uniqueId('refresh_'));
-  const [eventColumnExpanded, setEventColumnExpanded] = useState(false);
+  const [eventColumnExpanded, setEventColumnExpanded] = useState(readAlertEventTagsExpanded);
   const [eventDetailDrawerData, setEventDetailDrawerData] = useState<{
     visible: boolean;
     data?: any;
@@ -374,7 +375,11 @@ const Event = (props: Props) => {
                 size='small'
                 icon={eventColumnExpanded ? <ListChevronsDownUp size={14} /> : <ListChevronsUpDown size={14} />}
                 onClick={() => {
-                  setEventColumnExpanded(!eventColumnExpanded);
+                  setEventColumnExpanded((expanded) => {
+                    const next = !expanded;
+                    writeAlertEventTagsExpanded(next);
+                    return next;
+                  });
                 }}
               />
             </Tooltip>


### PR DESCRIPTION
## Summary
- Persist alert event tag expand/collapse state in localStorage.
- Store current alert events and history events under separate table keys so their expand/collapse state does not leak across tables.
- Add storage and static usage tests for the shared helper.

## Review
- /cmt strict review performed.
- Follow-up review addressed per-table storage isolation for the tags expand/collapse state.
- No blocker or warn findings found.

## Verification
- `npm test -- --runTestsByPath src/pages/alertCurEvent/utils/eventColumnExpandedStorage.test.ts` passed.
- `npm test -- --runTestsByPath src/plus/pages/mobileDevice/mobile-device-table.test.ts src/pages/alertCurEvent/utils/eventColumnExpandedStorage.test.ts` passed before the follow-up.
- `git diff --check` passed in the fe repo.
- Browser QA under `npm run dev:advanced` confirmed `/alert-cur-events` loads and the tag expand button updates rendered tag expansion state.

## Notes/Risks
- The localStorage behavior is covered by unit test; browser QA verified the UI interaction path.