### PR TITLE
fix(mcp): route MCP APIs through N9E_PATHNAME

### DIFF
--- a/src/pages/aiConfig/agents/services.ts
+++ b/src/pages/aiConfig/agents/services.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 
 import request from '@/utils/request';
 import { RequestMethod } from '@/store/common';
+import { N9E_PATHNAME } from '@/utils/constant';
 
 import { Item, FormValues } from './types';
 
@@ -40,7 +41,7 @@ export const deleteItem = function (id: number) {
 };
 
 export const getMCPServers = function (): Promise<{ id: number; name: string }[]> {
-  return request('/api/n9e/mcp-servers', {
+  return request(`/api/${N9E_PATHNAME}/mcp-servers`, {
     method: RequestMethod.Get,
   }).then((res) => res.dat ?? []);
 };

--- a/src/pages/oauthConsent/index.tsx
+++ b/src/pages/oauthConsent/index.tsx
@@ -34,6 +34,7 @@ import { ApiOutlined } from '@ant-design/icons';
 import request from '@/utils/request';
 import { RequestMethod } from '@/store/common';
 import { CommonStateContext } from '@/App';
+import { N9E_PATHNAME } from '@/utils/constant';
 
 import { NAME_SPACE } from './constants';
 
@@ -102,7 +103,7 @@ export default function OAuthConsent() {
   const decide = (decision: 'allow' | 'deny') => {
     setSubmitting(decision);
     setError(null);
-    request('/api/n9e/mcp/oauth/authorize', {
+    request(`/api/${N9E_PATHNAME}/mcp/oauth/authorize`, {
       method: RequestMethod.Post,
       data: { req, decision },
     })


### PR DESCRIPTION
## Summary
- Agent form `getMCPServers` → `/api/\${N9E_PATHNAME}/mcp-servers`
- OAuth consent authorize → `/api/\${N9E_PATHNAME}/mcp/oauth/authorize`

## Why
ENT/Pro should call `/api/n9e-plus`; open-source stays on `/api/n9e` via `N9E_PATHNAME`.

Conflict branch cut from `pre` + cherry-pick of the feat commit (feat branch itself stays based on `main`, no `pre` merged in). Replaces #2241.

## Test plan
- [ ] ENT: Agent MCP select → `/api/n9e-plus/mcp-servers`
- [ ] ENT: OAuth consent → `/api/n9e-plus/mcp/oauth/authorize`
- [ ] OS: paths remain `/api/n9e/...`


Made with [Cursor](https://cursor.com)