### PR TITLE
fix(mcp): route MCP APIs through N9E_PATHNAME

### DIFF
--- a/src/pages/aiConfig/agents/services.ts
+++ b/src/pages/aiConfig/agents/services.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 
 import request from '@/utils/request';
 import { RequestMethod } from '@/store/common';
+import { N9E_PATHNAME } from '@/utils/constant';
 
 import { Item, FormValues } from './types';
 
@@ -40,7 +41,7 @@ export const deleteItem = function (id: number) {
 };
 
 export const getMCPServers = function (): Promise<{ id: number; name: string }[]> {
-  return request('/api/n9e/mcp-servers', {
+  return request(`/api/${N9E_PATHNAME}/mcp-servers`, {
     method: RequestMethod.Get,
   }).then((res) => res.dat ?? []);
 };

--- a/src/pages/oauthConsent/index.tsx
+++ b/src/pages/oauthConsent/index.tsx
@@ -34,6 +34,7 @@ import { ApiOutlined } from '@ant-design/icons';
 import request from '@/utils/request';
 import { RequestMethod } from '@/store/common';
 import { CommonStateContext } from '@/App';
+import { N9E_PATHNAME } from '@/utils/constant';
 
 import { NAME_SPACE } from './constants';
 
@@ -102,7 +103,7 @@ export default function OAuthConsent() {
   const decide = (decision: 'allow' | 'deny') => {
     setSubmitting(decision);
     setError(null);
-    request('/api/n9e/mcp/oauth/authorize', {
+    request(`/api/${N9E_PATHNAME}/mcp/oauth/authorize`, {
       method: RequestMethod.Post,
       data: { req, decision },
     })


### PR DESCRIPTION
## Summary
- Route agent MCP server list and OAuth consent authorize URLs through `N9E_PATHNAME` instead of hardcoded `/api/n9e`.
- ENT resolves to `n9e-plus`; open-source Nightingale stays on `n9e`.

## Test plan
- [ ] Agent form MCP server dropdown loads via `/api/n9e-plus/...` on ENT
- [ ] OAuth consent authorize request uses the same prefix
- [ ] Open-source build still uses `/api/n9e/...`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for AI agent configuration and OAuth authorization requests across supported deployment paths.
  * Ensured these requests use the configured application path consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->