### PR TITLE
refactor(iotdb): migrate meta APIs to the unified db-* endpoints

### DIFF
--- a/src/plugins/iotdb/components/Meta/index.tsx
+++ b/src/plugins/iotdb/components/Meta/index.tsx
@@ -66,7 +66,7 @@ export default function Meta(props: Props) {
       if (node.levelType === 'tables' && node.database) {
         const tables = await getTables({
           ...baseParams,
-          db: node.database,
+          query: [node.database],
         });
         setTreeData((origin) =>
           updateTreeData(
@@ -87,8 +87,7 @@ export default function Meta(props: Props) {
       } else if (node.levelType === 'table' && node.database && node.table) {
         const columns = await getColumns({
           ...baseParams,
-          db: node.database,
-          table: node.table,
+          query: [{ database: node.database, table: node.table }],
         });
         setTreeData((origin) =>
           updateTreeData(
@@ -96,13 +95,13 @@ export default function Meta(props: Props) {
             key,
             _.map(columns, (item) => {
               return {
-                title: `${item.name} (${item.type})`,
-                key: `${key}.${item.name}`,
+                title: `${item.field} (${item.type})`,
+                key: `${key}.${item.field}`,
                 isLeaf: true,
                 levelType: 'field',
                 database: node.database,
                 table: node.table,
-                field: item.name,
+                field: item.field,
                 type: item.type,
               };
             }),

--- a/src/plugins/iotdb/services.ts
+++ b/src/plugins/iotdb/services.ts
@@ -1,12 +1,9 @@
 import request from '@/utils/request';
 import { RequestMethod } from '@/store/common';
-import { DatasourceCateEnum } from '@/utils/constant';
 import { BaseParams } from './types';
 
-const getDatasourceCate = (cate?: string) => encodeURIComponent(cate || DatasourceCateEnum.iotdb);
-
 export function getDatabases(data: BaseParams): Promise<string[]> {
-  return request(`/api/n9e/${getDatasourceCate(data.cate)}-databases`, {
+  return request('/api/n9e/db-databases', {
     method: RequestMethod.Post,
     data,
   }).then((res) => {
@@ -16,10 +13,10 @@ export function getDatabases(data: BaseParams): Promise<string[]> {
 
 export function getTables(
   data: BaseParams & {
-    db: string;
+    query: string[];
   },
 ): Promise<string[]> {
-  return request(`/api/n9e/${getDatasourceCate(data.cate)}-tables`, {
+  return request('/api/n9e/db-tables', {
     method: RequestMethod.Post,
     data,
   }).then((res) => {
@@ -29,17 +26,18 @@ export function getTables(
 
 export function getColumns(
   data: BaseParams & {
-    db: string;
-    table: string;
+    query: {
+      database: string;
+      table: string;
+    }[];
   },
 ): Promise<
   {
-    name: string;
+    field: string;
     type: string;
-    size: number;
   }[]
 > {
-  return request(`/api/n9e/${getDatasourceCate(data.cate)}-columns`, {
+  return request('/api/n9e/db-desc-table', {
     method: RequestMethod.Post,
     data,
   }).then((res) => {


### PR DESCRIPTION
Point the IoTDB metadata lookups at the shared `db-*` endpoints instead of the cate-templated `iotdb-*` ones.

- `/api/n9e/{cate}-databases` → `/api/n9e/db-databases`
- `/api/n9e/{cate}-tables` → `/api/n9e/db-tables`, payload `db: string` → `query: string[]`
- `/api/n9e/{cate}-columns` → `/api/n9e/db-desc-table`, payload `{ db, table }` → `query: { database, table }[]`, response field `name` → `field` (`size` dropped)
- Drops the now-unused `getDatasourceCate` helper and the `DatasourceCateEnum` import.

### Backend contract — checked against ccfos/nightingale main

| item | backend |
|---|---|
| routes | `center/router/router.go` registers `db-databases` / `db-tables` / `db-desc-table` |
| payload key | `models.QueryParam.Queries []interface{}` is tagged `json:"query"` |
| `ShowTables` | reads `f.Queries[0].(string)` → matches `query: [database]` |
| `DescribeTable` | passes `f.Queries[0]` through → matches `query: [{ database, table }]` |
| response | `types.ColumnProperty` is `{ field, type, type2?, indexable }` — hence `name` → `field`, no `size` |
| IoTDB plugin | `datasource/iotdb/iotdb.go` implements `ShowDatabases` / `ShowTables` / `DescribeTable` |

`getDatabases` / `getTables` / `getColumns` in `src/plugins/iotdb/services.ts` have exactly one consumer — `src/plugins/iotdb/components/Meta/index.tsx` — updated in the same commit. No other plugin is touched.