### PR TITLE
feat(i18n): add firemap template rule labels

### DIFF
--- a/src/pages/builtInComponents/locale/en_US.ts
+++ b/src/pages/builtInComponents/locale/en_US.ts
@@ -58,6 +58,16 @@ const en_US = {
   payload_by_system: 'System',
   firemap: {
     drill_path: 'Drill down path',
+    generate_rule: 'Generate rule',
+    custom_rule: 'Custom rule',
+    update_match_degree: 'Update match score',
+    match_degree_updated: 'Match score updated',
+    match_degree: {
+      title: 'Rule match score',
+      high: 'High match',
+      medium: 'Medium match',
+      low: 'Low match',
+    },
     urlConfig: 'Jump address',
     dashboardConfig: 'Dashboard',
     logExplore: 'Log search',

--- a/src/pages/builtInComponents/locale/ja_JP.ts
+++ b/src/pages/builtInComponents/locale/ja_JP.ts
@@ -58,6 +58,16 @@ const ja_JP = {
   payload_by_system: 'システム内蔵',
   firemap: {
     drill_path: 'ドリルダウンパス',
+    generate_rule: 'ルールを生成',
+    custom_rule: 'カスタムルール',
+    update_match_degree: 'マッチ度を一括更新',
+    match_degree_updated: 'マッチ度を更新しました',
+    match_degree: {
+      title: 'ルールマッチ度',
+      high: '高マッチ',
+      medium: '中マッチ',
+      low: '低マッチ',
+    },
     urlConfig: 'リンクアドレス',
     dashboardConfig: 'ダッシュボード',
     logExplore: 'ログ検索',

--- a/src/pages/builtInComponents/locale/ru_RU.ts
+++ b/src/pages/builtInComponents/locale/ru_RU.ts
@@ -58,6 +58,16 @@ const ru_RU = {
   payload_by_system: 'Встроенный в систему',
   firemap: {
     drill_path: 'Путь сверху',
+    generate_rule: 'Создать правило',
+    custom_rule: 'Пользовательское правило',
+    update_match_degree: 'Обновить совпадение',
+    match_degree_updated: 'Оценка совпадения обновлена',
+    match_degree: {
+      title: 'Оценка совпадения',
+      high: 'Высокое совпадение',
+      medium: 'Среднее совпадение',
+      low: 'Низкое совпадение',
+    },
     urlConfig: 'Ссылка',
     dashboardConfig: 'Панель мониторинга',
     logExplore: 'Поиск логов',

--- a/src/pages/builtInComponents/locale/zh_CN.ts
+++ b/src/pages/builtInComponents/locale/zh_CN.ts
@@ -58,6 +58,16 @@ const zh_CN = {
   payload_by_system: '系统内置',
   firemap: {
     drill_path: '下钻路径',
+    generate_rule: '生成规则',
+    custom_rule: '自定义规则',
+    update_match_degree: '一键更新匹配度',
+    match_degree_updated: '匹配度已更新',
+    match_degree: {
+      title: '规则匹配度',
+      high: '匹配度高',
+      medium: '匹配度中',
+      low: '匹配度低',
+    },
     urlConfig: '跳转地址',
     dashboardConfig: '仪表盘',
     logExplore: '日志检索',

--- a/src/pages/builtInComponents/locale/zh_HK.ts
+++ b/src/pages/builtInComponents/locale/zh_HK.ts
@@ -58,6 +58,16 @@ const zh_HK = {
   payload_by_system: '系統內置',
   firemap: {
     drill_path: '下鑽路徑',
+    generate_rule: '生成規則',
+    custom_rule: '自定義規則',
+    update_match_degree: '一鍵更新匹配度',
+    match_degree_updated: '匹配度已更新',
+    match_degree: {
+      title: '規則匹配度',
+      high: '匹配度高',
+      medium: '匹配度中',
+      low: '匹配度低',
+    },
     urlConfig: '跳轉地址',
     dashboardConfig: '儀表盤',
     logExplore: '日誌檢索',


### PR DESCRIPTION
Summary:
- Add localized labels for firemap template rule generation.
- Add match-degree labels for built-in firemap template UI.

Review:
- Reviewed diff against origin/pre; no blocking findings found.
- Used a clean branch based on origin/pre to avoid carrying unrelated main-only commits.

Verification:
- git diff --check origin/pre...HEAD: passed.
- npm run build:advanced: passed before commit.

Notes/Risks:
- This PR only contains the fe locale additions; the plus implementation is in flashcatcloud/n9e-plus-fe#952.