### PR TITLE
fix(mcp): route MCP APIs through N9E_PATHNAME

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n9e-fe",
-  "version": "v9.0.0",
+  "version": "v9.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n9e-fe",
-      "version": "v9.0.0",
+      "version": "v9.1.0",
       "dependencies": {
         "@ag-grid-community/locale": "^34.1.1",
         "@ant-design/graphs": "^1.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n9e-fe",
-  "version": "v9.0.0",
+  "version": "v9.1.0",
   "scripts": {
     "dev": "vite --port 8765 --host",
     "dev:advanced": "vite --port 8765 --host --mode advanced",

--- a/src/pages/aiConfig/agents/services.ts
+++ b/src/pages/aiConfig/agents/services.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 
 import request from '@/utils/request';
 import { RequestMethod } from '@/store/common';
+import { N9E_PATHNAME } from '@/utils/constant';
 
 import { Item, FormValues } from './types';
 
@@ -40,7 +41,7 @@ export const deleteItem = function (id: number) {
 };
 
 export const getMCPServers = function (): Promise<{ id: number; name: string }[]> {
-  return request('/api/n9e/mcp-servers', {
+  return request(`/api/${N9E_PATHNAME}/mcp-servers`, {
     method: RequestMethod.Get,
   }).then((res) => res.dat ?? []);
 };

--- a/src/pages/oauthConsent/index.tsx
+++ b/src/pages/oauthConsent/index.tsx
@@ -34,6 +34,7 @@ import { ApiOutlined } from '@ant-design/icons';
 import request from '@/utils/request';
 import { RequestMethod } from '@/store/common';
 import { CommonStateContext } from '@/App';
+import { N9E_PATHNAME } from '@/utils/constant';
 
 import { NAME_SPACE } from './constants';
 
@@ -102,7 +103,7 @@ export default function OAuthConsent() {
   const decide = (decision: 'allow' | 'deny') => {
     setSubmitting(decision);
     setError(null);
-    request('/api/n9e/mcp/oauth/authorize', {
+    request(`/api/${N9E_PATHNAME}/mcp/oauth/authorize`, {
       method: RequestMethod.Post,
       data: { req, decision },
     })


### PR DESCRIPTION
## Summary
- Agent form `getMCPServers` → `/api/\${N9E_PATHNAME}/mcp-servers`
- OAuth consent authorize → `/api/\${N9E_PATHNAME}/mcp/oauth/authorize`

## Why
Pair with n9e-plus-fe change so ENT hits `/api/n9e-plus` while open-source Nightingale stays on `/api/n9e`.

## Test plan
- [ ] ENT: Agent form MCP select loads via `/api/n9e-plus/mcp-servers`
- [ ] ENT: OAuth consent POST goes to `/api/n9e-plus/mcp/oauth/authorize`
- [ ] OS: paths remain `/api/n9e/...`


Made with [Cursor](https://cursor.com)