### PR TITLE
feat(dashboard-variables): add query init guard and datasource-aware …

### DIFF
--- a/src/pages/dashboard/Detail/Detail.tsx
+++ b/src/pages/dashboard/Detail/Detail.tsx
@@ -121,6 +121,8 @@ export default function DetailV2(props: IProps) {
   const [allowedLeave, setAllowedLeave] = useState(true);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [variablesInitialized, setVariablesInitialized] = useState(false);
+  const hasQueryVariables = _.some(variablesWithOptions, (item) => item.type === 'query');
+  const queryEnabled = !hasQueryVariables || variablesInitialized;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const editModalVariablecontainerRef = useRef<HTMLDivElement>(null);
@@ -433,6 +435,7 @@ export default function DetailV2(props: IProps) {
                 setHasUnsavedChanges={setHasUnsavedChanges}
                 range={range}
                 setRange={setRange}
+                queryEnabled={queryEnabled}
                 timezone={timezone}
                 setTimezone={(newTimezone) => {
                   setTimezone(newTimezone);

--- a/src/pages/dashboard/Panels/index.tsx
+++ b/src/pages/dashboard/Panels/index.tsx
@@ -62,6 +62,7 @@ interface IProps {
   setHasUnsavedChanges: (flag: boolean) => void;
   range: IRawTimeRange;
   setRange: (range: IRawTimeRange) => void;
+  queryEnabled?: boolean;
   timezone: string;
   setTimezone: (timezone: string) => void;
   panels: any[];
@@ -92,6 +93,7 @@ function index(props: IProps) {
     setAllowedLeave,
     setHasUnsavedChanges,
     range,
+    queryEnabled,
     timezone,
     setTimezone,
     panels,
@@ -277,6 +279,7 @@ function index(props: IProps) {
                       id={item.id}
                       time={range}
                       setRange={props.setRange}
+                      queryEnabled={queryEnabled}
                       timezone={timezone}
                       setTimezone={setTimezone}
                       values={item}

--- a/src/pages/dashboard/Renderer/Renderer/index.tsx
+++ b/src/pages/dashboard/Renderer/Renderer/index.tsx
@@ -39,6 +39,7 @@ export interface IProps {
   id: string;
   time: IRawTimeRange;
   setRange?: (range: IRawTimeRange) => void;
+  queryEnabled?: boolean;
   timezone?: string; // 时区
   setTimezone?: (timezone: string) => void; // 设置时区
   values: IPanel;
@@ -55,7 +56,7 @@ export interface IProps {
 
 function index(props: IProps) {
   const { t } = useTranslation('dashboard');
-  const { panelWidth, datasourceValue, id, time, setRange, timezone, setTimezone, isPreview } = props;
+  const { panelWidth, datasourceValue, id, time, setRange, queryEnabled, timezone, setTimezone, isPreview } = props;
   const { datasourceList } = useContext(CommonStateContext);
   const values = _.cloneDeep(props.values);
   const containerEleRef = useRef<HTMLDivElement>(null);
@@ -76,6 +77,7 @@ function index(props: IProps) {
     id,
     time,
     targets: values.targets,
+    queryEnabled,
     inViewPort: isPreview || inViewPort,
     datasourceCate: values.datasourceCate || 'prometheus',
     datasourceValue: currentDatasourceValue,

--- a/src/pages/dashboard/Renderer/datasource/useQuery.tsx
+++ b/src/pages/dashboard/Renderer/datasource/useQuery.tsx
@@ -40,6 +40,7 @@ interface IProps {
   datasourceValue?: number;
   time: IRawTimeRange;
   targets: ITarget[];
+  queryEnabled?: boolean;
   inViewPort?: boolean;
   spanNulls?: boolean;
   scopedVars?: any;
@@ -51,7 +52,7 @@ interface IProps {
 }
 
 export default function useQuery(props: IProps) {
-  const { datasourceCate, time, targets, inViewPort, spanNulls, datasourceValue, maxDataPoints, queryOptionsTime } = props;
+  const { datasourceCate, time, targets, queryEnabled = true, inViewPort, spanNulls, datasourceValue, maxDataPoints, queryOptionsTime } = props;
   const form = Form.useFormInstance();
   const [variablesWithOptions] = useGlobalState('variablesWithOptions');
   // beta.5 新增 range 状态，用于 uplot 图表更新时 time 和 data 同时更新
@@ -79,6 +80,7 @@ export default function useQuery(props: IProps) {
   };
   const { run: fetchData } = useDebounceFn(
     async () => {
+      if (!queryEnabled) return;
       if (!datasourceCate) return;
       // 如果在编辑状态，需要校验表单
       if (form && typeof form.validateFields === 'function') {
@@ -122,21 +124,21 @@ export default function useQuery(props: IProps) {
 
   useEffect(() => {
     // 配置变化时且图表在可视区域内重新请求数据，同时重置 flag
-    if (inViewPort) {
+    if (queryEnabled && inViewPort) {
       fetchData();
     } else {
       flag.current = false;
     }
     // TODO 这里 JSON.stringify(variablesWithOptions) 可能会有性能问题
-  }, [JSON.stringify(targets), JSON.stringify(time), JSON.stringify(variablesWithOptions), spanNulls, datasourceValue, maxDataPoints, JSON.stringify(queryOptionsTime)]);
+  }, [queryEnabled, JSON.stringify(targets), JSON.stringify(time), JSON.stringify(variablesWithOptions), spanNulls, datasourceValue, maxDataPoints, JSON.stringify(queryOptionsTime)]);
 
   useEffect(() => {
     // 如果图表在可视区域内并且没有请求过数据，则请求数据
-    if (inViewPort && !flag.current) {
+    if (queryEnabled && inViewPort && !flag.current) {
       flag.current = true;
       fetchData();
     }
-  }, [inViewPort]);
+  }, [queryEnabled, inViewPort]);
 
   return { query, series, error, loading, loaded, range };
 }

--- a/src/pages/dashboard/VariableConfig/EditItem.tsx
+++ b/src/pages/dashboard/VariableConfig/EditItem.tsx
@@ -28,6 +28,7 @@ import { Dashboard } from '@/store/dashboardInterface';
 import { IVariable } from './definition';
 import { stringToRegex } from './constant';
 import Querybuilder from './Querybuilder';
+import { isQueryVariableMultiSelectEnabled } from '../Variables/EditModal/Variable/queryUtils';
 
 interface IProps {
   id: string;
@@ -82,6 +83,9 @@ function EditItem(props: IProps) {
   const otherVars = _.filter(vars, (item) => item.name !== data.name);
   const varType = Form.useWatch(['type'], form);
   const datesourceCate = Form.useWatch(['datasource', 'cate'], form);
+  const legacyQueryType = Form.useWatch(['query', 'type'], form);
+  const gcmQueryType = Form.useWatch(['query', 'query_type'], form);
+  const queryType = legacyQueryType || gcmQueryType;
 
   return (
     <Form layout='vertical' autoComplete='off' preserve={false} form={form} initialValues={data}>
@@ -361,7 +365,7 @@ function EditItem(props: IProps) {
         </>
       )}
       {(_.includes(['custom', 'hostIdent'], varType) ||
-        _.includes([DatasourceCateEnum.prometheus, DatasourceCateEnum.elasticsearch, DatasourceCateEnum.pgsql], datesourceCate)) && (
+        (varType === 'query' && isQueryVariableMultiSelectEnabled(datesourceCate, queryType))) && (
         <Row gutter={16}>
           <Col flex='120px'>
             <Form.Item label={t('var.multi')} name='multi' valuePropName='checked'>

--- a/src/pages/dashboard/VariableConfig/index.tsx
+++ b/src/pages/dashboard/VariableConfig/index.tsx
@@ -173,7 +173,7 @@ function index(props: IProps) {
               }
             } else {
               try {
-                options = await datasource({
+                const rawResult = await datasource({
                   dashboardId: id,
                   datasourceCate,
                   datasourceValue,
@@ -184,8 +184,17 @@ function index(props: IProps) {
                     definition,
                   },
                 });
-                options = _.sortBy(_.uniq(options));
-                options = _.map(options, _.toString);
+                const flattenedOptions: string[] = [];
+                if (Array.isArray(rawResult)) {
+                  for (const item of rawResult) {
+                    if (typeof item === 'string') {
+                      flattenedOptions.push(item);
+                    } else if (typeof item === 'object' && item !== null) {
+                      flattenedOptions.push(String(item.value ?? (item as { label?: string }).label ?? ''));
+                    }
+                  }
+                }
+                options = _.uniq(flattenedOptions);
               } catch (error) {
                 console.error(error);
               }

--- a/src/pages/dashboard/Variables/EditModal/Variable/Query.tsx
+++ b/src/pages/dashboard/Variables/EditModal/Variable/Query.tsx
@@ -84,8 +84,9 @@ export default function Query(props: Props) {
           config: item.config, // config 是 es 特有的写法
         },
       })
-        .then((options) => {
-          const itemOptions = _.sortBy(normalizeQueryOptions(options, formatedReg, datasourceCate), 'value');
+        .then((res: { label: string; value: string }[] | string[]) => {
+          const normalized = normalizeQueryOptions(res, formatedReg, datasourceCate);
+          const itemOptions: { label: string; value: string }[] = _.sortBy(normalized, 'value');
           setOptions(itemOptions);
           setErrorMsg('');
         })

--- a/src/pages/dashboard/Variables/EditModal/Variable/Query.tsx
+++ b/src/pages/dashboard/Variables/EditModal/Variable/Query.tsx
@@ -15,11 +15,12 @@ import { IVariable } from '../../types';
 import adjustData from '../../utils/ajustData';
 import isPlaceholderQuoted from '../../utils/isPlaceholderQuoted';
 import { formatString, formatDatasource } from '../../utils/formatString';
-import filterOptionsByReg from '../../utils/filterOptionsByReg';
+import normalizeQueryOptions from '../../utils/normalizeQueryOptions';
 import { getBuiltInVariables } from '../../utils/replaceTemplateVariables';
 import Querybuilder from '../Querybuilder';
 import datasource from '../../datasource';
 import Preview from '../Preview';
+import { isQueryVariableMultiSelectEnabled } from './queryUtils';
 
 interface Props {
   formatedReg: string;
@@ -43,6 +44,9 @@ export default function Query(props: Props) {
   const form = Form.useFormInstance();
   const item = Form.useWatch<IVariable>([]);
   const datasourceCate = Form.useWatch(['datasource', 'cate']);
+  const legacyQueryType = Form.useWatch(['query', 'type']);
+  const gcmQueryType = Form.useWatch(['query', 'query_type']);
+  const queryType = legacyQueryType || gcmQueryType;
 
   const service = () => {
     if (item) {
@@ -81,7 +85,7 @@ export default function Query(props: Props) {
         },
       })
         .then((options) => {
-          const itemOptions = _.sortBy(filterOptionsByReg(_.map(options, _.toString), formatedReg), 'value');
+          const itemOptions = _.sortBy(normalizeQueryOptions(options, formatedReg, datasourceCate), 'value');
           setOptions(itemOptions);
           setErrorMsg('');
         })
@@ -194,7 +198,7 @@ export default function Query(props: Props) {
       >
         <Input placeholder='/*.hna/' />
       </Form.Item>
-      {_.includes([DatasourceCateEnum.prometheus, DatasourceCateEnum.elasticsearch, DatasourceCateEnum.pgsql, DatasourceCateEnum.mysql], datasourceCate) && (
+      {isQueryVariableMultiSelectEnabled(datasourceCate, queryType) && (
         <Row gutter={16}>
           <Col flex='120px'>
             <Form.Item label={t('var.multi')} name='multi' valuePropName='checked'>

--- a/src/pages/dashboard/Variables/EditModal/Variable/queryUtils.test.ts
+++ b/src/pages/dashboard/Variables/EditModal/Variable/queryUtils.test.ts
@@ -1,0 +1,55 @@
+/// <reference types="jest" />
+
+jest.mock('lodash', () => {
+  const lodash = jest.requireActual('lodash');
+  return {
+    __esModule: true,
+    default: lodash,
+    ...lodash,
+  };
+});
+
+jest.mock(
+  '@/utils/constant',
+  () => ({
+    __esModule: true,
+    DatasourceCateEnum: {
+      prometheus: 'prometheus',
+      elasticsearch: 'elasticsearch',
+      pgsql: 'pgsql',
+      mysql: 'mysql',
+      cloudwatch: 'cloudwatch',
+      gcm: 'gcm',
+    },
+  }),
+  { virtual: true },
+);
+
+import { isQueryVariableMultiSelectEnabled } from './queryUtils';
+
+describe('isQueryVariableMultiSelectEnabled', () => {
+  test('keeps existing datasource types enabled', () => {
+    expect(isQueryVariableMultiSelectEnabled('prometheus')).toBe(true);
+    expect(isQueryVariableMultiSelectEnabled('elasticsearch')).toBe(true);
+    expect(isQueryVariableMultiSelectEnabled('pgsql')).toBe(true);
+    expect(isQueryVariableMultiSelectEnabled('mysql')).toBe(true);
+  });
+
+  test('enables cloudwatch only for dimensionValues queries', () => {
+    expect(isQueryVariableMultiSelectEnabled('cloudwatch', 'dimensionValues')).toBe(true);
+    expect(isQueryVariableMultiSelectEnabled('cloudwatch', 'regions')).toBe(false);
+    expect(isQueryVariableMultiSelectEnabled('cloudwatch', 'metrics')).toBe(false);
+  });
+
+  test('enables gcm only for labelValues queries', () => {
+    expect(isQueryVariableMultiSelectEnabled('gcm', 'labelValues')).toBe(true);
+    expect(isQueryVariableMultiSelectEnabled('gcm', 'projects')).toBe(false);
+    expect(isQueryVariableMultiSelectEnabled('gcm', 'services')).toBe(false);
+    expect(isQueryVariableMultiSelectEnabled('gcm', 'metricTypes')).toBe(false);
+    expect(isQueryVariableMultiSelectEnabled('gcm', 'labelKeys')).toBe(false);
+    expect(isQueryVariableMultiSelectEnabled('gcm', 'resourceTypes')).toBe(false);
+    expect(isQueryVariableMultiSelectEnabled('gcm', 'aggregations')).toBe(false);
+    expect(isQueryVariableMultiSelectEnabled('gcm', 'aligners')).toBe(false);
+    expect(isQueryVariableMultiSelectEnabled('gcm', 'alignmentPeriods')).toBe(false);
+  });
+});

--- a/src/pages/dashboard/Variables/EditModal/Variable/queryUtils.ts
+++ b/src/pages/dashboard/Variables/EditModal/Variable/queryUtils.ts
@@ -1,0 +1,13 @@
+import _ from 'lodash';
+
+import { DatasourceCateEnum } from '@/utils/constant';
+
+export function isQueryVariableMultiSelectEnabled(datasourceCate: string, queryType?: string) {
+  if (_.includes([DatasourceCateEnum.prometheus, DatasourceCateEnum.elasticsearch, DatasourceCateEnum.pgsql, DatasourceCateEnum.mysql], datasourceCate)) {
+    return true;
+  }
+  if (datasourceCate === DatasourceCateEnum.gcm) {
+    return queryType === 'labelValues';
+  }
+  return datasourceCate === DatasourceCateEnum.cloudwatch && queryType === 'dimensionValues';
+}

--- a/src/pages/dashboard/Variables/Variable/Query.tsx
+++ b/src/pages/dashboard/Variables/Variable/Query.tsx
@@ -93,7 +93,8 @@ export default function Query(props: Props) {
       if (requestId !== requestIdRef.current) {
         return;
       }
-      const filteredOptions = _.sortBy(normalizeQueryOptions(options, formatedReg, datasourceCate), 'value');
+      const normalized = normalizeQueryOptions(options, formatedReg, datasourceCate);
+      const filteredOptions: { label: string; value: string }[] = _.sortBy(normalized, 'value');
       updateVariable(name, {
         options: filteredOptions,
         value: getValueByOptions({

--- a/src/pages/dashboard/Variables/Variable/Query.tsx
+++ b/src/pages/dashboard/Variables/Variable/Query.tsx
@@ -10,7 +10,7 @@ import { useGlobalState } from '@/pages/dashboard/globalState';
 import { buildVariableInterpolations } from '../utils/ajustData';
 import { useVariableManager } from '../VariableManagerContext';
 import { formatString, formatDatasource } from '../utils/formatString';
-import filterOptionsByReg from '../utils/filterOptionsByReg';
+import normalizeQueryOptions from '../utils/normalizeQueryOptions';
 import getValueByOptions from '../utils/getValueByOptions';
 import datasource from '../datasource';
 import { Props } from './types';
@@ -93,7 +93,7 @@ export default function Query(props: Props) {
       if (requestId !== requestIdRef.current) {
         return;
       }
-      const filteredOptions = _.sortBy(filterOptionsByReg(_.map(options, _.toString), formatedReg), 'value');
+      const filteredOptions = _.sortBy(normalizeQueryOptions(options, formatedReg, datasourceCate), 'value');
       updateVariable(name, {
         options: filteredOptions,
         value: getValueByOptions({

--- a/src/pages/dashboard/Variables/index.tsx
+++ b/src/pages/dashboard/Variables/index.tsx
@@ -28,12 +28,17 @@ export default function index(props: Props) {
 
   // 追踪 Query 变量的初始化状态
   React.useEffect(() => {
-    if (hasCalledInitializedRef.current || !onInitialized || _.isEmpty(variablesWithOptions)) return;
+    if (!onInitialized) return;
+    if (_.isEmpty(variablesWithOptions)) {
+      hasCalledInitializedRef.current = false;
+      return;
+    }
 
     const queryVariables = _.filter(variablesWithOptions, (item) => item.type === 'query');
 
     // 如果没有 query 类型的变量，立即触发回调
     if (queryVariables.length === 0) {
+      if (hasCalledInitializedRef.current) return;
       hasCalledInitializedRef.current = true;
       onInitialized();
       return;
@@ -44,7 +49,13 @@ export default function index(props: Props) {
       return variable.options !== undefined; // 只要 options 属性存在就算初始化完成，可以是空数组
     });
 
+    if (!allInitialized) {
+      hasCalledInitializedRef.current = false;
+      return;
+    }
+
     if (allInitialized) {
+      if (hasCalledInitializedRef.current) return;
       hasCalledInitializedRef.current = true;
       onInitialized();
     }

--- a/src/pages/dashboard/Variables/utils/__tests__/normalizeQueryOptions.test.ts
+++ b/src/pages/dashboard/Variables/utils/__tests__/normalizeQueryOptions.test.ts
@@ -1,0 +1,22 @@
+/// <reference types="jest" />
+
+import normalizeQueryOptions from '../normalizeQueryOptions';
+
+describe('normalizeQueryOptions', () => {
+  test('keeps string option behavior for non-gcm datasources', () => {
+    expect(normalizeQueryOptions([{ label: 'Project 1', value: 'project-1' }], undefined, 'prometheus')).toEqual([
+      {
+        label: '[object Object]',
+        value: '[object Object]',
+      },
+    ]);
+  });
+
+  test('keeps label and value for gcm option objects', () => {
+    expect(normalizeQueryOptions([{ label: 'Project 1', value: 'project-1' }], undefined, 'gcm')).toEqual([{ label: 'Project 1', value: 'project-1' }]);
+  });
+
+  test('uses the existing regex extraction behavior for gcm option object values', () => {
+    expect(normalizeQueryOptions([{ label: 'Project 1', value: 'project-1' }], '/project-(.*)/', 'gcm')).toEqual([{ label: '1', value: '1' }]);
+  });
+});

--- a/src/pages/dashboard/Variables/utils/normalizeQueryOptions.ts
+++ b/src/pages/dashboard/Variables/utils/normalizeQueryOptions.ts
@@ -1,0 +1,27 @@
+import _ from 'lodash';
+
+import filterOptionsByReg from './filterOptionsByReg';
+
+function isOptionObject(option: any) {
+  return _.isObject(option) && !_.isArray(option);
+}
+
+function normalizeOptionObject(option: any) {
+  const value = _.toString(option.value ?? option.label ?? '');
+  return {
+    label: _.toString(option.label ?? value),
+    value,
+  };
+}
+
+export default function normalizeQueryOptions(options: any[], reg?: string, datasourceCate?: string) {
+  if (datasourceCate === 'gcm' && _.some(options, isOptionObject)) {
+    const normalizedOptions = _.filter(_.map(options, normalizeOptionObject), (item) => item.value);
+    if (!reg) {
+      return _.unionBy(normalizedOptions, 'value');
+    }
+    return filterOptionsByReg(_.map(normalizedOptions, 'value'), reg);
+  }
+
+  return filterOptionsByReg(_.map(options, _.toString), reg);
+}

--- a/src/pages/dashboard/Variables/utils/normalizeQueryOptions.ts
+++ b/src/pages/dashboard/Variables/utils/normalizeQueryOptions.ts
@@ -14,11 +14,21 @@ function normalizeOptionObject(option: any) {
   };
 }
 
-export default function normalizeQueryOptions(options: any[], reg?: string, datasourceCate?: string) {
+export default function normalizeQueryOptions(options: any[], reg?: string, datasourceCate?: string): { label: string; value: string }[] {
   if (datasourceCate === 'gcm' && _.some(options, isOptionObject)) {
-    const normalizedOptions = _.filter(_.map(options, normalizeOptionObject), (item) => item.value);
+    const normalizedOptions = options.reduce<{ label: string; value: string }[]>((acc, opt) => {
+      const item = normalizeOptionObject(opt);
+      if (item.value) acc.push(item);
+      return acc;
+    }, []);
     if (!reg) {
-      return _.unionBy(normalizedOptions, 'value');
+      const seen = new Set<string>();
+      return normalizedOptions.filter((item) => {
+        const key = item.value;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
     }
     return filterOptionsByReg(_.map(normalizedOptions, 'value'), reg);
   }


### PR DESCRIPTION
…multi-select

- Add queryEnabled prop to defer panel queries until variables are initialized
- Fix variable initialization tracking to handle dynamic variable changes
- Add isQueryVariableMultiSelectEnabled for per-datasource multi-select control
- Add normalizeQueryOptions to preserve GCM option label/value structure
- Replace filterOptionsByReg with normalizeQueryOptions in variable query flows