### PR TITLE
fix: aggregate eventid query param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6127,21 +6127,6 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.2.tgz",
-      "integrity": "sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -19519,48 +19504,6 @@
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
-    "node_modules/rollup": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmmirror.com/rollup/-/rollup-4.40.2.tgz",
-      "integrity": "sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "1.0.7"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.40.2",
-        "@rollup/rollup-android-arm64": "4.40.2",
-        "@rollup/rollup-darwin-arm64": "4.40.2",
-        "@rollup/rollup-darwin-x64": "4.40.2",
-        "@rollup/rollup-freebsd-arm64": "4.40.2",
-        "@rollup/rollup-freebsd-x64": "4.40.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.40.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.40.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.40.2",
-        "@rollup/rollup-linux-arm64-musl": "4.40.2",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.40.2",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.40.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.40.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.40.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.40.2",
-        "@rollup/rollup-linux-x64-gnu": "4.40.2",
-        "@rollup/rollup-linux-x64-musl": "4.40.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.40.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.40.2",
-        "@rollup/rollup-win32-x64-msvc": "4.40.2",
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/rollup-plugin-visualizer": {
       "version": "5.12.0",
       "resolved": "https://registry.npmmirror.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.12.0.tgz",
@@ -22430,22 +22373,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/vite-plugin-svgr/node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/vite/node_modules/rollup": {
@@ -27751,14 +27678,6 @@
         "estree-walker": "^2.0.1",
         "picomatch": "^2.2.2"
       }
-    },
-    "@rollup/rollup-darwin-arm64": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.2.tgz",
-      "integrity": "sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "@sinclair/typebox": {
       "version": "0.27.8",
