### PR TITLE
refactor(clickHouse)!: drop `not` flag, express negation only via operator

### DIFF
--- a/src/plugins/clickHouse/ExplorerNG/types.ts
+++ b/src/plugins/clickHouse/ExplorerNG/types.ts
@@ -3,12 +3,15 @@ import { Field as BaseField } from '@/pages/logExplorer/types';
 
 export type HandleValueFilterParams = (params: OnValueFilterParams) => void;
 
+// Negation is expressed via the operator (`!=`, `NOT IN`, `IS NOT NULL`,
+// `NOT LIKE`, `NOT ILIKE`, `NOT BETWEEN AND`, `notMatch`) — there is no
+// separate `not` flag. Mirrors the CK BE contract in
+// plus/datasource/ck/ck.go:QueryBuilderFilterItem.
 export interface FilterConfig {
   logic?: 'and' | 'or';
   field?: string;
   operator?: string;
   value?: string | number | boolean | null | Array<string | number | boolean | null>;
-  not?: boolean;
   disabled?: boolean;
 }
 

--- a/src/plugins/clickHouse/ExplorerNG/utils/queryMode.test.ts
+++ b/src/plugins/clickHouse/ExplorerNG/utils/queryMode.test.ts
@@ -9,7 +9,24 @@ describe('ClickHouse Explorer query mode', () => {
   test('keeps a real dotted column name intact', () => {
     expect(
       buildCKFilterFromLogValue({ key: 'service.name', value: null, operator: 'NOT' }, [{ field: 'service.name', type: 'Nullable(String)', normalized_type: 'text' }]),
-    ).toMatchObject({ field: 'service.name', operator: 'IS NULL', not: true });
+    ).toMatchObject({ field: 'service.name', operator: 'IS NOT NULL' });
+  });
+
+  test('maps LogsViewer intent onto operator (no `not` flag)', () => {
+    const indexData = [{ field: 'level', type: 'String', normalized_type: 'text' }];
+    // AND + value → equality
+    expect(buildCKFilterFromLogValue({ key: 'level', value: 'warn', operator: 'AND' }, indexData)).toMatchObject({ operator: '=', value: 'warn' });
+    // AND + null → IS NULL
+    expect(buildCKFilterFromLogValue({ key: 'level', value: null, operator: 'AND' }, indexData)).toMatchObject({ operator: 'IS NULL' });
+    // NOT + value → !=
+    expect(buildCKFilterFromLogValue({ key: 'level', value: 'warn', operator: 'NOT' }, indexData)).toMatchObject({ operator: '!=', value: 'warn' });
+    // NOT + null → IS NOT NULL
+    expect(buildCKFilterFromLogValue({ key: 'level', value: null, operator: 'NOT' }, indexData)).toMatchObject({ operator: 'IS NOT NULL' });
+    // EXISTS → IS NOT NULL regardless of value
+    expect(buildCKFilterFromLogValue({ key: 'level', value: 'anything', operator: 'EXISTS' }, indexData)).toMatchObject({ operator: 'IS NOT NULL' });
+    // No filter should carry a `not` property anymore.
+    const filter = buildCKFilterFromLogValue({ key: 'level', value: 'warn', operator: 'NOT' }, indexData);
+    expect(filter).not.toHaveProperty('not');
   });
 
   test('enables highlighting only for positive text filters', () => {

--- a/src/plugins/clickHouse/ExplorerNG/utils/queryMode.ts
+++ b/src/plugins/clickHouse/ExplorerNG/utils/queryMode.ts
@@ -8,15 +8,31 @@ import { Field, FilterConfig } from '../types';
 // constants.ts) so the FE gate mirrors the BE contract exactly.
 const HIGHLIGHTABLE_OPERATORS = new Set(['=', 'IN', 'LIKE', 'ILIKE', 'hasToken', 'match']);
 
+// Map the LogsViewer token-menu intent (AND/NOT/EXISTS) directly to a CK
+// operator. Negation lives entirely in the operator space (no `not` flag on
+// the filter) so the QueryBuilder chip renders truthfully and the BE payload
+// is unambiguous — see docs/ck-querybuilder-aggregate-golden-lessons-learned §K.
 export function buildCKFilterFromLogValue(params: OnValueFilterParams, indexData: Field[]): FilterConfig | undefined {
   if (!indexData.some((item) => item.field === params.key)) return undefined;
+
+  const intent = params.operator.toUpperCase();
+  let operator: string;
+  if (intent === 'EXISTS') {
+    // Token menu "field exists" — always IS NOT NULL regardless of the
+    // triggering value.
+    operator = 'IS NOT NULL';
+  } else if (intent === 'NOT') {
+    operator = params.value === null ? 'IS NOT NULL' : '!=';
+  } else {
+    // 'AND' or unknown intent → positive filter
+    operator = params.value === null ? 'IS NULL' : '=';
+  }
 
   return {
     logic: 'and',
     field: params.key,
-    operator: params.value === null ? 'IS NULL' : '=',
+    operator,
     value: params.value,
-    not: params.operator.toUpperCase() === 'NOT',
   };
 }
 
@@ -24,7 +40,6 @@ export function hasHighlightableFilter(filters: FilterConfig[] = []): boolean {
   return filters.some((filter) => {
     if (filter.disabled) return false;
     const operator = filter.operator || '';
-    if (filter.not) return false;
     if (!HIGHLIGHTABLE_OPERATORS.has(operator)) return false;
     const values = Array.isArray(filter.value) ? filter.value : [filter.value];
     return values.some((value) => typeof value === 'string' && value.length > 0);


### PR DESCRIPTION
## Summary

Sync FE with n9e-plus BE contract change: `QueryBuilderFilterItem` no longer carries a `not: boolean` flag — negation lives entirely in the operator space (`!=` / `NOT IN` / `IS NOT NULL` / `NOT LIKE` / `NOT ILIKE` / `NOT BETWEEN AND` / `notMatch`).

**Before**: LogsViewer "exclude value" produced `{ operator: '=', value: 'warning', not: true }`, so the QueryBuilder chip rendered a positive filter while the SQL generated `NOT (event_severity = 'warning')` — UI text and semantics were reversed.

**After**: `buildCKFilterFromLogValue` maps the intent (`AND` / `NOT` / `EXISTS`) directly to a CK operator:

| Intent | Value | Operator |
|---|---|---|
| `AND` | `!= null` | `=` |
| `AND` | `null` | `IS NULL` |
| `NOT` | `!= null` | `!=` |
| `NOT` | `null` | `IS NOT NULL` |
| `EXISTS` | any | `IS NOT NULL` |

The chip now shows the true operator; BE generates CK-native reverse keywords instead of `NOT (...)` wrappers.

## Design & rationale

Full write-up (design review, alternatives, hidden-bug fix): [`docs/ck-querybuilder-aggregate-golden-lessons-learned.md` §K in n9e-plus](https://github.com/flashcatcloud/n9e-plus/blob/dev/docs/ck-querybuilder-aggregate-golden-lessons-learned.md) (local-only doc — see summary above).

## BREAKING

`FilterConfig.not?: boolean` removed. Project in dev; no back-compat shim. Users with stale browser cache holding filter state with `not: true` will see reversed semantics until page reload.

Also incidentally fixes a pre-existing bug: previously `operator === 'EXISTS'` fell through to `operator: '='` (LogsViewer's "field exists" button produced a wrong filter). Now correctly maps to `IS NOT NULL`.

## Companion PR

n9e-plus: [`refactor(ck)!: drop \`not\` field, express negation only via operator`](https://github.com/flashcatcloud/n9e-plus/commit/7e8c6230) — already merged to `dev`.

Doris FE is **untouched** (Doris ExplorerNG uses KQL string concat and never populates `not: true`; the `Not` field on Doris BE is dead code awaiting a separate cleanup ticket).

## Test plan

- [x] `npx jest src/plugins/clickHouse` — 47 tests pass (5 new cases covering AND/NOT × value/null + EXISTS + `not` property absence assertion)
- [x] `npx tsc --noEmit -p tsconfig.json` clean
- [ ] After deploy to test env: LogsViewer → click "exclude value" on some field → verify chip shows `!=` (not `=`), verify SQL query returns rows that don't match the excluded value
- [ ] LogsViewer → click "field exists" → verify chip shows `IS NOT NULL`, query returns non-null rows

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ClickHouse filter handling for negated conditions, including null checks and existence queries.
  * Ensured filters use consistent operators across query building and highlighting.
  * Updated query behavior to correctly support operators such as `IS NOT NULL`, `!=`, and `NOT IN`.

* **Tests**
  * Expanded coverage for filter operator and value combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->