### PR TITLE
fix(ck-explorer): rename `notMatch` operator to `NOT match`

### DIFF
--- a/src/plugins/clickHouse/ExplorerNG/components/QueryBuilder/constants.ts
+++ b/src/plugins/clickHouse/ExplorerNG/components/QueryBuilder/constants.ts
@@ -8,8 +8,10 @@ export const FILTERABLE_TYPES = [...NUMBER_TYPES, ...DATE_TYPES, ...STRING_TYPES
 // Operator constants align with ClickHouse native SQL surface:
 //   - Keywords use upper-case with single spaces (IN / NOT IN / IS NULL /
 //     BETWEEN AND / LIKE / ILIKE), matching CK SQL Reference verbatim.
-//   - Functions use camelCase (match / notMatch / hasToken), matching CK
-//     function names verbatim.
+//   - Functions use camelCase (match / hasToken), matching CK function
+//     names verbatim. Negated function reads as keyword + function:
+//     `NOT match` mirrors the SQL the BE emits — `NOT match(f, 'p')` —
+//     because no CK OSS version has a `notMatch()` function.
 // See docs/ck-querybuilder-n9e-plus-fe-todo.md §2 for the full matrix.
 export const EQUAL_OPERATORS = ['=', '!='];
 export const COMPARISON_OPERATORS = ['>', '<', '>=', '<='];
@@ -17,7 +19,7 @@ export const IN_OPERATORS = ['IN', 'NOT IN'];
 export const NULL_OPERATORS = ['IS NULL', 'IS NOT NULL'];
 export const BETWEEN_OPERATORS = ['BETWEEN AND', 'NOT BETWEEN AND'];
 export const LIKE_OPERATORS = ['LIKE', 'NOT LIKE', 'ILIKE', 'NOT ILIKE'];
-export const MATCH_OPERATORS = ['match', 'notMatch', 'hasToken'];
+export const MATCH_OPERATORS = ['match', 'NOT match', 'hasToken'];
 
 const SCALAR_OPERATORS = [...EQUAL_OPERATORS, ...IN_OPERATORS, ...NULL_OPERATORS];
 const NUMBER_TYPE_OPERATORS = [...EQUAL_OPERATORS, ...COMPARISON_OPERATORS, ...IN_OPERATORS, ...NULL_OPERATORS, ...BETWEEN_OPERATORS];

--- a/src/plugins/clickHouse/ExplorerNG/components/QueryBuilder/utils/getOperatorsByTypeIndex.test.ts
+++ b/src/plugins/clickHouse/ExplorerNG/components/QueryBuilder/utils/getOperatorsByTypeIndex.test.ts
@@ -10,7 +10,7 @@ describe('getOperatorsByTypeIndex', () => {
   it.each([
     ['long', ['=', '!=', '>', '<', '>=', '<=', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL', 'BETWEEN AND', 'NOT BETWEEN AND']],
     ['date', ['=', '!=', '>', '<', '>=', '<=', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL', 'BETWEEN AND', 'NOT BETWEEN AND']],
-    ['text', ['=', '!=', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL', 'LIKE', 'NOT LIKE', 'ILIKE', 'NOT ILIKE', 'match', 'notMatch', 'hasToken']],
+    ['text', ['=', '!=', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL', 'LIKE', 'NOT LIKE', 'ILIKE', 'NOT ILIKE', 'match', 'NOT match', 'hasToken']],
     ['bool', ['=', '!=', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL']],
     ['ipv4', ['=', '!=', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL', 'BETWEEN AND', 'NOT BETWEEN AND']],
     ['ipv6', ['=', '!=', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL', 'BETWEEN AND', 'NOT BETWEEN AND']],

--- a/src/plugins/clickHouse/ExplorerNG/types.ts
+++ b/src/plugins/clickHouse/ExplorerNG/types.ts
@@ -4,7 +4,7 @@ import { Field as BaseField } from '@/pages/logExplorer/types';
 export type HandleValueFilterParams = (params: OnValueFilterParams) => void;
 
 // Negation is expressed via the operator (`!=`, `NOT IN`, `IS NOT NULL`,
-// `NOT LIKE`, `NOT ILIKE`, `NOT BETWEEN AND`, `notMatch`) — there is no
+// `NOT LIKE`, `NOT ILIKE`, `NOT BETWEEN AND`, `NOT match`) — there is no
 // separate `not` flag. Mirrors the CK BE contract in
 // plus/datasource/ck/ck.go:QueryBuilderFilterItem.
 export interface FilterConfig {

--- a/src/plugins/clickHouse/ExplorerNG/utils/queryMode.test.ts
+++ b/src/plugins/clickHouse/ExplorerNG/utils/queryMode.test.ts
@@ -33,7 +33,7 @@ describe('ClickHouse Explorer query mode', () => {
     expect(hasHighlightableFilter([{ field: 'message', operator: 'ILIKE', value: '%error%' }])).toBe(true);
     expect(hasHighlightableFilter([{ field: 'message', operator: 'NOT ILIKE', value: '%error%' }])).toBe(false);
     expect(hasHighlightableFilter([{ field: 'message', operator: 'hasToken', value: 'timeout' }])).toBe(true);
-    expect(hasHighlightableFilter([{ field: 'message', operator: 'notMatch', value: 'x' }])).toBe(false);
+    expect(hasHighlightableFilter([{ field: 'message', operator: 'NOT match', value: 'x' }])).toBe(false);
     expect(hasHighlightableFilter([{ field: 'status', operator: '=', value: 500 }])).toBe(false);
   });
 
@@ -47,7 +47,7 @@ describe('ClickHouse Explorer query mode', () => {
   });
 
   test('exposes CK-native text operators and advanced aggregates', () => {
-    expect(TYPE_OPERATOR_MAP.text).toEqual(expect.arrayContaining(['ILIKE', 'NOT ILIKE', 'match', 'notMatch', 'hasToken']));
+    expect(TYPE_OPERATOR_MAP.text).toEqual(expect.arrayContaining(['ILIKE', 'NOT ILIKE', 'match', 'NOT match', 'hasToken']));
     expect(TYPE_OPERATOR_MAP.json).toEqual(['IS NULL', 'IS NOT NULL']);
     expect(TYPE_OPERATOR_MAP.map).toEqual(['IS NULL', 'IS NOT NULL']);
     expect(Object.keys(AGGREGATE_FUNCTION_TYPE_MAP)).toEqual(expect.arrayContaining(['TOPN', 'RATIO', 'EXIST_RATIO', 'PERCENTILE', 'VARIANCE', 'STDDEV']));


### PR DESCRIPTION
## Summary

- `MATCH_OPERATORS` 里的 `notMatch` 改成 `NOT match`（keyword + function
  的读法），与 BE 生成的 SQL `NOT match(f, 'p')` 一一对应
- Explorer QueryBuilder operator dropdown 里 CK operators 不再展示 CK OSS
  实际不存在的 `notMatch()` 函数名——`SELECT notMatch('a','b')` 在 21.8
  ~ 25.3 全部返回 UNKNOWN_FUNCTION
- 同步更新 2 个 jest 测试与 1 个类型注释

## Wire 兼容

BE `normalizeOperator` compact-lowercase-space 归一后 `"NOT match"` /
`"not match"` / `"notMatch"` 都 fold 到同一 canonical，无需迁移旧
saved filter payload。BE 侧已加 tolerance test 用例（`{"NOT match","notMatch"}`
+ `{"not match","notMatch"}`），见 n9e-plus `feat/ck-notmatch-compat`。

## Verified

- `jest src/plugins/clickHouse/ExplorerNG/utils/queryMode.test.ts src/plugins/clickHouse/ExplorerNG/components/QueryBuilder/utils/getOperatorsByTypeIndex.test.ts`
  → 2 suites / 15 tests PASS
- `tsc --noEmit -p tsconfig.json` → clean

## 相关

- n9e-plus BE 主 fix：`5dced56d fix(ck): emit \`NOT match(...)\` for notMatch operator; add match-family E2E guard`（已在 dev 上）
- 上下文：`docs/ck-querybuilder-aggregate-golden-lessons-learned.md §N`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the ClickHouse query builder to use the correct `NOT match` operator syntax.
  * Improved consistency between generated SQL, operator selection, and query highlighting behavior.

* **Tests**
  * Updated operator and query mode tests to validate the corrected syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->