### PR TITLE
feat(table): 全局启用分页跳转至第 X 页 (showQuickJumper)

### DIFF
--- a/src/components/usePagination.tsx
+++ b/src/components/usePagination.tsx
@@ -27,6 +27,7 @@ export default function usePagination(props: PaginationProps) {
 
   return {
     showSizeChanger,
+    showQuickJumper: true,
     pageSize,
     pageSizeOptions,
     showTotal: (total) => {


### PR DESCRIPTION
## 背景
[table 走查] 子任务「统一的分页器」。走查发现 cat 的 EnhancedTable 是 antd Table 透传壳，分页无统一分页器组件，共享的 `usePagination` hook 默认不含 `showQuickJumper`，导致「跳转至第 X 页」仅个别页面 ad-hoc 打开、全仓不一致。

## 改动
`src/components/usePagination.tsx` 的返回对象加一行 `showQuickJumper: true`。所有 spread 该 hook 返回值的列表自动获得跳页输入框。

## 安全性（已核实）
- 跳页复用已有的 `onChange(page,pageSize)` 回调，与点击页码同一路径，**服务端分页表无影响**：所有走 hook 的服务端分页表都正确传了 `total`，跳页上界准确。
- 全仓仅 1 张表显式 `showQuickJumper:false`（dashboard Renderer Table），且不走 hook，**无覆盖冲突**。
- 已知局限：不走 hook 的表（doris/ES/cloudwatch Explorer、EventSource、WebLogicTable 等）不受此改动影响，保持现状，另行处理。

## 配套
srm-fe 同源 hook 同步改动（另一 PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)