### PR TITLE
fix(doris): 快捷过滤时把 flatten 出的伪字段名归到真实字段

### DIFF
--- a/src/plugins/doris/ExplorerNG/Main/Query/index.tsx
+++ b/src/plugins/doris/ExplorerNG/Main/Query/index.tsx
@@ -19,6 +19,7 @@ import { getDorisLogsQuery, getDorisHistogram } from '../../../services';
 import { Field } from '../../types';
 import { getOptionsFromLocalstorage, setOptionsToLocalstorage } from '../../utils/optionsLocalstorage';
 import filteredFields from '../../utils/filteredFields';
+import getValidIndexName from '../../utils/getValidIndexName';
 import { scrollToTop, getIsAtBottom } from '../../utils/tableElementMethods';
 import { PinIcon, UnPinIcon } from '../../SideBarNav/FieldsSidebar/PinIcon';
 import { HandleValueFilterParams } from '../../types';
@@ -535,6 +536,10 @@ export default function index(props: Props) {
               // state context
               fieldConfig={currentFieldConfig}
               indexData={indexData}
+              getAddToQueryInfo={(params) => {
+                const indexName = getValidIndexName(params);
+                return { isIndex: !!indexName, indexName };
+              }}
               range={queryValues?.range}
             />
           ) : loading || histogramLoading ? (

--- a/src/plugins/doris/ExplorerNG/index.tsx
+++ b/src/plugins/doris/ExplorerNG/index.tsx
@@ -102,7 +102,11 @@ export default function index(props: Props) {
   };
 
   const handleValueFilter = (params: OnValueFilterParams) => {
-    const assignmentOperator = params.assignmentOperator || ':';
+    // params.key 是日志行 flatten 后的名字，可能是 fctags.dirname 这类非表字段；indexName 才是真实字段。
+    // 两者不一致说明点中的值只是该字段值里的一个片段，只能用 ":" 做内容匹配，"=" 永远匹配不到。
+    const filterKey = params.indexName || params.key;
+    const isFragmentOfField = _.toLower(filterKey) !== _.toLower(params.key);
+    const assignmentOperator = isFragmentOfField ? ':' : params.assignmentOperator || ':';
     const values = form.getFieldsValue();
     const query = values.query;
     let queryStr = _.trim(query.query);
@@ -111,10 +115,10 @@ export default function index(props: Props) {
     }
     if (params.value === null) {
       if (params.operator === 'AND') {
-        queryStr += `${queryStr === '' ? '' : ' AND'} ${params.key} IS NULL`;
+        queryStr += `${queryStr === '' ? '' : ' AND'} ${filterKey} IS NULL`;
       }
       if (params.operator === 'NOT') {
-        queryStr += `${queryStr === '' ? '' : ' AND'} ${params.key} IS NOT NULL`;
+        queryStr += `${queryStr === '' ? '' : ' AND'} ${filterKey} IS NOT NULL`;
       }
     } else {
       let escapedValue = params.value;
@@ -123,10 +127,10 @@ export default function index(props: Props) {
         escapedValue = _.replace(params.value, /"/g, '\\"');
       }
       if (params.operator === 'AND') {
-        queryStr += `${queryStr === '' ? '' : ' AND'} ${params.key}${assignmentOperator}"${escapedValue}"`;
+        queryStr += `${queryStr === '' ? '' : ' AND'} ${filterKey}${assignmentOperator}"${escapedValue}"`;
       }
       if (params.operator === 'NOT') {
-        queryStr += `${queryStr === '' ? ' NOT' : ' AND NOT'} ${params.key}${assignmentOperator}"${escapedValue}"`;
+        queryStr += `${queryStr === '' ? ' NOT' : ' AND NOT'} ${filterKey}${assignmentOperator}"${escapedValue}"`;
       }
     }
     form.setFieldsValue({

--- a/src/plugins/doris/ExplorerNG/utils/getValidIndexName.test.ts
+++ b/src/plugins/doris/ExplorerNG/utils/getValidIndexName.test.ts
@@ -1,0 +1,59 @@
+import { Field } from '@/pages/logExplorer/types';
+
+import getValidIndexName from './getValidIndexName';
+
+function buildIndexData(fields: string[]): Field[] {
+  return fields.map((field) => ({ field, type: 'text', indexable: true }));
+}
+
+describe('getValidIndexName', () => {
+  describe('flatten 出的非表字段回退到真实字段', () => {
+    it('fctags 是 text 列时，fctags.dirname 回退到 fctags', () => {
+      const indexData = buildIndexData(['timestamp', 'fctags', 'message']);
+      expect(getValidIndexName({ fieldName: 'fctags.dirname', indexData })).toBe('fctags');
+    });
+
+    it('多层路径逐级向上回退到最近的真实字段', () => {
+      const indexData = buildIndexData(['logRecord.attributes', 'logRecord']);
+      expect(getValidIndexName({ fieldName: 'logRecord.attributes.msg.inner', indexData })).toBe('logRecord.attributes');
+    });
+  });
+
+  describe('VARIANT 子字段是真实字段', () => {
+    it('完整路径在 indexData 中时直接返回', () => {
+      const indexData = buildIndexData(['fctags', 'fctags.dirname']);
+      expect(getValidIndexName({ fieldName: 'fctags.dirname', indexData })).toBe('fctags.dirname');
+    });
+
+    it('大小写与日志里的 key 不一致时仍命中，并返回 indexData 中的写法', () => {
+      const indexData = buildIndexData(['logrecord.attributes.msg']);
+      expect(getValidIndexName({ fieldName: 'logRecord.attributes.msg', indexData })).toBe('logrecord.attributes.msg');
+    });
+  });
+
+  describe('parentKey 与 fieldName 拼成完整路径', () => {
+    it('嵌套渲染传入叶子名时用 parentKey 补全', () => {
+      expect(getValidIndexName({ fieldName: 'dirname', parentKey: 'fctags', indexData: buildIndexData(['fctags']) })).toBe('fctags');
+    });
+
+    it('补全后的完整路径命中时返回完整路径', () => {
+      expect(getValidIndexName({ fieldName: 'dirname', parentKey: 'fctags', indexData: buildIndexData(['fctags.dirname']) })).toBe('fctags.dirname');
+    });
+  });
+
+  describe('无字段可用', () => {
+    it('顶层字段不存在时返回空', () => {
+      expect(getValidIndexName({ fieldName: 'unknown', indexData: buildIndexData(['fctags']) })).toBe('');
+    });
+
+    it('indexData 为空时返回空', () => {
+      expect(getValidIndexName({ fieldName: 'fctags.dirname', indexData: [] })).toBe('');
+    });
+  });
+
+  describe('普通顶层字段', () => {
+    it('直接命中', () => {
+      expect(getValidIndexName({ fieldName: 'message', indexData: buildIndexData(['message']) })).toBe('message');
+    });
+  });
+});

--- a/src/plugins/doris/ExplorerNG/utils/getValidIndexName.ts
+++ b/src/plugins/doris/ExplorerNG/utils/getValidIndexName.ts
@@ -1,0 +1,21 @@
+import _ from 'lodash';
+
+import { Field } from '@/pages/logExplorer/types';
+
+/**
+ * 沿点号逐级向上回退，返回第一个存在于 indexData 的真实字段名；都不存在时返回 ''。
+ * 日志行 flatten 后，值是 JSON 文本的 text 列会展开出 fctags.dirname 这类名字，它们不是表字段，
+ * 只有 VARIANT 列的子字段才会由后端 /doris-index 返回。Doris 字段名不区分大小写，故不敏感匹配。
+ */
+export default function getValidIndexName(params: { fieldName: string; parentKey?: string; indexData: Field[] }): string {
+  const { fieldName, parentKey, indexData } = params;
+  const parts = _.split(parentKey ? `${parentKey}.${fieldName}` : fieldName, '.');
+  for (let end = parts.length; end > 0; end--) {
+    const candidate = _.join(_.slice(parts, 0, end), '.');
+    const matched = _.find(indexData, (item) => _.toLower(item.field) === _.toLower(candidate));
+    if (matched) {
+      return matched.field;
+    }
+  }
+  return '';
+}


### PR DESCRIPTION
## 问题

Doris 日志检索里，`fctags` 是值为 JSON 文本的 text 列。前端加载日志后会按值形态做启发式展开（`normalizeLogStructures` + `flatten`），把它展成 `fctags.dirname`、`fctags.filename` 这类名字。

这些名字**不是表字段**——`dirname` 是 `fctags` 的内容。后端 `/doris-index` 只返回 `fctags`，`FormatField` 解析不出 `fctags.dirname`，会返回 `ErrFieldNotExists`；而 `QueryOriginLogs` 把这个错误吞成空结果。

用户体感：在日志详情面板点 `fctags.dirname` 的值做快捷过滤，日志全部消失，且没有任何报错。

真正存在子字段的是 VARIANT 列，它的子字段由 Doris `DESC`（`describe_extend_variant_column=true`）展开后经 `/doris-index` 返回，本来就是合法字段。

## 改动

新增 `getValidIndexName`：把点击的字段名沿点号逐级向上回退，返回第一个真实存在于 `indexData` 的字段名。

- `fctags` 是 text 列 → `fctags.dirname` 回退到 `fctags`
- `fctags` 是 VARIANT 列 → `fctags.dirname` 本就在 index 里，精确命中，不回退

不需要判断字段类型，index 存在性本身就区分了两种情况。

给 Doris 的 `LogsViewer` 补上 `getAddToQueryInfo`（该 prop 早已存在，SLS / 华为 LTS / BCE 都在用，Doris 是唯一没填的）。连一个真实祖先都找不到时返回 `isIndex: false`，快捷过滤菜单不显示，不再生成后端解析不出来的查询。

`handleValueFilter` 改用真实字段名。发生回退时强制用 `:` 做内容匹配——点中的值只是 `fctags` 整段 JSON 文本里的一个片段，用 `=` 精确等于永远匹配不到，那只是换个方式静默返回空。后端对 `:` 在字段无倒排索引时会自动降级成 `LIKE '%value%'`，所以 text 列上一定能执行。

## 影响面

改动全部在 `src/plugins/doris/ExplorerNG/` 内，未触碰任何共享组件，其他数据源（ES / ClickHouse / SLS / 华为 LTS / BCE / Loki / VictoriaLogs）零影响。仅作用于「点内容做快捷过滤」这一条链路。

## Test plan

- [x] 新增 9 个单测覆盖 text 列回退、VARIANT 精确命中、大小写不一致、`parentKey` 补全、无字段可用
- [x] `jest src/pages/logExplorer src/plugins/doris`：14 suites / 99 tests 全过
- [x] `tsc --noEmit`：报错数与 `git stash` 后的基线逐条一致，无新增
- [x] `prettier --check`：合规
- [ ] 测试环境验证：text 列（`pre_log.pre_java_log` 的 `fctags`）点子字段值过滤，query 应为 `fctags:"..."` 且能返回结果
- [ ] 测试环境验证：VARIANT 列点子字段值过滤，query 应为 `xxx.sub="..."` 精确匹配

Made with [Cursor](https://cursor.com)