### PR TITLE
refactor(clickHouse): align operator naming with CK native SQL keywords

### DIFF
--- a/src/plugins/clickHouse/ExplorerNG/components/QueryBuilder/constants.ts
+++ b/src/plugins/clickHouse/ExplorerNG/components/QueryBuilder/constants.ts
@@ -5,18 +5,25 @@ export const BOOLEAN_TYPES = ['bool', 'boolean'];
 export const IP_TYPES = ['ipv4', 'ipv6'];
 export const FILTERABLE_TYPES = [...NUMBER_TYPES, ...DATE_TYPES, ...STRING_TYPES, ...BOOLEAN_TYPES, ...IP_TYPES];
 
+// Operator constants align with ClickHouse native SQL surface:
+//   - Keywords use upper-case with single spaces (IN / NOT IN / IS NULL /
+//     BETWEEN AND / LIKE / ILIKE), matching CK SQL Reference verbatim.
+//   - Functions use camelCase (match / notMatch / hasToken), matching CK
+//     function names verbatim.
+// See docs/ck-querybuilder-n9e-plus-fe-todo.md §2 for the full matrix.
 export const EQUAL_OPERATORS = ['=', '!='];
 export const COMPARISON_OPERATORS = ['>', '<', '>=', '<='];
-export const IN_OPERATORS = ['in', 'not-in'];
-export const NULL_OPERATORS = ['is-null', 'is-not-null'];
-export const BETWEEN_OPERATORS = ['between', 'not-between'];
-export const LIKE_OPERATORS = ['like', 'not-like', 'ilike', 'not_ilike'];
-export const MATCH_OPERATORS = ['match', 'not_match', 'has_token'];
+export const IN_OPERATORS = ['IN', 'NOT IN'];
+export const NULL_OPERATORS = ['IS NULL', 'IS NOT NULL'];
+export const BETWEEN_OPERATORS = ['BETWEEN AND', 'NOT BETWEEN AND'];
+export const LIKE_OPERATORS = ['LIKE', 'NOT LIKE', 'ILIKE', 'NOT ILIKE'];
+export const MATCH_OPERATORS = ['match', 'notMatch', 'hasToken'];
 
 const SCALAR_OPERATORS = [...EQUAL_OPERATORS, ...IN_OPERATORS, ...NULL_OPERATORS];
 const NUMBER_TYPE_OPERATORS = [...EQUAL_OPERATORS, ...COMPARISON_OPERATORS, ...IN_OPERATORS, ...NULL_OPERATORS, ...BETWEEN_OPERATORS];
 const DATE_TYPE_OPERATORS = NUMBER_TYPE_OPERATORS;
 const STRING_TYPE_OPERATORS = [...EQUAL_OPERATORS, ...IN_OPERATORS, ...NULL_OPERATORS, ...LIKE_OPERATORS, ...MATCH_OPERATORS];
