### PR TITLE
feat(login): support /login?sso=xxx to auto redirect to SSO provider

### DIFF
--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -130,6 +130,9 @@ export default function Login() {
   }, []);
 
   useEffect(() => {
+    // 自动跳转期间登录表单未挂载，verifyimgRef 为空，此时拉验证码会误报「获取验证码失败」，
+    // 且跳转失败复位后验证码图没有 src。等 ssoRedirecting 复位、表单挂载后再拉
+    if (ssoRedirecting) return;
     getSsoConfig().then((res) => {
       if (res.dat) {
         setDis({
@@ -156,7 +159,7 @@ export default function Login() {
         });
       }
     });
-  }, []);
+  }, [ssoRedirecting]);
 
   const handleSubmit = () => {
     form.validateFields().then(() => {

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -15,7 +15,7 @@
  *
  */
 import React, { useState, useEffect, useRef, useContext } from 'react';
-import { Form, Input, Button, message, Space, Dropdown, Menu } from 'antd';
+import { Form, Input, Button, message, Space, Dropdown, Menu, Spin } from 'antd';
 import { useLocation } from 'react-router-dom';
 import { PictureOutlined, UserOutlined, LockOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
@@ -62,12 +62,27 @@ export interface DisplayName {
   feishu?: string;
 }
 
+// /login?sso=oidc 支持的取值，用于免去手动点击第三方登录链接
+const SSO_REDIRECT_GETTERS: Record<string, (redirect: string) => Promise<any>> = {
+  oidc: getRedirectURL,
+  cas: getRedirectURLCAS,
+  oauth: getRedirectURLOAuth,
+  oauth2: getRedirectURLOAuth,
+  custom: getRedirectURLCustom,
+  dingtalk: getRedirectURLDingtalk,
+  feishu: getRedirectURLFeishu,
+};
+
 export default function Login() {
   const { t, i18n } = useTranslation(NAME_SPACE);
   const [form] = Form.useForm();
   const location = useLocation();
   const { siteInfo } = useContext(CommonStateContext);
   const redirect = (location.search && new URLSearchParams(location.search).get('redirect')) || '';
+  const searchParams = new URLSearchParams(location.search);
+  // 带 ?admin 表示要用本地账号登录，此时不自动跳转，与 Plus 侧全局自动跳转的约定保持一致
+  const ssoWay = searchParams.has('admin') ? '' : (searchParams.get('sso') || '').toLowerCase();
+  const [ssoRedirecting, setSsoRedirecting] = useState(!!SSO_REDIRECT_GETTERS[ssoWay]);
   const [displayName, setDis] = useState<DisplayName>({
     oidc: 'OIDC',
     cas: 'CAS',
@@ -91,6 +106,28 @@ export default function Login() {
     });
   };
   useSsoWay(redirect);
+
+  // /login?sso=oidc 直接跳转到指定的第三方登录，跳转成功后浏览器会离开当前页面，
+  // 只有拿不到登录地址或接口异常时才复位 loading，把登录表单还给用户
+  useEffect(() => {
+    const getSSORedirectURL = SSO_REDIRECT_GETTERS[ssoWay];
+    if (!getSSORedirectURL) return;
+    getSSORedirectURL(redirect)
+      .then((res) => {
+        if (!res.dat) {
+          message.warning(t('sso_no_url', { name: ssoWay }));
+          setSsoRedirecting(false);
+        } else if (ssoWay === 'cas') {
+          localStorage.setItem('CAS_state', res.dat.state);
+          window.location.href = res.dat.redirect;
+        } else {
+          window.location.href = res.dat;
+        }
+      })
+      .catch(() => {
+        setSsoRedirecting(false);
+      });
+  }, []);
 
   useEffect(() => {
     getSsoConfig().then((res) => {
@@ -150,6 +187,14 @@ export default function Login() {
         }
       });
   };
+
+  if (ssoRedirecting) {
+    return (
+      <div className='login-warp'>
+        <Spin size='large' />
+      </div>
+    );
+  }
 
   return (
     <div className='login-warp'>


### PR DESCRIPTION
## 背景

登录页目前只能手动点击「其他登录方式」里的 SSO 链接。有些场景（内部门户跳转、书签、告警通知里的链接）希望直接落到第三方登录，省掉这一次点击。

Pro 版虽然有 `global_sso_way` 的全局自动跳转，但它由后端配置决定跳哪个，前端无法按链接指定。

## 改动

登录页新增 `sso` URL 参数，例如 `/login?sso=oidc`，等价于自动点了对应的 SSO 链接。

- 支持的取值：`oidc` / `cas` / `oauth`（兼容 `oauth2`）/ `custom` / `dingtalk` / `feishu`，大小写不敏感
- 无法识别的值当作没传，正常展示登录表单
- 跳转期间展示 loading 遮罩，避免登录表单闪现、用户误输入
- 该 SSO 未配置登录地址或接口异常时，复位 loading 把登录表单还给用户，并复用已有的 `sso_no_url` 提示，不会卡在转圈
- `redirect` 参数照常透传给 SSO 接口
- `?admin` 仍然是「用本地账号登录」的逃生口，`/login?admin&sso=oidc` 不跳转

实现为纯增量，复用已有的 `getRedirectURL*` service，未改动原有的六个 SSO 链接，未新增 i18n key。

> 注意：CAS 需要在跳转前写 `CAS_state`，这段逻辑现在在自动跳转和手动点击两处各有一份，后续调整 CAS 需要同时改。

配套 PR（Pro）：URL 上显式指定 `sso` 时，`useSsoWay` 不再按 `global_sso_way` 跳转，避免两处抢着写 `window.location.href`。

## 验证

用 Playwright 对社区版构建（`plus:` 走 PlusPlaceholder）做的端到端验证：

| 场景 | 结果 |
| --- | --- |
| `/login` 正常渲染、无 JS 运行时错误 | PASS |
| `?sso=oidc` 未配置时还原表单 + 提示 | PASS |
| `?sso=oidc` 跳转前展示遮罩、不闪表单 | PASS |
| `?sso=oidc` 已配置时自动跳转 | PASS |
| `?sso=cas` 自动跳转且写入 `CAS_state` | PASS |
| `?sso=OAuth2` 大小写与别名兼容 | PASS |
| `?sso=oidc&redirect=/targets` 透传 redirect | PASS |
| `?sso=garbage` 展示表单、不发跳转请求 | PASS |
| `?sso=oidc&admin` 保留本地表单、不跳转 | PASS |
| 原有六个 SSO 链接点击回归（含 CAS_state、未配置提示） | PASS |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic single sign-on redirection based on the selected provider.
  * Added support for OAuth2 and other configured SSO providers.
  * Added a loading indicator while redirecting to SSO.
  * Preserved the local login form when redirection is unavailable or fails.
  * Added support for forcing local administrator login.
  * Improved handling of login state during automatic redirection and fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->