### PR TITLE
fix(table-tags): show full tag content on hover

### DIFF
--- a/src/components/TableTags/Tags.test.ts
+++ b/src/components/TableTags/Tags.test.ts
@@ -1,0 +1,46 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+jest.mock('@/utils', () => ({ copy2ClipBoard: jest.fn() }));
+jest.mock('@ant-design/icons', () => ({ CopyOutlined: () => null }));
+jest.mock('react-i18next', () => ({ Trans: () => null }));
+jest.mock('antd', () => {
+  const React = require('react');
+
+  return {
+    Button: ({ children }: { children?: React.ReactNode }) => React.createElement('button', null, children),
+    Popover: ({ children }: { children: React.ReactElement }) => children,
+    Tooltip: ({ title, children }: { title?: React.ReactNode; children: React.ReactElement }) => React.createElement('span', { 'data-tooltip-title': title }, children),
+  };
+});
+
+import Tags from './Tags';
+
+describe('TableTags tooltip', () => {
+  beforeAll(() => {
+    jest.spyOn(React, 'useLayoutEffect').mockImplementation(React.useEffect);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('shows the complete tag label through the shared tooltip component', () => {
+    const label = 'environment=production-with-a-very-long-name';
+    const markup = renderToStaticMarkup(React.createElement(Tags, { data: [label], maxWidth: 80 }));
+
+    expect(markup).toContain(`data-tooltip-title="${label}"`);
+  });
+
+  it('does not render a tooltip when getTooltipTitle returns undefined', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(Tags, {
+        data: ['environment=production'],
+        maxWidth: 80,
+        getTooltipTitle: () => undefined,
+      }),
+    );
+
+    expect(markup).not.toContain('data-tooltip-title');
+  });
+});

--- a/src/components/TableTags/Tags.tsx
+++ b/src/components/TableTags/Tags.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useLayoutEffect } from 'react';
-import { Button, Popover } from 'antd';
+import { Button, Popover, Tooltip } from 'antd';
 import { CopyOutlined } from '@ant-design/icons';
 import { Trans } from 'react-i18next';
 
@@ -192,19 +192,19 @@ export default function Tags<T>(props: Props<T>) {
       {/* 可见布局层 */}
       <div className='flex flex-wrap gap-0.5 content-start'>
         {(data as (string | T)[]).slice(0, visibleCount).map((item, i) => (
-          <span
-            key={getItemKey(item, i)}
-            className={visibleTagClass}
-            style={getTagStyle(item, i)}
-            title={getTooltipTitle ? getTooltipTitle(item, i) : getItemLabel(item, i)}
-            onClick={(e) => {
-              e.stopPropagation();
-              onTagClick?.(item, i);
-            }}
-          >
-            {icon && <span className={`${hideLabel ? '' : 'mr-[3px]'} flex items-center shrink-0`}>{resolveIcon(icon, item, i)}</span>}
-            {!hideLabel && <span className='overflow-hidden text-ellipsis'>{getItemLabel(item, i)}</span>}
-          </span>
+          <Tooltip key={getItemKey(item, i)} title={getTooltipTitle ? getTooltipTitle(item, i) : getItemLabel(item, i)}>
+            <span
+              className={visibleTagClass}
+              style={getTagStyle(item, i)}
+              onClick={(e) => {
+                e.stopPropagation();
+                onTagClick?.(item, i);
+              }}
+            >
+              {icon && <span className={`${hideLabel ? '' : 'mr-[3px]'} flex items-center shrink-0`}>{resolveIcon(icon, item, i)}</span>}
+              {!hideLabel && <span className='overflow-hidden text-ellipsis'>{getItemLabel(item, i)}</span>}
+            </span>
+          </Tooltip>
         ))}
         {overflowCount > 0 && (
           <Popover


### PR DESCRIPTION
## Summary

- Replace the native `title` attribute on visible table tags with the shared Ant Design `Tooltip`.
- Preserve custom tooltip suppression when `getTooltipTitle` returns `undefined`.
- Add focused regression coverage for full tag labels and disabled tooltips.

## Review

- `/cmt strict` and `/cr` review were completed before committing.
- No blocker or warning findings were identified.

## Verification

- `npm test -- --runInBand src/components/TableTags/Tags.test.ts src/components/EnhancedTable/columns.test.ts src/components/EnhancedTable/RowActionCell.test.ts src/components/EnhancedTable/inlineActionPages.test.ts` — 32 tests passed on the updated `pre` branch.
- `npx prettier --check src/components/TableTags/Tags.tsx src/components/TableTags/Tags.test.ts` — passed.
- `git diff --check origin/pre..HEAD` — passed before pushing `pre`.

## Notes / Risks

- No browser visual verification was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hover tooltips to visible table tags, displaying the full tag label when needed.

* **Bug Fixes**
  * Improved tag tooltip behavior when custom tooltip text is unavailable.
  * Removed reliance on browser-native title attributes for tag details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->