### PR TITLE
fix(table): 操作列文字左对齐(整体方案) + 排序/筛选图标间距收紧

### DIFF
--- a/src/components/EnhancedTable/EnhancedTable.tsx
+++ b/src/components/EnhancedTable/EnhancedTable.tsx
@@ -28,13 +28,19 @@ export default function EnhancedTable<RecordType extends object = any>(props: En
     let finalColumns: ColumnsType<RecordType> | undefined = injectColumnFilters(columns, Array.isArray(dataSource) ? dataSource : undefined);
 
     const allColumns: ColumnType<RecordType>[] = ((finalColumns ?? []) as ColumnsType<RecordType>).filter(Boolean).map((col: ColumnType<RecordType>) => {
-      if (!autoSortColumns) {
-        return col;
-      }
       const dataIndex = col.dataIndex;
-      // 操作列不排序
-      const sorter = col.sorter !== undefined ? col.sorter : !!dataIndex && !['operate'].includes(dataIndex as string) ? defaultComparator(dataIndex as string) : false;
-      return { ...col, sorter };
+      // 手写操作列（dataIndex='operate' 或标题为「操作」）统一打标 + 左对齐；
+      // .fc-table-op-column 由 style.less 去掉首个内联 link/text 按钮的左内边距，
+      // 使按钮文字与表头「操作」左对齐（与中央 rowActions 的 .fc-table-action-cell 一致）。
+      const isOpColumn = dataIndex === 'operate' || col.title === '操作';
+      let next: ColumnType<RecordType> = isOpColumn ? { ...col, align: col.align ?? 'left', className: classNames(col.className, 'fc-table-op-column') } : col;
+
+      if (autoSortColumns) {
+        // 操作列不排序
+        const sorter = next.sorter !== undefined ? next.sorter : !isOpColumn && !!dataIndex ? defaultComparator(dataIndex as string) : false;
+        next = { ...next, sorter };
+      }
+      return next;
     });
 
     if (hasRowActions) {

--- a/src/components/EnhancedTable/style.less
+++ b/src/components/EnhancedTable/style.less
@@ -24,6 +24,18 @@
   gap: 4px;
 }
 
+// 手写操作列（EnhancedTable 给操作列 td 注入 .fc-table-op-column）：
+// 首个内联 link/text 按钮去左内边距，让文字与「操作」表头左对齐（与 .fc-table-action-cell 一致）。
+// class 开头（不加 td 前缀）：只动 link/text 按钮，不影响 <a>/自定义 span 与多按钮间距。
+.fc-table-op-column {
+  > .ant-btn-link:first-child,
+  > .ant-btn-text:first-child,
+  > .ant-space > .ant-space-item:first-child > .ant-btn-link,
+  > .ant-space > .ant-space-item:first-child > .ant-btn-text {
+    padding-left: 0;
+  }
+}
+
 .fc-table-action-inline-btn-wrap {
   display: inline-flex;
 }

--- a/src/theme/table.less
+++ b/src/theme/table.less
@@ -187,7 +187,8 @@
     width: 24px;
     min-width: 24px;
     height: 24px;
-    margin: 0 0 0 6px;
+    // 排序图标与筛选漏斗同列时两者间距：6px→2px，避免「排序+筛选」列图标离太远、窄列放不下（走查共性）
+    margin: 0 0 0 2px;
     border-radius: 6px;
     color: var(--fc-text-4);
     opacity: 0;


### PR DESCRIPTION
## 背景
srm-fe table 走查发现两个**共性**样式问题。因 9111 集成构建的 `EnhancedTable` / `src/theme` 以 **n9e/fe** 为准（`integrate.js` 不覆盖 fe 已有的共享组件与 theme），故须在本仓修复。对应 srm-fe PR flashcatcloud/srm-fe#1033 的同类改动。

## 改动
1. **操作列内联按钮文字左对齐（整体方案）**
   - `EnhancedTable.tsx`：检测操作列（`dataIndex==='operate'` 或标题「操作」）→ 注入 `.fc-table-op-column` + `align:'left'`。
   - `EnhancedTable/style.less`：`.fc-table-op-column` 去掉首个内联 link/text 按钮左内边距（class-led，只动 link/text 按钮，不影响 `<a>`/自定义 span 与多按钮间距）。
   - 效果：所有走 EnhancedTable 的手写操作列，按钮文字与「操作」表头左对齐；`rowActions` 中央路径本已对齐，不受影响。
2. **排序 + 筛选同列图标间距收紧**
   - `theme/table.less`：`.ant-table-filter-trigger` `margin-left 6px→2px`。
   - 效果：同列既有排序又有筛选时，排序箭头与筛选漏斗不再离太远；窄列（如「数据源类型」）不再放不下被裁。

## 验证
9111 构建 #5215 SUCCESS 部署；浏览器实测：filter-trigger margin=2px、`.fc-table-op-column` 规则存在、「更新人」列排序↔筛选实测间距 6px→2px。

🤖 Generated with [Claude Code](https://claude.com/claude-code)