### PR TITLE
feat(dashboard): persist TableNG column widths via overrides

### DIFF
--- a/src/pages/dashboard/Editor/Fields/Overrides/index.tsx
+++ b/src/pages/dashboard/Editor/Fields/Overrides/index.tsx
@@ -15,7 +15,7 @@
  *
  */
 import React from 'react';
-import { Form, Space, Select, Row, Col } from 'antd';
+import { Form, Space, Select, Row, Col, InputNumber } from 'antd';
 import { PlusCircleOutlined, MinusCircleOutlined } from '@ant-design/icons';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -133,6 +133,11 @@ export default function index({ targets, matcherNames = ['byFrameRefID', 'byName
                   </Form.Item>
                 </Col>
               </Row>
+              {_.includes(overrideOptions, 'custom.width') && (
+                <Form.Item label={t('panel.overrides.columnWidth')} {...restField} name={[name, 'properties', 'width']}>
+                  <InputNumber min={100} placeholder='auto' style={{ width: '100%' }} />
+                </Form.Item>
+              )}
               {_.includes(overrideOptions, 'custom.cellOptions') && (
                 <Panel header={t('panel.custom.title')} isActive={_.includes(activeOptions, 'custom.cellOptions')}>
                   <CellOptions prefixNamePath={namePrefix} namePath={[name, 'properties', 'cellOptions']} hideWrapText />

--- a/src/pages/dashboard/Editor/Form.tsx
+++ b/src/pages/dashboard/Editor/Form.tsx
@@ -95,6 +95,9 @@ function FormCpt(props: IProps, ref) {
                     isPreview
                     themeMode={darkMode ? 'dark' : undefined}
                     annotations={[]}
+                    onOverridesChange={(overrides) => {
+                      chartForm.setFieldsValue({ overrides });
+                    }}
                   />
                 )}
               </div>

--- a/src/pages/dashboard/Editor/Options/TableNG/index.tsx
+++ b/src/pages/dashboard/Editor/Options/TableNG/index.tsx
@@ -19,7 +19,12 @@ export default function Table({ targets }) {
       {cellOptionsType !== 'none' && <Thresholds showMode />}
       <ValueMappings isActive={false} />
       <StandardOptions isActive={false} />
-      <Overrides targets={targets} matcherNames={['byName']} defaultMatcherId='byName' overrideOptions={['custom.cellOptions', 'thresholds', 'thresholds_showMode']} />
+      <Overrides
+        targets={targets}
+        matcherNames={['byName']}
+        defaultMatcherId='byName'
+        overrideOptions={['custom.width', 'custom.cellOptions', 'thresholds', 'thresholds_showMode']}
+      />
     </>
   );
 }

--- a/src/pages/dashboard/Panels/index.tsx
+++ b/src/pages/dashboard/Panels/index.tsx
@@ -281,6 +281,34 @@ function index(props: IProps) {
                       setTimezone={setTimezone}
                       values={item}
                       annotations={_.filter(annotations, (annotation) => annotation.panel_id === item.id)}
+                      onOverridesChange={
+                        isAuthorized && editable
+                          ? (overrides) => {
+                              const sourcePanelId = item.repeatPanelId || item.id;
+                              setPanels((currentPanels) => {
+                                const newPanels = _.map(currentPanels, (panel) => {
+                                  if (panel.id === sourcePanelId || panel.repeatPanelId === sourcePanelId) {
+                                    return {
+                                      ...panel,
+                                      overrides,
+                                    };
+                                  }
+                                  return panel;
+                                });
+                                updateDashboardConfigs(dashboard.id, {
+                                  configs: panelsMergeToConfigs(dashboard.configs, newPanels),
+                                })
+                                  .then((res) => {
+                                    onUpdated(res);
+                                  })
+                                  .catch(() => {
+                                    // 手动保存模式下配置已进入 dashboard 草稿；接口失败沿用现有静默处理。
+                                  });
+                                return newPanels;
+                              });
+                            }
+                          : undefined
+                      }
                       onCloneClick={() => {
                         setPanels((panels) => {
                           return updatePanelsInsertNewPanel(panels, {

--- a/src/pages/dashboard/Renderer/Renderer/Main.tsx
+++ b/src/pages/dashboard/Renderer/Renderer/Main.tsx
@@ -75,6 +75,7 @@ function index(
     onEditClick,
     onDeleteClick,
     onCopyClick,
+    onOverridesChange,
     // from index.tsx
     controllersVisible,
     queryResult,
@@ -110,6 +111,7 @@ function index(
     id,
     values,
     series,
+    onOverridesChange,
   };
 
   const RendererCptMap = {

--- a/src/pages/dashboard/Renderer/Renderer/TableNG/index.tsx
+++ b/src/pages/dashboard/Renderer/Renderer/TableNG/index.tsx
@@ -11,11 +11,19 @@ import getFontFamily from '@/utils/getFontFamily';
 import { useGlobalState } from '@/pages/dashboard/globalState';
 import localeCompare from '@/pages/dashboard/Renderer/utils/localeCompare';
 
-import { IPanel } from '../../../types';
+import { IOverride, IPanel } from '../../../types';
 import { downloadCsv } from '../Table/utils';
 import { DARK_PARAMS, LIGHT_PARAMS } from './constants';
 import getFormattedRowData from './utils/getFormattedRowData';
 import normalizeData from './utils/normalizeData';
+import {
+  getColumnWidthColDef,
+  getResolvedColumnWidths,
+  readCachedColumnWidths,
+  removeCachedColumnWidth,
+  TABLE_COLUMN_MIN_WIDTH,
+  upsertColumnWidthOverride,
+} from './utils/columnWidth';
 import CellRenderer from './CellRenderer';
 import { TextObject } from './CellRenderer/types';
 import CustomColumnFilter, { doesFilterPass } from './CustomColumnFilter';
@@ -58,6 +66,7 @@ interface Props {
     >,
   ) => void;
   domLayout?: DomLayoutType;
+  onOverridesChange?: (overrides: IOverride[]) => void;
 }
 
 function index(props: Props, ref: React.Ref<any>) {
@@ -80,31 +89,19 @@ function index(props: Props, ref: React.Ref<any>) {
     showUnderline = false,
     onCellClick,
     domLayout,
+    onOverridesChange,
   } = props;
 
   // 列宽缓存 key：dashboardID + panelID
   const cacheKey = dashboardId && values?.id ? `tableNG_colWidths_${dashboardId}_${values.id}` : null;
 
-  // 从 localStorage 同步读取已缓存的（仅被用户修改过的）列宽，供 onGridReady 时恢复使用
-  const readCachedColWidths = (key: string | null): Record<string, number> => {
-    if (!key) return {};
-    try {
-      return JSON.parse(localStorage.getItem(key) || '{}');
-    } catch {
-      return {};
-    }
-  };
-
-  // useRef 不支持懒初始化，在渲染时直接同步读取初始值
-  const modifiedColWidthsRef = React.useRef<Record<string, number>>(readCachedColWidths(cacheKey));
-
-  // cacheKey 变化时（如面板切换）重新从 localStorage 加载列宽
-  React.useEffect(() => {
-    modifiedColWidthsRef.current = readCachedColWidths(cacheKey);
-  }, [cacheKey]);
-
   const { transformationsNG: transformations, custom, options, overrides } = values;
   const { showHeader = true, cellOptions = {}, filterable, sortColumn, sortOrder } = custom || {};
+  // useRef 不支持懒初始化，在渲染时直接同步读取初始值
+  const cachedColWidthsRef = React.useRef<Record<string, number>>(readCachedColumnWidths(cacheKey));
+  const appliedColWidthsRef = React.useRef<Record<string, number>>({});
+  const gridApiRef = React.useRef<any>(null);
+  const persistedColumnWidths = getResolvedColumnWidths(cachedColWidthsRef.current, overrides);
   const linksRef = React.useRef<any>(null);
   const [activeIndex, setActiveIndex] = useState<number>(0);
   const [, setSeries] = useGlobalState('series');
@@ -155,6 +152,30 @@ function index(props: Props, ref: React.Ref<any>) {
     }
   }, [JSON.stringify(_.map(series, 'id'))]);
 
+  const applyPersistedColumnWidths = (api = gridApiRef.current) => {
+    if (!api) return;
+    const columnWidths = getResolvedColumnWidths(cachedColWidthsRef.current, overrides);
+    const removedFields = _.difference(_.keys(appliedColWidthsRef.current), _.keys(columnWidths));
+    const state = [..._.map(columnWidths, (width, colId) => ({ colId, width, flex: null })), ..._.map(removedFields, (colId) => ({ colId, flex: 1 }))];
+    if (_.isEmpty(state)) return;
+
+    api.applyColumnState({
+      state,
+    });
+    appliedColWidthsRef.current = columnWidths;
+  };
+
+  // cacheKey 变化时（如面板切换）重新加载旧缓存。
+  useEffect(() => {
+    cachedColWidthsRef.current = readCachedColumnWidths(cacheKey);
+    applyPersistedColumnWidths();
+  }, [cacheKey]);
+
+  // 编辑器表单或仪表盘状态更新 override 后，立即同步到当前网格。
+  useEffect(() => {
+    applyPersistedColumnWidths();
+  }, [JSON.stringify(overrides)]);
+
   return (
     <div className={`n9e-dashboard-panel-table-ng ${showHeader ? '' : 'n9e-dashboard-panel-table-ng-hide-header'} p-2 h-full w-full flex flex-col gap-2`}>
       <AgGridReact
@@ -172,10 +193,13 @@ function index(props: Props, ref: React.Ref<any>) {
         }}
         rowData={rowData}
         columnDefs={_.map(ajustColumns ? ajustColumns(columns) : columns, (item) => {
+          const persistedWidth = persistedColumnWidths[item];
           return {
             field: item,
             unSortIcon: true,
             headerName: item,
+            // 重渲染首帧直接使用持久化宽度，避免 defaultColDef.flex 先回排再由 effect 修正造成闪动。
+            ...getColumnWidthColDef(persistedWidth),
             cellStyle: {
               padding: 0,
             },
@@ -225,7 +249,7 @@ function index(props: Props, ref: React.Ref<any>) {
         defaultColDef={{
           flex: 1,
           resizable: true,
-          minWidth: 100,
+          minWidth: TABLE_COLUMN_MIN_WIDTH,
           sortable: true, // 启用排序功能
           cellStyle: {
             fontFamily: getFontFamily(siteInfo?.font_family),
@@ -247,28 +271,18 @@ function index(props: Props, ref: React.Ref<any>) {
           },
         }}
         onColumnResized={(event) => {
-          // 仅在拖拽结束时保存，且只保存被修改的列宽
-          if (!event.finished || !cacheKey || !event.column) return;
+          // 仅持久化用户完成的拖拽；初始化和 API 回放不会反向生成 override。
+          if (!event.finished || event.source !== 'uiColumnResized' || !event.column || !onOverridesChange) return;
           const colId = event.column.getColId();
           const width = event.column.getActualWidth();
-          modifiedColWidthsRef.current = {
-            ...modifiedColWidthsRef.current,
-            [colId]: width,
-          };
-          try {
-            localStorage.setItem(cacheKey, JSON.stringify(modifiedColWidthsRef.current));
-          } catch {
-            // ignore storage errors
-          }
+          const nextOverrides = upsertColumnWidthOverride(overrides, colId, width);
+          onOverridesChange(nextOverrides);
+          cachedColWidthsRef.current = removeCachedColumnWidth(cacheKey, colId);
         }}
         onGridReady={(params) => {
-          // 恢复缓存的列宽
-          const cachedWidths = modifiedColWidthsRef.current;
-          if (!_.isEmpty(cachedWidths)) {
-            params.api.applyColumnState({
-              state: _.map(cachedWidths, (width, colId) => ({ colId, width })),
-            });
-          }
+          gridApiRef.current = params.api;
+          // override 优先，旧 localStorage 缓存只为尚未迁移的字段兜底。
+          applyPersistedColumnWidths(params.api);
           // 列的默认排序
           if (sortColumn && sortOrder) {
             params.api.applyColumnState({

--- a/src/pages/dashboard/Renderer/Renderer/TableNG/utils/columnWidth.test.ts
+++ b/src/pages/dashboard/Renderer/Renderer/TableNG/utils/columnWidth.test.ts
@@ -1,0 +1,94 @@
+import { IOverride } from '@/pages/dashboard/types';
+
+import { getColumnWidthColDef, getOverrideColumnWidths, getResolvedColumnWidths, readCachedColumnWidths, removeCachedColumnWidth, upsertColumnWidthOverride } from './columnWidth';
+
+function createStorage(initialValue: Record<string, string> = {}) {
+  const values = { ...initialValue };
+  return {
+    getItem: jest.fn((key: string) => values[key] ?? null),
+    setItem: jest.fn((key: string, value: string) => {
+      values[key] = value;
+    }),
+    removeItem: jest.fn((key: string) => {
+      delete values[key];
+    }),
+    values,
+  };
+}
+
+describe('TableNG column width utils', () => {
+  it('builds a fixed-width column definition that disables default flex layout', () => {
+    expect(getColumnWidthColDef(180)).toEqual({ width: 180, flex: 0 });
+    expect(getColumnWidthColDef(99)).toEqual({});
+  });
+
+  it('uses the last valid byName override and lets overrides take precedence over cache', () => {
+    const overrides = [
+      { matcher: { id: 'byName', value: 'host' }, properties: { width: 120 } },
+      { matcher: { id: 'byName', value: 'host' }, properties: { width: 180 } },
+      { matcher: { id: 'byName', value: 'value' }, properties: { width: 80 } },
+      { matcher: { type: 'byName', value: 'legacy' }, properties: { width: 130 } },
+    ] as IOverride[];
+
+    expect(getOverrideColumnWidths(overrides)).toEqual({ host: 180, legacy: 130 });
+    expect(getResolvedColumnWidths({ host: 140, value: 160 }, overrides)).toEqual({
+      host: 180,
+      value: 160,
+      legacy: 130,
+    });
+  });
+
+  it('merges width into the last matching override and preserves other properties', () => {
+    const overrides = [
+      { matcher: { id: 'byName', value: 'host' }, properties: { width: 120 } },
+      {
+        matcher: { id: 'byName', value: 'host' },
+        properties: { cellOptions: { type: 'color-text' }, thresholds: { mode: 'absolute' } },
+      },
+    ] as IOverride[];
+
+    expect(upsertColumnWidthOverride(overrides, 'host', 240)).toEqual([
+      overrides[0],
+      {
+        matcher: { id: 'byName', value: 'host' },
+        properties: {
+          cellOptions: { type: 'color-text' },
+          thresholds: { mode: 'absolute' },
+          width: 240,
+        },
+      },
+    ]);
+  });
+
+  it('appends a byName override when the field has no matching rule', () => {
+    expect(upsertColumnWidthOverride([], 'host', 200)).toEqual([
+      {
+        matcher: { id: 'byName', value: 'host' },
+        properties: { width: 200 },
+      },
+    ]);
+  });
+
+  it('removes only the migrated field and removes the storage key when no widths remain', () => {
+    const storage = createStorage({
+      widths: JSON.stringify({ host: 180, value: 220 }),
+    });
+
+    expect(removeCachedColumnWidth('widths', 'host', storage)).toEqual({ value: 220 });
+    expect(storage.setItem).toHaveBeenCalledWith('widths', JSON.stringify({ value: 220 }));
+
+    expect(removeCachedColumnWidth('widths', 'value', storage)).toEqual({});
+    expect(storage.removeItem).toHaveBeenCalledWith('widths');
+  });
+
+  it('ignores malformed cache data and invalid widths', () => {
+    const malformedStorage = createStorage({ widths: '{malformed' });
+    const invalidStorage = createStorage({
+      widths: JSON.stringify({ tooSmall: 99, infinite: null, valid: 100, text: '200' }),
+    });
+
+    expect(readCachedColumnWidths('widths', malformedStorage)).toEqual({});
+    expect(readCachedColumnWidths('widths', invalidStorage)).toEqual({ valid: 100 });
+    expect(readCachedColumnWidths(null, invalidStorage)).toEqual({});
+  });
+});

--- a/src/pages/dashboard/Renderer/Renderer/TableNG/utils/columnWidth.test.ts
+++ b/src/pages/dashboard/Renderer/Renderer/TableNG/utils/columnWidth.test.ts
@@ -69,6 +69,40 @@ describe('TableNG column width utils', () => {
     ]);
   });
 
+  it('replaces the only override when it has no matcher value', () => {
+    const placeholder = {
+      matcher: { id: 'byName', value: '' },
+      properties: { cellOptions: { type: 'color-text' } },
+    } as IOverride;
+
+    expect(upsertColumnWidthOverride([placeholder], 'host', 200)).toEqual([
+      {
+        matcher: { id: 'byName', value: 'host' },
+        properties: { width: 200 },
+      },
+    ]);
+  });
+
+  it('does not remove an empty override when other override rules exist', () => {
+    const placeholder = {
+      matcher: { id: 'byName', value: '' },
+      properties: {},
+    } as IOverride;
+    const existing = {
+      matcher: { id: 'byName', value: 'value' },
+      properties: { width: 160 },
+    } as IOverride;
+
+    expect(upsertColumnWidthOverride([placeholder, existing], 'host', 200)).toEqual([
+      placeholder,
+      existing,
+      {
+        matcher: { id: 'byName', value: 'host' },
+        properties: { width: 200 },
+      },
+    ]);
+  });
+
   it('removes only the migrated field and removes the storage key when no widths remain', () => {
     const storage = createStorage({
       widths: JSON.stringify({ host: 180, value: 220 }),

--- a/src/pages/dashboard/Renderer/Renderer/TableNG/utils/columnWidth.ts
+++ b/src/pages/dashboard/Renderer/Renderer/TableNG/utils/columnWidth.ts
@@ -59,14 +59,16 @@ export function getResolvedColumnWidths(cachedWidths: ColumnWidths, overrides: I
 export function upsertColumnWidthOverride(overrides: IOverride[] = [], field: string, width: number): IOverride[] {
   if (!field || !isValidColumnWidth(width)) return overrides;
 
-  const lastMatchedIndex = _.findLastIndex(overrides, (override) => {
+  // 编辑器默认会保留一条未选择匹配值的 override，占位规则不应阻止拖拽生成有效配置。
+  const effectiveOverrides = overrides.length === 1 && !_.trim(overrides[0]?.matcher?.value) ? [] : overrides;
+  const lastMatchedIndex = _.findLastIndex(effectiveOverrides, (override) => {
     const matcherType = override?.matcher?.id || override?.matcher?.type;
     return matcherType === 'byName' && override?.matcher?.value === field;
   });
 
   if (lastMatchedIndex === -1) {
     return [
-      ...overrides,
+      ...effectiveOverrides,
       {
         matcher: {
           id: 'byName',
@@ -79,7 +81,7 @@ export function upsertColumnWidthOverride(overrides: IOverride[] = [], field: st
     ];
   }
 
-  return _.map(overrides, (override, index) => {
+  return _.map(effectiveOverrides, (override, index) => {
     if (index !== lastMatchedIndex) return override;
     return {
       ...override,

--- a/src/pages/dashboard/Renderer/Renderer/TableNG/utils/columnWidth.ts
+++ b/src/pages/dashboard/Renderer/Renderer/TableNG/utils/columnWidth.ts
@@ -8,7 +8,7 @@ type ColumnWidths = Record<string, number>;
 type ColumnWidthStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
 
 export function isValidColumnWidth(value: unknown): value is number {
-  return _.isNumber(value) && Number.isFinite(value) && value >= TABLE_COLUMN_MIN_WIDTH;
+  return typeof value === 'number' && Number.isFinite(value) && value >= TABLE_COLUMN_MIN_WIDTH;
 }
 
 export function getColumnWidthColDef(width: unknown): { width: number; flex: 0 } | Record<string, never> {

--- a/src/pages/dashboard/Renderer/Renderer/TableNG/utils/columnWidth.ts
+++ b/src/pages/dashboard/Renderer/Renderer/TableNG/utils/columnWidth.ts
@@ -1,0 +1,111 @@
+import _ from 'lodash';
+
+import { IOverride } from '@/pages/dashboard/types';
+
+export const TABLE_COLUMN_MIN_WIDTH = 100;
+
+type ColumnWidths = Record<string, number>;
+type ColumnWidthStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+export function isValidColumnWidth(value: unknown): value is number {
+  return _.isNumber(value) && Number.isFinite(value) && value >= TABLE_COLUMN_MIN_WIDTH;
+}
+
+export function getColumnWidthColDef(width: unknown): { width: number; flex: 0 } | Record<string, never> {
+  if (!isValidColumnWidth(width)) return {};
+  return {
+    width,
+    flex: 0,
+  };
+}
+
+export function readCachedColumnWidths(cacheKey: string | null, storage: ColumnWidthStorage = localStorage): ColumnWidths {
+  if (!cacheKey) return {};
+
+  try {
+    const value = JSON.parse(storage.getItem(cacheKey) || '{}');
+    if (!_.isPlainObject(value)) return {};
+
+    return _.pickBy(value as ColumnWidths, isValidColumnWidth);
+  } catch {
+    return {};
+  }
+}
+
+export function getOverrideColumnWidths(overrides: IOverride[] = []): ColumnWidths {
+  return _.reduce(
+    overrides,
+    (result, override) => {
+      const matcherType = override?.matcher?.id || override?.matcher?.type;
+      const field = override?.matcher?.value;
+      const width = override?.properties?.width;
+
+      if (matcherType === 'byName' && field && isValidColumnWidth(width)) {
+        result[field] = width;
+      }
+      return result;
+    },
+    {} as ColumnWidths,
+  );
+}
+
+export function getResolvedColumnWidths(cachedWidths: ColumnWidths, overrides: IOverride[] = []): ColumnWidths {
+  return {
+    ...cachedWidths,
+    ...getOverrideColumnWidths(overrides),
+  };
+}
+
+export function upsertColumnWidthOverride(overrides: IOverride[] = [], field: string, width: number): IOverride[] {
+  if (!field || !isValidColumnWidth(width)) return overrides;
+
+  const lastMatchedIndex = _.findLastIndex(overrides, (override) => {
+    const matcherType = override?.matcher?.id || override?.matcher?.type;
+    return matcherType === 'byName' && override?.matcher?.value === field;
+  });
+
+  if (lastMatchedIndex === -1) {
+    return [
+      ...overrides,
+      {
+        matcher: {
+          id: 'byName',
+          value: field,
+        },
+        properties: {
+          width,
+        },
+      },
+    ];
+  }
+
+  return _.map(overrides, (override, index) => {
+    if (index !== lastMatchedIndex) return override;
+    return {
+      ...override,
+      properties: {
+        ...override.properties,
+        width,
+      },
+    };
+  });
+}
+
+export function removeCachedColumnWidth(cacheKey: string | null, field: string, storage: ColumnWidthStorage = localStorage): ColumnWidths {
+  if (!cacheKey || !field) return {};
+
+  const cachedWidths = readCachedColumnWidths(cacheKey, storage);
+  const remainingWidths = _.omit(cachedWidths, field);
+
+  try {
+    if (_.isEmpty(remainingWidths)) {
+      storage.removeItem(cacheKey);
+    } else {
+      storage.setItem(cacheKey, JSON.stringify(remainingWidths));
+    }
+  } catch {
+    // ignore storage errors
+  }
+
+  return remainingWidths;
+}

--- a/src/pages/dashboard/Renderer/Renderer/index.tsx
+++ b/src/pages/dashboard/Renderer/Renderer/index.tsx
@@ -27,7 +27,7 @@ import { CommonStateContext } from '@/App';
 import { replaceDatasourceVariables } from '@/pages/dashboard/Variables/utils/replaceTemplateVariables';
 
 import useQuery from '../datasource/useQuery';
-import { IPanel } from '../../types';
+import { IOverride, IPanel } from '../../types';
 import Main from './Main';
 
 import './style.less';
@@ -51,6 +51,7 @@ export interface IProps {
   onDeleteClick?: () => void;
   onCopyClick?: () => void | Promise<void>;
   setAnnotationsRefreshFlag?: (flag: string) => void;
+  onOverridesChange?: (overrides: IOverride[]) => void;
 }
 
 function index(props: IProps) {

--- a/src/pages/dashboard/locale/en_US.ts
+++ b/src/pages/dashboard/locale/en_US.ts
@@ -338,6 +338,7 @@ const en_US = {
       displayName_tip: 'Change the series name',
     },
     overrides: {
+      columnWidth: 'Column width',
       matcher: {
         id: 'Matcher',
         byFrameRefID: {

--- a/src/pages/dashboard/locale/ja_JP.ts
+++ b/src/pages/dashboard/locale/ja_JP.ts
@@ -339,6 +339,7 @@ const ja_JP = {
       displayName_tip: 'シリーズ名をカスタム',
     },
     overrides: {
+      columnWidth: '列幅',
       matcher: {
         id: 'マッチングタイプ',
         byFrameRefID: {

--- a/src/pages/dashboard/locale/ru_RU.ts
+++ b/src/pages/dashboard/locale/ru_RU.ts
@@ -310,6 +310,7 @@ const ru_RU = {
       displayName_tip: 'Пользовательское название серии',
     },
     overrides: {
+      columnWidth: 'Ширина столбца',
       matcher: {
         id: 'Тип сопоставления',
         byFrameRefID: {

--- a/src/pages/dashboard/locale/zh_CN.ts
+++ b/src/pages/dashboard/locale/zh_CN.ts
@@ -344,6 +344,7 @@ const zh_CN = {
       displayName_tip: '自定义系列名称',
     },
     overrides: {
+      columnWidth: '列宽',
       matcher: {
         id: '匹配类型',
         byFrameRefID: {

--- a/src/pages/dashboard/locale/zh_HK.ts
+++ b/src/pages/dashboard/locale/zh_HK.ts
@@ -344,6 +344,7 @@ const zh_HK = {
       displayName_tip: '自定義顯示名稱',
     },
     overrides: {
+      columnWidth: '欄寬',
       matcher: {
         id: '匹配類型',
         byFrameRefID: {

--- a/src/pages/dashboard/types.ts
+++ b/src/pages/dashboard/types.ts
@@ -123,11 +123,13 @@ export interface IOptions {
 
 export interface IOverride {
   matcher: {
-    type: 'byName'; // 目前只支持 byName
+    id?: 'byFrameRefID' | 'byName';
+    type?: 'byFrameRefID' | 'byName'; // 兼容历史配置
     value: string;
   };
   properties: {
-    [key: string]: any; // standardOptions | valueMappings
+    width?: number;
+    [key: string]: any; // standardOptions | valueMappings | width
   };
 }
 


### PR DESCRIPTION
Replace the pure localStorage column-width cache with an overrides-based persistence model. Drag-resizing a column now writes a byName override (via onOverridesChange) that persists with the panel config, while localStorage serves as a fallback for unmigrated widths.

- Extract column width utilities (getColumnWidthColDef, upsertColumnWidthOverride, etc.)
- Add 'custom.width' override option with InputNumber editor (min=100)
- Extend IOverride type with optional width and matcher.id fields
- Wire onOverridesChange through the renderer stack to parent state