### PR TITLE
feat(log-explorer): wire log download and drilldown actions

### DIFF
--- a/src/pages/logExplorer/components/RenderValue/types.ts
+++ b/src/pages/logExplorer/components/RenderValue/types.ts
@@ -18,6 +18,8 @@ export interface Resource {
   es_resource?: EsResource;
   sls_resource?: SlsResource;
   doris_resource?: DorisResource;
+  victorialogs_resource?: VictoriaLogsResource;
+  clickhouse_resource?: ClickHouseResource;
   cls_resource?: ClsResource;
   lts_resource?: LtsResource;
 }
@@ -32,6 +34,19 @@ export interface SlsResource {
 }
 
 export interface DorisResource {
+  database: string;
+  table: string;
+}
+
+export interface VictoriaLogsResource {
+  field_filters: {
+    key: string;
+    op: string;
+    values: string[];
+  }[];
+}
+
+export interface ClickHouseResource {
   database: string;
   table: string;
 }

--- a/src/pages/logExplorer/components/RenderValue/useFieldConfig.tsx
+++ b/src/pages/logExplorer/components/RenderValue/useFieldConfig.tsx
@@ -41,9 +41,11 @@ export default function useFieldConfig(search: IFieldSearch, dep: any): FieldCon
       const isLokiAvailable = search.cate === 'loki' && search.query;
       const isSLSAvailable = search.cate === 'aliyun-sls' && search.resource;
       const isDorisAvailable = search.cate === 'doris' && search.resource;
+      const isVictoriaLogsAvailable = search.cate === 'victorialogs' && search.query;
+      const isCKAvailable = search.cate === 'ck' && search.resource;
       const isCLSAvailable = search.cate === 'tencent-cls' && search.resource;
       const isLTSAvailable = search.cate === 'huawei-lts' && search.resource;
