### PR TITLE
feat(pageLayout, hosts): add headerCenter slot for ObsLoop entry

### DIFF
--- a/src/components/pageLayout/PageLayoutWithTabs/index.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/index.tsx
@@ -54,9 +54,24 @@ interface IPageLayoutProps {
   productDocLink?: string;
   tabGroup?: string;
   docButtonText?: string;
+  headerCenter?: ReactNode;
 }
 
-const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introIcon, children, customArea, showBack, backPath, doc, productDocLink, tabGroup, docButtonText }) => {
+const PageLayout: React.FC<IPageLayoutProps> = ({
+  icon,
+  title,
+  rightArea,
+  introIcon,
+  children,
+  customArea,
+  showBack,
+  backPath,
+  doc,
+  productDocLink,
+  tabGroup,
+  docButtonText,
+  headerCenter,
+}) => {
   const { t, i18n } = useTranslation('pageLayout');
   const history = useHistory();
   const location = useLocation();
@@ -127,6 +142,8 @@ const PageLayout: React.FC<IPageLayoutProps> = ({ icon, title, rightArea, introI
                   <TabMenu currentMenu={currentMenu} />
                   {shouldShowPageDocLink(doc) && <PageDocLink link={doc} buttonText={docButtonText} />}
                 </div>
+
+                {headerCenter}
 
                 <div className={'page-header-right-area flex-shrink-0'} style={{ display: sessionStorage.getItem('menuHide') === '1' ? 'none' : undefined }}>
                   <span className='page-layout-intro-container'>{introIcon}</span>

--- a/src/components/pageLayout/index.tsx
+++ b/src/components/pageLayout/index.tsx
@@ -48,6 +48,7 @@ interface IPageLayoutProps {
   showBack?: Boolean;
   backPath?: string;
   docFn?: Function;
+  headerCenter?: ReactNode;
 }
 
 export const i18nMap = {

--- a/src/pages/hosts/pages/List/index.tsx
+++ b/src/pages/hosts/pages/List/index.tsx
@@ -7,6 +7,10 @@ import { CommonStateContext } from '@/App';
 import PageLayout from '@/components/pageLayout';
 import BusinessGroup2, { getCleanBusinessGroupIds } from '@/components/BusinessGroup';
 import { getTargetsCompatibleGids } from '@/components/BusinessGroup/presetFilters';
+import { IS_ENT } from '@/utils/constant';
+
+// @ts-ignore — ObsLoop HostEntry（srm-fe parcel；开源/plus 源仓不挂此依赖）
+import ObsLoopHostEntry from 'plus:/parcels/ObsLoop/HostEntry';
 
 import { NS, STATS_COLLAPSED_KEY } from '../../constants';
 import { Item, OperateType } from '../../types';
@@ -43,7 +47,11 @@ export default function index() {
   }, [businessGroup.ids]);
 
   return (
-    <PageLayout title={t('title')} doc='https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/usage/infrastructure/server-list/'>
+    <PageLayout
+      title={t('title')}
+      doc='https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/usage/infrastructure/server-list/'
+      headerCenter={IS_ENT ? <ObsLoopHostEntry gids={gids} /> : undefined}
+    >
       <div className='n9e n9e-hosts-ng-list overflow-hidden'>
         <div className='flex gap-[6px] h-full'>
           <BusinessGroup2


### PR DESCRIPTION
Add an optional headerCenter prop to PageLayout and render the ObsLoop host entry in the hosts list, gated by IS_ENT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for centered content in page headers.
  * The hosts list now displays enterprise host information in the header when applicable.
* **UI Improvements**
  * Header content is positioned between document links and available actions without changing existing page titles or documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->