### PR TITLE
feat(logs): support bce bls drilldown lookup

### DIFF
--- a/src/pages/explorer/components/RenderValue/types.ts
+++ b/src/pages/explorer/components/RenderValue/types.ts
@@ -17,6 +17,7 @@ export interface Resource {
   es_resource?: EsResource;
   sls_resource?: SlsResource;
   doris_resource?: DorisResource;
+  bls_resource?: BlsResource;
 }
 
 export interface EsResource {
@@ -31,4 +32,10 @@ export interface SlsResource {
 export interface DorisResource {
   database: string;
   table: string;
+}
+
+export interface BlsResource {
+  project: string;
+  logstore: string;
+  logstream: string;
 }

--- a/src/pages/logExplorer/components/RenderValue/types.ts
+++ b/src/pages/logExplorer/components/RenderValue/types.ts
@@ -22,6 +22,7 @@ export interface Resource {
   clickhouse_resource?: ClickHouseResource;
   cls_resource?: ClsResource;
   lts_resource?: LtsResource;
+  bls_resource?: BlsResource;
 }
 
 export interface EsResource {
@@ -63,4 +64,10 @@ export interface LtsResource {
   stream_id: string;
   group_name?: string;
   stream_name?: string;
+}
+
+export interface BlsResource {
+  project: string;
+  logstore: string;
+  logstream: string;
 }

--- a/src/pages/logExplorer/components/RenderValue/useFieldConfig.tsx
+++ b/src/pages/logExplorer/components/RenderValue/useFieldConfig.tsx
@@ -45,7 +45,18 @@ export default function useFieldConfig(search: IFieldSearch, dep: any): FieldCon
       const isCKAvailable = search.cate === 'ck' && search.resource;
       const isCLSAvailable = search.cate === 'tencent-cls' && search.resource;
       const isLTSAvailable = search.cate === 'huawei-lts' && search.resource;
-      if (isESAvailable || isLokiAvailable || isSLSAvailable || isDorisAvailable || isVictoriaLogsAvailable || isCKAvailable || isCLSAvailable || isLTSAvailable) {
+      const isBLSAvailable = search.cate === 'bce-bls' && search.resource;
+      if (
+        isESAvailable ||
+        isLokiAvailable ||
+        isSLSAvailable ||
+        isDorisAvailable ||
+        isVictoriaLogsAvailable ||
+        isCKAvailable ||
+        isCLSAvailable ||
+        isLTSAvailable ||
+        isBLSAvailable
+      ) {
         searchDrilldown(search).then((res) => {
           if (cancelled) return;
           if (res.length > 0) {


### PR DESCRIPTION
Cherry-pick of 56e6f12c2 onto pre.\n\nChanges:\n- add BLS resource typing for render value drilldown context\n- allow bce-bls to trigger drilldown search in log explorer field config lookup