-      if (isESAvailable || isLokiAvailable || isSLSAvailable || isDorisAvailable || isCLSAvailable || isLTSAvailable) {
+      if (isESAvailable || isLokiAvailable || isSLSAvailable || isDorisAvailable || isVictoriaLogsAvailable || isCKAvailable || isCLSAvailable || isLTSAvailable) {
         searchDrilldown(search).then((res) => {
           if (cancelled) return;
           if (res.length > 0) {

--- a/src/plugins/clickHouse/ExplorerNG/Main/Query/index.tsx
+++ b/src/plugins/clickHouse/ExplorerNG/Main/Query/index.tsx
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import moment from 'moment';
 import { useRequest, useGetState } from 'ahooks';
 
-import { DatasourceCateEnum } from '@/utils/constant';
+import { DatasourceCateEnum, IS_PLUS } from '@/utils/constant';
 import { parseRange } from '@/components/TimeRangePicker';
 import { NAME_SPACE as logExplorerNS } from '@/pages/logExplorer/constants';
 import LogsViewer from '@/pages/logExplorer/components/LogsViewer';
@@ -30,6 +30,9 @@ import { scrollToTop, getIsAtBottom } from '../../utils/tableElementMethods';
 import { PinIcon, UnPinIcon } from '../../SideBarNav/FieldsSidebar/PinIcon';
 import { HandleValueFilterParams } from '../../types';
 import QueryBuilderFilters from './QueryBuilderFilters';
+
+// @ts-ignore
+import DownloadModal from 'plus:/components/LogDownload/DownloadModal';
 
 interface Props {
   tableSelector: {
@@ -305,6 +308,7 @@ export default function index(props: Props) {
     {
       cate: DatasourceCateEnum.ck,
       datasource_id: form.getFieldValue('datasourceValue'),
+      resource: { clickhouse_resource: { database: queryValues?.database, table: queryValues?.table } },
     },
     refreshFlag,
   );
@@ -379,6 +383,7 @@ export default function index(props: Props) {
                         </>
                       )}
                       {toggleNode}
+                      {IS_PLUS && <DownloadModal marginLeft={0} queryData={{ ...form.getFieldsValue(), mode: 'query', total: data?.total }} />}
                     </Space>
                   );
                 }

--- a/src/plugins/clickHouse/ExplorerNG/Main/SQL/Table.tsx
+++ b/src/plugins/clickHouse/ExplorerNG/Main/SQL/Table.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef } from 'react';
 import { Form, Space, Pagination, Radio, Empty } from 'antd';
 import _ from 'lodash';
 import moment from 'moment';
-import { DatasourceCateEnum } from '@/utils/constant';
+import { DatasourceCateEnum, IS_PLUS } from '@/utils/constant';
 import { useRequest, useGetState } from 'ahooks';
 import { useTranslation, Trans } from 'react-i18next';
 
@@ -20,6 +20,9 @@ import filteredFields from '../../utils/filteredFields';
 import replaceTemplateVariables from '../../utils/replaceTemplateVariables';
 import { scrollToTop, getIsAtBottom } from '../../utils/tableElementMethods';
 import AddTo from '../../components/AddTo';
+
+// @ts-ignore
+import DownloadModal from 'plus:/components/LogDownload/DownloadModal';
 
 interface IProps {
   sqlVizType: string;
@@ -262,6 +265,7 @@ export default function Table(props: IProps) {
                       <span>{data?.total}</span>
                     </Space>
                   )}
+                  {IS_PLUS && <DownloadModal marginLeft={0} queryData={{ ...form.getFieldsValue(), mode: 'sql', total: data?.total }} />}
                   <AddTo />
                 </Space>
               }

--- a/src/plugins/clickHouse/ExplorerNG/components/MainMoreOperations.tsx
+++ b/src/plugins/clickHouse/ExplorerNG/components/MainMoreOperations.tsx
@@ -3,44 +3,49 @@ import { Form, Button, Space, Dropdown, Menu } from 'antd';
 import { MoreOutlined, ApartmentOutlined, DownloadOutlined } from '@ant-design/icons';
 
 import { ShareLinkText } from '@/pages/logExplorer/components/Share';
+import { IS_PLUS } from '@/utils/constant';
 
 // @ts-ignore
-// import ExportModal from 'plus:/components/LogDownload/ExportModal';
+import ExportModal from 'plus:/components/LogDownload/ExportModal';
 // @ts-ignore
-// import DrilldownBtn from 'plus:/pages/LogExploreLinkSetting/components/DrilldownBtn';
+import DrilldownBtn from 'plus:/pages/LogExploreLinkSetting/components/DrilldownBtn';
 
 export default function MainMoreOperations() {
-  // const datasourceValue = Form.useWatch('datasourceValue');
+  const datasourceValue = Form.useWatch('datasourceValue');
+
+  const menuItems = [
+    ...(IS_PLUS
+      ? [
+          {
+            label: (
+              <Space>
+                <DownloadOutlined />
+                <ExportModal datasourceValue={datasourceValue} type='text' />
+              </Space>
+            ),
+            key: 'export',
+          },
+          {
+            label: (
+              <Space>
+                <ApartmentOutlined />
+                <DrilldownBtn dataSourceId={datasourceValue} type='text' />
+              </Space>
+            ),
+            key: 'drilldown',
+          },
+        ]
+      : []),
+    {
+      label: <ShareLinkText hideText={false} />,
+      key: 'share',
+    },
+  ];
 
   return (
     <Dropdown
       overlay={
-        <Menu
-          items={[
-            {
-              label: <ShareLinkText hideText={false} />,
-              key: 'share',
-            },
-            // {
-            //   label: (
-            //     <Space>
-            //       <DownloadOutlined />
-            //       <ExportModal datasourceValue={datasourceValue} type='text' />
-            //     </Space>
-            //   ),
-            //   key: 'export',
-            // },
-            // {
-            //   label: (
-            //     <Space>
-            //       <ApartmentOutlined />
-            //       <DrilldownBtn dataSourceId={datasourceValue} type='text' />
-            //     </Space>
-            //   ),
-            //   key: 'drilldown',
-            // },
-          ]}
-        />
+        <Menu items={menuItems} />
       }
     >
       <Button icon={<MoreOutlined />} />

--- a/src/plugins/loki/ExplorerNG/Main/Metric/index.tsx
+++ b/src/plugins/loki/ExplorerNG/Main/Metric/index.tsx
@@ -7,7 +7,7 @@ import { useRequest, useSize } from 'ahooks';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { CommonStateContext } from '@/App';
-import { DatasourceCateEnum } from '@/utils/constant';
+import { DatasourceCateEnum, IS_PLUS } from '@/utils/constant';
 import { parseRange } from '@/components/TimeRangePicker';
 import InputGroupWithFormItem from '@/components/InputGroupWithFormItem';
 import UPlotChart, { axisBuilder, cursorBuider, paddingSide, scalesBuilder, seriesBuider, tooltipPlugin } from '@/components/UPlotChart';
@@ -31,6 +31,9 @@ import { getOptionsFromLocalstorage, setOptionsToLocalstorage } from '../../util
 import renderBuiltinFields from '../../utils/renderBuiltinFields';
 import renderLogViewerFieldValueWithoutFilters from '../../utils/renderLogViewerFieldValueWithoutFilters';
 import ResetZoomButton from './ResetZoomButton';
+
+// @ts-ignore
+import DownloadModal from 'plus:/components/LogDownload/DownloadModal';
 
 interface Props {
   indexData: Field[];
@@ -477,6 +480,7 @@ export default function Metric(props: Props) {
                 <span>{tableData?.total}</span>
               </Space>
             )}
+            {IS_PLUS && <DownloadModal marginLeft={0} queryData={{ ...form.getFieldsValue(), mode: 'metric', total: tableData?.total }} />}
           </Space>
         }
         onOptionsChange={updateOptions}

--- a/src/plugins/loki/ExplorerNG/Main/Raw/index.tsx
+++ b/src/plugins/loki/ExplorerNG/Main/Raw/index.tsx
@@ -6,12 +6,13 @@ import { Form } from 'antd';
 import { useRequest } from 'ahooks';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { DatasourceCateEnum } from '@/utils/constant';
+import { DatasourceCateEnum, IS_PLUS } from '@/utils/constant';
 import { parseRange } from '@/components/TimeRangePicker';
 import { NAME_SPACE as logExplorerNS } from '@/pages/logExplorer/constants';
 import LogsViewer from '@/pages/logExplorer/components/LogsViewer';
 import calcColWidthByData from '@/pages/logExplorer/components/LogsViewer/utils/calcColWidthByData';
 import getFieldsFromTableData from '@/pages/logExplorer/components/LogsViewer/utils/getFieldsFromTableData';
+import useFieldConfig from '@/pages/logExplorer/components/RenderValue/useFieldConfig';
 
 import { NAME_SPACE } from '../../../constants';
 import { DEFAULT_LOGS_PAGE_SIZE, DEFAULT_RAW_LOG_LIMIT, DEFAULT_TIME_FIELD, LOGS_OPTIONS_CACHE_KEY, LOGS_TABLE_COLUMNS_WIDTH_CACHE_KEY, MAX_RAW_LOG_LIMIT } from '../../constants';
@@ -24,6 +25,9 @@ import renderBuiltinFields from '../../utils/renderBuiltinFields';
 import renderLogViewerFieldValueWithoutFilters from '../../utils/renderLogViewerFieldValueWithoutFilters';
 import ContextViewer from './components/ContextViewer';
 import { buildLogHighlights, getLineHighlightFilters } from './utils/highlights';
+
+// @ts-ignore
+import DownloadModal from 'plus:/components/LogDownload/DownloadModal';
 
 interface Props {
   indexData: Field[];
@@ -272,11 +276,20 @@ export default function Raw(props: Props) {
     [queryValues?.query, queryValues?.querySource, queryValues?.builderStatus, queryValues?.builder],
   );
   const highlights = useMemo(() => buildLogHighlights(pageLogs, lineHighlightFilters), [pageLogs, lineHighlightFilters]);
+  const currentFieldConfig = useFieldConfig(
+    {
+      cate: DatasourceCateEnum.loki,
+      datasource_id: datasourceValue,
+      query: queryValues?.query,
+    },
+    refreshFlag,
+  );
 
   return refreshFlag ? (
     <>
       {!_.isEmpty(data?.list) || !_.isEmpty(histogramData?.data) ? (
         <LogsViewer
+          fieldConfig={currentFieldConfig}
           indexData={indexData}
           id_key='___id___'
           raw_key='___raw___'
@@ -316,6 +329,7 @@ export default function Raw(props: Props) {
                 <Space>
                   {moment(rangeRef.current.from).format('YYYY-MM-DD HH:mm:ss.SSS')} ~ {moment(rangeRef.current.to).format('YYYY-MM-DD HH:mm:ss.SSS')}
                   {toggleNode}
+                  {IS_PLUS && <DownloadModal marginLeft={0} queryData={{ ...form.getFieldsValue(), mode: 'raw', total: data?.total }} />}
                 </Space>
               );
             }

--- a/src/plugins/victorialogs/ExplorerNG/Main/Metric/index.tsx
+++ b/src/plugins/victorialogs/ExplorerNG/Main/Metric/index.tsx
@@ -8,7 +8,7 @@ import { useRequest, useSize } from 'ahooks';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { CommonStateContext } from '@/App';
-import { DatasourceCateEnum } from '@/utils/constant';
+import { DatasourceCateEnum, IS_PLUS } from '@/utils/constant';
 import { parseRange } from '@/components/TimeRangePicker';
 import InputGroupWithFormItem from '@/components/InputGroupWithFormItem';
 import UPlotChart, { axisBuilder, cursorBuider, paddingSide, scalesBuilder, seriesBuider, tooltipPlugin } from '@/components/UPlotChart';
@@ -34,6 +34,9 @@ import { inferMetricTimeseriesKeysFromQuery } from '../../utils/logsQL';
 import renderBuiltinFields from '../../utils/renderBuiltinFields';
 import renderLogViewerFieldValueWithoutFilters from '../../utils/renderLogViewerFieldValueWithoutFilters';
 import ResetZoomButton from './ResetZoomButton';
+
+// @ts-ignore
+import DownloadModal from 'plus:/components/LogDownload/DownloadModal';
 
 interface Props {
   indexData: Field[];
@@ -493,6 +496,7 @@ export default function Metric(props: Props) {
                 <span>{tableData?.total}</span>
               </Space>
             )}
+            {IS_PLUS && <DownloadModal marginLeft={0} queryData={{ ...form.getFieldsValue(), mode: 'metric', total: tableData?.total }} />}
           </Space>
         }
         onOptionsChange={updateOptions}

--- a/src/plugins/victorialogs/ExplorerNG/Main/Raw/index.tsx
+++ b/src/plugins/victorialogs/ExplorerNG/Main/Raw/index.tsx
@@ -20,6 +20,7 @@ import filteredFields, { filterOutBuiltinFields } from '../../utils/filteredFiel
 import { getOptionsFromLocalstorage, setOptionsToLocalstorage } from '../../utils/optionsLocalstorage';
 import renderBuiltinFields from '../../utils/renderBuiltinFields';
 import renderLogViewerFieldValueWithoutFilters from '../../utils/renderLogViewerFieldValueWithoutFilters';
+import useFieldConfig from '@/pages/logExplorer/components/RenderValue/useFieldConfig';
 import { getIsAtBottom, scrollToTop } from '../../utils/tableElementMethods';
 
 // @ts-ignore
@@ -304,10 +305,20 @@ export default function Raw(props: Props) {
     updateOptions({ organizeFields: newOrganizeFields || [] });
   };
 
+  const currentFieldConfig = useFieldConfig(
+    {
+      cate: DatasourceCateEnum.victorialogs,
+      datasource_id: datasourceValue,
+      query: queryValues?.query,
+    },
+    refreshFlag,
+  );
+
   return refreshFlag ? (
     <>
       {!_.isEmpty(data?.list) || !_.isEmpty(histogramData?.data) ? (
         <LogsViewer
+          fieldConfig={currentFieldConfig}
           indexData={indexData}
           range={queryValues?.range}
           id_key='__n9e_id_n9e__'
@@ -338,7 +349,7 @@ export default function Raw(props: Props) {
                     </>
                   )}
                   {toggleNode}
-                  {IS_PLUS && <DownloadModal marginLeft={0} queryData={{ ...form.getFieldsValue(), mode: 'query', total: data?.total }} />}
+                  {IS_PLUS && <DownloadModal marginLeft={0} queryData={{ ...form.getFieldsValue(), mode: 'raw', total: data?.total }} />}
                 </Space>
               );
             }


### PR DESCRIPTION
Cherry-pick c696c9865 to pre.\n\n- Wire download entries for ClickHouse, Loki, and VictoriaLogs ExplorerNG views\n- Add drilldown field config support for ClickHouse query mode and Loki/VictoriaLogs raw logs\n- Keep SQL/metric drilldown behavior aligned with current product scope