### PR TITLE
fix(side-menu): align collapsed hover menu hierarchy

### DIFF
--- a/src/components/SideMenu/MenuList.tsx
+++ b/src/components/SideMenu/MenuList.tsx
@@ -33,22 +33,6 @@ interface IMenuProps {
   isLight?: boolean;
 }
 
-function flattenMenuChildrenForHoverPanel(children: IMenuItem[]): IMenuItem[] {
-  return children
-    .flatMap((c) => {
-      if (!c) return [];
-      if (c.type === 'tabs') {
-        return (c.children || []).map((tab) => ({
-          ...tab,
-          type: undefined,
-          children: undefined,
-        }));
-      }
-      return [c];
-    })
-    .filter(Boolean) as IMenuItem[];
-}
-
 function getMenuGroupChildKeys(item: IMenuItem): string[] {
   return (
     (item.children
@@ -619,7 +603,7 @@ export default function MenuList(
               {chunk.items.map((menu) => {
                 if (menu.children?.length) {
                   const visibleChildren = menu.children?.filter((c) => c && (c.type === 'tabs' ? c.children && c.children.length > 0 : true)) || [];
-                  const hoverChildren = flattenMenuChildrenForHoverPanel(visibleChildren);
+                  const hoverChildren = visibleChildren;
                   const hoverEnabled = props.collapsed && hoverChildren.length > 0;
                   const open = hoverEnabled && activeHoverGroupKey === menu.key;
                   const menuGroupActive = isMenuGroupActive(menu, props.selectedKeys);
@@ -686,7 +670,9 @@ export default function MenuList(
                           <div className='sidemenu-hover-panel-divider' aria-hidden />
                           <div className='sidemenu-hover-panel-list'>
                             {hoverChildren.map((c) => {
-                              const isItemActive = props.selectedKeys?.includes(c.key);
+                              const isItemActive = c.type === 'tabs' ? props.selectedKeys?.some((key) => c.children?.some((child) => child.key === key)) : props.selectedKeys?.includes(c.key);
+                              const itemPath = c.type === 'tabs' ? c.children?.[0]?.key || c.key : c.key;
+                              const savedItemPath = c.children ? getSavedPath(itemPath) : c.key;
                               const itemClass = cn(
                                 'group relative flex h-7 min-w-0 cursor-pointer items-center gap-2 rounded-md px-2 text-[13px] leading-[18px] transition-colors duration-150',
                                 isItemActive
@@ -735,7 +721,7 @@ export default function MenuList(
                                 );
                               }
                               return (
-                                <Link key={c.key} to={c.key} className={itemClass} onClick={handleClick}>
+                                <Link key={c.key} to={savedItemPath || itemPath} className={itemClass} onClick={handleClick}>
                                   {itemContent}
                                 </Link>
                               );

--- a/src/components/SideMenu/menu.test.ts
+++ b/src/components/SideMenu/menu.test.ts
@@ -34,4 +34,12 @@ describe('SideMenu hover panel styles', () => {
     expect(lessContent).toMatch(/\.side-menu-profile-avatar\s*\{[\s\S]*?box-sizing:\s*border-box;/);
     expect(lessContent).toMatch(/\.side-menu-profile-avatar-on-light\s*\{[\s\S]*?background:\s*var\(--fc-fill-2\);[\s\S]*?border:\s*1px solid rgb\(var\(--fc-text-link-rgb\) \/ 0\.28\);/);
   });
+
+  it('keeps the collapsed hover panel at the same menu level as the expanded side menu', () => {
+    const menuListPath = path.join(__dirname, 'MenuList.tsx');
+    const menuListContent = fs.readFileSync(menuListPath, 'utf8');
+
+    expect(menuListContent).not.toContain('flattenMenuChildrenForHoverPanel');
+    expect(menuListContent).toContain('const hoverChildren = visibleChildren;');
+  });
 });


### PR DESCRIPTION
## Summary
- Keep the collapsed side-menu hover panel at the same hierarchy level as the expanded side menu.
- Remove the tabs-flattening helper that exposed nested tab leaves directly in the hover panel.
- Preserve tabs active-state and remembered/default child-route navigation behavior in the collapsed hover panel.

## Review
- Ran `/cmt strict` review with project-local rules and React/TypeScript frontend checks.
- No blocker, warn, or info findings.

## Verification
- `npm test -- src/components/SideMenu/menu.test.ts --runInBand` passed.
- `git diff --check` passed.
- `git diff --check HEAD~1 HEAD` passed after merging into `pre`.

## Notes/Risks
- `pre` has been updated and pushed with this branch merged.
- Did not run project-wide build/tsc during `/ship cmt` per repo instruction to prefer lighter focused checks unless explicitly requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved side menu hover behavior so nested items stay aligned with the main menu level.
  * Hover panel links now open the correct saved destination for tab-based items and use the appropriate active state across tab children.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->