### PR TITLE
fix(perms): alias /flashAI role op to /flashai menu path

### DIFF
--- a/src/services/common.ts
+++ b/src/services/common.ts
@@ -65,6 +65,10 @@ export function getMenuPerm() {
     if (_.includes(perms, '/embedded-products')) {
       perms = _.concat(perms, ['/embedded-product']);
     }
+    // Backend role op is `/flashAI`; frontend path/menu key is `/flashai` (case-sensitive indexOf/includes).
+    if (_.includes(perms, '/flashAI') && !_.includes(perms, '/flashai')) {
+      perms = _.concat(perms, ['/flashai']);
+    }
     return {
       ...(res || {}),
       dat: perms,


### PR DESCRIPTION
## Summary

Single commit: alias the backend role operation `/flashAI` to the frontend menu path `/flashai` in `getMenuPerm`.

## Why this is needed now

`SideMenu` and the route guard match permissions with **case-sensitive** `includes`, but the two sides spell it differently:

- backend role operation: `/flashAI` — `fc-insight` `app/insight/controller/ai/ai.go`, `FlashAIOperation = "/flashAI"`, upserted for every role by `upgradeRoleOperation`
- frontend menu key / route path: `/flashai`

srm-fe previously papered over the gap by unconditionally appending `/flashai` to `perms` in `App.n9e.tsx`. That whitelist was removed on the srm-fe side (`be16206e7`, already merged to srm-fe `pre`) so the entry could be governed by the real role permission — which makes this alias the only thing bridging the two spellings.

**Without this commit the FlashAI menu entry disappears**: `perms` contains `/flashAI`, `SideMenu` filters on `/flashai`, nothing matches. This is currently reproducible on the 9000 environment, which builds `pre` for all three repos — srm-fe's half landed on `pre`, this half did not.

## Scope

```
src/services/common.ts | 4 ++++
```

```ts
// Backend role op is `/flashAI`; frontend path/menu key is `/flashai` (case-sensitive indexOf/includes).
if (_.includes(perms, '/flashAI') && !_.includes(perms, '/flashai')) {
  perms = _.concat(perms, ['/flashai']);
}
```

Additive only — appends a derived entry, never removes one, and no-ops when `/flashai` is already present or `/flashAI` is not granted.

## Verification

Jenkins `build_9000_of_106` **#5423 SUCCESS** with all three repos on `feat-flash-ai-fullpage-0720` (folder `srm-integration-menu-8` → `http://10.99.1.106:9888/`), i.e. this commit has been building and running together with the srm-fe side.

## Related

- srm-fe [#1085 → main](https://github.com/flashcatcloud/srm-fe/pull/1085), [#1091 → pre](https://github.com/flashcatcloud/srm-fe/pull/1091)
- Land this together with the srm-fe PR for the matching base branch; merging either side alone breaks the FlashAI menu entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed menu access recognition when backend permissions use a different letter casing than the corresponding frontend path.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->