+const IP_TYPE_OPERATORS = [...EQUAL_OPERATORS, ...IN_OPERATORS, ...NULL_OPERATORS, ...BETWEEN_OPERATORS];
 const COMPLEX_TYPE_OPERATORS = NULL_OPERATORS;
 
 export const TYPE_OPERATOR_MAP: Record<string, string[]> = {
@@ -28,8 +35,8 @@ export const TYPE_OPERATOR_MAP: Record<string, string[]> = {
   map: COMPLEX_TYPE_OPERATORS,
   bool: SCALAR_OPERATORS,
   boolean: SCALAR_OPERATORS,
-  ipv4: SCALAR_OPERATORS,
-  ipv6: SCALAR_OPERATORS,
+  ipv4: IP_TYPE_OPERATORS,
+  ipv6: IP_TYPE_OPERATORS,
 };
 
 export const AGGREGATE_FUNCTION_TYPE_MAP: Record<string, string[]> = {

--- a/src/plugins/clickHouse/ExplorerNG/components/QueryBuilder/utils/getOperatorsByTypeIndex.test.ts
+++ b/src/plugins/clickHouse/ExplorerNG/components/QueryBuilder/utils/getOperatorsByTypeIndex.test.ts
@@ -8,13 +8,14 @@ function field(normalized_type: string): Field {
 
 describe('getOperatorsByTypeIndex', () => {
   it.each([
-    ['long', ['=', '!=', '>', '<', '>=', '<=', 'in', 'not-in', 'is-null', 'is-not-null', 'between', 'not-between']],
-    ['date', ['=', '!=', '>', '<', '>=', '<=', 'in', 'not-in', 'is-null', 'is-not-null', 'between', 'not-between']],
-    ['text', ['=', '!=', 'in', 'not-in', 'is-null', 'is-not-null', 'like', 'not-like', 'ilike', 'not_ilike', 'match', 'not_match', 'has_token']],
-    ['bool', ['=', '!=', 'in', 'not-in', 'is-null', 'is-not-null']],
-    ['ipv4', ['=', '!=', 'in', 'not-in', 'is-null', 'is-not-null']],
-    ['json', ['is-null', 'is-not-null']],
-    ['map', ['is-null', 'is-not-null']],
+    ['long', ['=', '!=', '>', '<', '>=', '<=', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL', 'BETWEEN AND', 'NOT BETWEEN AND']],
+    ['date', ['=', '!=', '>', '<', '>=', '<=', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL', 'BETWEEN AND', 'NOT BETWEEN AND']],
+    ['text', ['=', '!=', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL', 'LIKE', 'NOT LIKE', 'ILIKE', 'NOT ILIKE', 'match', 'notMatch', 'hasToken']],
+    ['bool', ['=', '!=', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL']],
+    ['ipv4', ['=', '!=', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL', 'BETWEEN AND', 'NOT BETWEEN AND']],
+    ['ipv6', ['=', '!=', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL', 'BETWEEN AND', 'NOT BETWEEN AND']],
+    ['json', ['IS NULL', 'IS NOT NULL']],
+    ['map', ['IS NULL', 'IS NOT NULL']],
   ])('returns only operators supported by %s', (normalizedType, expected) => {
     expect(getOperatorsByTypeIndex(field(normalizedType))).toEqual(expected);
   });

--- a/src/plugins/clickHouse/ExplorerNG/utils/queryMode.test.ts
+++ b/src/plugins/clickHouse/ExplorerNG/utils/queryMode.test.ts
@@ -9,12 +9,14 @@ describe('ClickHouse Explorer query mode', () => {
   test('keeps a real dotted column name intact', () => {
     expect(
       buildCKFilterFromLogValue({ key: 'service.name', value: null, operator: 'NOT' }, [{ field: 'service.name', type: 'Nullable(String)', normalized_type: 'text' }]),
-    ).toMatchObject({ field: 'service.name', operator: 'is-null', not: true });
+    ).toMatchObject({ field: 'service.name', operator: 'IS NULL', not: true });
   });
 
   test('enables highlighting only for positive text filters', () => {
-    expect(hasHighlightableFilter([{ field: 'message', operator: 'ilike', value: '%error%' }])).toBe(true);
-    expect(hasHighlightableFilter([{ field: 'message', operator: 'not_ilike', value: '%error%' }])).toBe(false);
+    expect(hasHighlightableFilter([{ field: 'message', operator: 'ILIKE', value: '%error%' }])).toBe(true);
+    expect(hasHighlightableFilter([{ field: 'message', operator: 'NOT ILIKE', value: '%error%' }])).toBe(false);
+    expect(hasHighlightableFilter([{ field: 'message', operator: 'hasToken', value: 'timeout' }])).toBe(true);
+    expect(hasHighlightableFilter([{ field: 'message', operator: 'notMatch', value: 'x' }])).toBe(false);
     expect(hasHighlightableFilter([{ field: 'status', operator: '=', value: 500 }])).toBe(false);
   });
 
@@ -28,9 +30,9 @@ describe('ClickHouse Explorer query mode', () => {
   });
 
   test('exposes CK-native text operators and advanced aggregates', () => {
-    expect(TYPE_OPERATOR_MAP.text).toEqual(expect.arrayContaining(['ilike', 'not_ilike', 'match', 'not_match', 'has_token']));
-    expect(TYPE_OPERATOR_MAP.json).toEqual(['is-null', 'is-not-null']);
-    expect(TYPE_OPERATOR_MAP.map).toEqual(['is-null', 'is-not-null']);
+    expect(TYPE_OPERATOR_MAP.text).toEqual(expect.arrayContaining(['ILIKE', 'NOT ILIKE', 'match', 'notMatch', 'hasToken']));
+    expect(TYPE_OPERATOR_MAP.json).toEqual(['IS NULL', 'IS NOT NULL']);
+    expect(TYPE_OPERATOR_MAP.map).toEqual(['IS NULL', 'IS NOT NULL']);
     expect(Object.keys(AGGREGATE_FUNCTION_TYPE_MAP)).toEqual(expect.arrayContaining(['TOPN', 'RATIO', 'EXIST_RATIO', 'PERCENTILE', 'VARIANCE', 'STDDEV']));
   });
 });

--- a/src/plugins/clickHouse/ExplorerNG/utils/queryMode.ts
+++ b/src/plugins/clickHouse/ExplorerNG/utils/queryMode.ts
@@ -3,7 +3,10 @@ import { OnValueFilterParams } from '@/pages/logExplorer/components/LogsViewer/t
 import { isCKDateType } from '../../constants';
 import { Field, FilterConfig } from '../types';
 
-const HIGHLIGHTABLE_OPERATORS = new Set(['=', 'in', 'like', 'ilike', 'has_token', 'match']);
+// Positive-text operators that BE PrepareHighlightTerms in
+// plus/datasource/ck/highlight.go accepts. Kept in canonical form (see
+// constants.ts) so the FE gate mirrors the BE contract exactly.
+const HIGHLIGHTABLE_OPERATORS = new Set(['=', 'IN', 'LIKE', 'ILIKE', 'hasToken', 'match']);
 
 export function buildCKFilterFromLogValue(params: OnValueFilterParams, indexData: Field[]): FilterConfig | undefined {
   if (!indexData.some((item) => item.field === params.key)) return undefined;
@@ -11,7 +14,7 @@ export function buildCKFilterFromLogValue(params: OnValueFilterParams, indexData
   return {
     logic: 'and',
     field: params.key,
-    operator: params.value === null ? 'is-null' : '=',
+    operator: params.value === null ? 'IS NULL' : '=',
     value: params.value,
     not: params.operator.toUpperCase() === 'NOT',
   };
@@ -19,8 +22,8 @@ export function buildCKFilterFromLogValue(params: OnValueFilterParams, indexData
 
 export function hasHighlightableFilter(filters: FilterConfig[] = []): boolean {
   return filters.some((filter) => {
-    const operator = (filter.operator || '').toLowerCase();
-    if (filter.not || operator.startsWith('not')) return false;
+    const operator = filter.operator || '';
+    if (filter.not) return false;
     if (!HIGHLIGHTABLE_OPERATORS.has(operator)) return false;
     const values = Array.isArray(filter.value) ? filter.value : [filter.value];
     return values.some((value) => typeof value === 'string' && value.length > 0);


### PR DESCRIPTION
## Summary

CK QueryBuilder operator naming was kebab-case (`not-in` / `is-null` / `has_token`), out of sync with what users write in hand-authored CK SQL (`NOT IN` / `IS NULL` / `hasToken`). This PR aligns FE constants to CK native SQL Reference verbatim so filter chips, SQL preview, and QueryBuilder dropdowns show the same tokens users type.

- **Keywords** use upper-case with single spaces: `IN` / `NOT IN` / `IS NULL` / `IS NOT NULL` / `BETWEEN AND` / `NOT BETWEEN AND` / `LIKE` / `NOT LIKE` / `ILIKE` / `NOT ILIKE`
- **Functions** use camelCase: `match` / `notMatch` / `hasToken`
- Add `BETWEEN AND` / `NOT BETWEEN AND` for `ipv4` / `ipv6` (ipv4 底层 UInt32; ipv6 底层 FixedString(16) 大端字节序 == 数值序)
- Refactor `queryMode.hasHighlightableFilter` from `toLowerCase() + startsWith('not')` heuristic to explicit-set match (mirrors BE `PrepareHighlightTerms` allow-list exactly, no more accidental match on `notMatch` as "not-prefix")

Pair with n9e-plus BE: [db3656ab refactor(ck): align operator naming with clickhouse native SQL keywords](https://github.com/flashcatcloud/n9e-plus/commit/db3656ab)

## Test plan

- [x] `npx jest src/plugins/clickHouse` — 45 tests pass (added ipv6 case in `getOperatorsByTypeIndex.test.ts`; updated `queryMode.test.ts` for new operator values + explicit `hasToken` / `notMatch` gates)
- [ ] 手动: 打开 CK Explorer → 添加 filter → 确认下拉里的算子文案是 `IN` / `NOT IN` / `hasToken` 而不是老的 kebab
- [ ] 手动: ipv4 / ipv6 字段的 filter 下拉现在应该多出 `BETWEEN AND` / `NOT BETWEEN AND`
- [ ] 手动: `message ILIKE '%error%'` filter 时 SQL preview + 命中行高亮片段正常

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated ClickHouse query operators to use canonical SQL formatting, including uppercase keywords and correct spacing.
  * Improved operator handling for IPv4 and IPv6 fields.
  * Corrected null-value filters to use `IS NULL`.
  * Updated filter highlighting to recognize ClickHouse-native operators, including `ILIKE`, `hasToken`, and `notMatch`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->