@@ -39112,38 +39031,6 @@
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
-    "rollup": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmmirror.com/rollup/-/rollup-4.40.2.tgz",
-      "integrity": "sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@rollup/rollup-android-arm-eabi": "4.40.2",
-        "@rollup/rollup-android-arm64": "4.40.2",
-        "@rollup/rollup-darwin-arm64": "4.40.2",
-        "@rollup/rollup-darwin-x64": "4.40.2",
-        "@rollup/rollup-freebsd-arm64": "4.40.2",
-        "@rollup/rollup-freebsd-x64": "4.40.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.40.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.40.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.40.2",
-        "@rollup/rollup-linux-arm64-musl": "4.40.2",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.40.2",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.40.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.40.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.40.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.40.2",
-        "@rollup/rollup-linux-x64-gnu": "4.40.2",
-        "@rollup/rollup-linux-x64-musl": "4.40.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.40.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.40.2",
-        "@rollup/rollup-win32-x64-msvc": "4.40.2",
-        "@types/estree": "1.0.7",
-        "fsevents": "~2.3.2"
-      }
-    },
     "rollup-plugin-visualizer": {
       "version": "5.12.0",
       "resolved": "https://registry.npmmirror.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.12.0.tgz",
@@ -41327,14 +41214,6 @@
           "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.2.tgz",
           "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
           "dev": true
-        },
-        "typescript": {
-          "version": "5.8.3",
-          "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.8.3.tgz",
-          "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6127,6 +6127,21 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.40.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.2.tgz",
+      "integrity": "sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -19504,6 +19519,48 @@
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
+    "node_modules/rollup": {
+      "version": "4.40.2",
+      "resolved": "https://registry.npmmirror.com/rollup/-/rollup-4.40.2.tgz",
+      "integrity": "sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "1.0.7"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.40.2",
+        "@rollup/rollup-android-arm64": "4.40.2",
+        "@rollup/rollup-darwin-arm64": "4.40.2",
+        "@rollup/rollup-darwin-x64": "4.40.2",
+        "@rollup/rollup-freebsd-arm64": "4.40.2",
+        "@rollup/rollup-freebsd-x64": "4.40.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.40.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.40.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.40.2",
+        "@rollup/rollup-linux-arm64-musl": "4.40.2",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.40.2",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.40.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.40.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.40.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.40.2",
+        "@rollup/rollup-linux-x64-gnu": "4.40.2",
+        "@rollup/rollup-linux-x64-musl": "4.40.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.40.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.40.2",
+        "@rollup/rollup-win32-x64-msvc": "4.40.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/rollup-plugin-visualizer": {
       "version": "5.12.0",
       "resolved": "https://registry.npmmirror.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.12.0.tgz",
@@ -22373,6 +22430,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite-plugin-svgr/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/vite/node_modules/rollup": {
@@ -27678,6 +27751,14 @@
         "estree-walker": "^2.0.1",
         "picomatch": "^2.2.2"
       }
+    },
+    "@rollup/rollup-darwin-arm64": {
+      "version": "4.40.2",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.2.tgz",
+      "integrity": "sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "@sinclair/typebox": {
       "version": "0.27.8",
@@ -39031,6 +39112,38 @@
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
+    "rollup": {
+      "version": "4.40.2",
+      "resolved": "https://registry.npmmirror.com/rollup/-/rollup-4.40.2.tgz",
+      "integrity": "sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@rollup/rollup-android-arm-eabi": "4.40.2",
+        "@rollup/rollup-android-arm64": "4.40.2",
+        "@rollup/rollup-darwin-arm64": "4.40.2",
+        "@rollup/rollup-darwin-x64": "4.40.2",
+        "@rollup/rollup-freebsd-arm64": "4.40.2",
+        "@rollup/rollup-freebsd-x64": "4.40.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.40.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.40.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.40.2",
+        "@rollup/rollup-linux-arm64-musl": "4.40.2",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.40.2",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.40.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.40.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.40.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.40.2",
+        "@rollup/rollup-linux-x64-gnu": "4.40.2",
+        "@rollup/rollup-linux-x64-musl": "4.40.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.40.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.40.2",
+        "@rollup/rollup-win32-x64-msvc": "4.40.2",
+        "@types/estree": "1.0.7",
+        "fsevents": "~2.3.2"
+      }
+    },
     "rollup-plugin-visualizer": {
       "version": "5.12.0",
       "resolved": "https://registry.npmmirror.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.12.0.tgz",
@@ -41214,6 +41327,14 @@
           "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.2.tgz",
           "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
           "dev": true
+        },
+        "typescript": {
+          "version": "5.8.3",
+          "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.8.3.tgz",
+          "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },

--- a/src/pages/alertCurEvent/pages/List/index.tsx
+++ b/src/pages/alertCurEvent/pages/List/index.tsx
@@ -123,7 +123,8 @@ const AlertCurEvent: React.FC = () => {
     const requestParams: RuleCardsRequestParams = {
       view_id: filter.aggr_rule_id,
       my_groups: String(params.my_groups) === 'true',
-      ..._.omit(params, ['range', 'my_groups']),
+      // card 接口按聚合规则自行分组，无需 event_ids；其数量可能极大，去掉以免 URL 超长(414)
+      ..._.omit(params, ['range', 'my_groups', 'event_ids']),
     };
     if (params.range) {
       const parsedRange = parseRange(params.range);

--- a/src/pages/alertCurEvent/services.ts
+++ b/src/pages/alertCurEvent/services.ts
@@ -9,7 +9,7 @@ export function getEvents(params) {
   if (import.meta.env.VITE_IS_PRO === 'true') {
     url = '/api/n9e-plus/alert-cur-events/list';
   }
-  // event_ids 可能多达数千个，拼到 URL query 会超长被 nginx 中断(414)，因此改用 POST 放入请求体
+  // event_ids 可能多达数千个，拼到 URL query 会超长被 nginx 中断(414)，因此改用 POST 以数组形式放入请求体
   const { event_ids, ...query } = params;
   return request(url, {
     method: RequestMethod.Post,

--- a/src/pages/alertCurEvent/services.ts
+++ b/src/pages/alertCurEvent/services.ts
@@ -9,9 +9,12 @@ export function getEvents(params) {
   if (import.meta.env.VITE_IS_PRO === 'true') {
     url = '/api/n9e-plus/alert-cur-events/list';
   }
+  // event_ids 可能多达数千个，拼到 URL query 会超长被 nginx 中断(414)，因此改用 POST 放入请求体
+  const { event_ids, ...query } = params;
   return request(url, {
-    method: RequestMethod.Get,
-    params,
+    method: RequestMethod.Post,
+    params: query,
+    data: { event_ids },
   });
 }
 

--- a/src/pages/alertCurEvent/utils/getRequestParamsByFilter.ts
+++ b/src/pages/alertCurEvent/utils/getRequestParamsByFilter.ts
@@ -10,7 +10,7 @@ export default function getRequestParamsByFilter(filter: FilterType) {
     filter.query ? { query: filter.query } : {},
     filter.bgid ? { bgid: filter.bgid } : {},
     !_.isEmpty(filter.rule_prods) ? { rule_prods: _.join(filter.rule_prods, ',') } : {},
-    !_.isEmpty(filter.event_ids) ? { event_ids: _.join(filter.event_ids, ',') } : {},
+    !_.isEmpty(filter.event_ids) ? { event_ids: filter.event_ids } : {}, // 保留数组，随 POST 请求体下发（不再拼接进 URL）
     filter.my_groups ? { my_groups: filter.my_groups === 'true' } : {},
   );
   return params;


### PR DESCRIPTION
修复「活跃告警 → 聚合视图」中选中聚合卡片后，因事件过多、event_id 被拼进请求 URL 导致超长、被 nginx 返回 414 的问题，并保证大规模事件下稳定可用。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event-related requests so large event selections no longer risk oversized URL query parameters.
  * Prevented specific event filter fields from being sent as part of card requests, reducing incorrect or overly large payloads.
  * Updated request parameter handling to keep selected event IDs as an array for POST-based submission rather than URL string concatenation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->