### PR TITLE
fix(table): drop duplicate metric-view tips and unstick notify pagination

### DIFF
--- a/src/pages/metricsBuiltin/List.tsx
+++ b/src/pages/metricsBuiltin/List.tsx
@@ -161,42 +161,40 @@ export default function index() {
       render: (val, record) => {
         const recordClone = _.cloneDeep(record);
         return (
-          <Tooltip overlayClassName='ant-tooltip-max-width-600 ant-tooltip-with-link' title={record.note ? <Markdown content={record.note} inTooltip /> : undefined}>
-            <a
-              onClick={() => {
-                const curFilter = filtersRef.current?.getActive();
-                let label_filter = '';
-                try {
-                  if (curFilter && curFilter.configs) {
-                    label_filter = filtersToStr(JSON.parse(curFilter.configs));
-                  }
-                } catch (e) {
-                  console.error(e);
+          <a
+            onClick={() => {
+              const curFilter = filtersRef.current?.getActive();
+              let label_filter = '';
+              try {
+                if (curFilter && curFilter.configs) {
+                  label_filter = filtersToStr(JSON.parse(curFilter.configs));
                 }
-                if (label_filter) {
-                  buildLabelFilterAndExpression({
-                    label_filter,
-                    promql: record.expression,
+              } catch (e) {
+                console.error(e);
+              }
+              if (label_filter) {
+                buildLabelFilterAndExpression({
+                  label_filter,
+                  promql: record.expression,
+                })
+                  .then((res) => {
+                    recordClone.expression = res;
+                    setExplorerDrawerVisible(true);
+                    setExplorerDrawerData(recordClone);
                   })
-                    .then((res) => {
-                      recordClone.expression = res;
-                      setExplorerDrawerVisible(true);
-                      setExplorerDrawerData(recordClone);
-                    })
-                    .catch(() => {
-                      message.warning(t('filter.build_labelfilter_and_expression_error'));
-                      setExplorerDrawerVisible(true);
-                      setExplorerDrawerData(recordClone);
-                    });
-                } else {
-                  setExplorerDrawerVisible(true);
-                  setExplorerDrawerData(recordClone);
-                }
-              }}
-            >
-              {val}
-            </a>
-          </Tooltip>
+                  .catch(() => {
+                    message.warning(t('filter.build_labelfilter_and_expression_error'));
+                    setExplorerDrawerVisible(true);
+                    setExplorerDrawerData(recordClone);
+                  });
+              } else {
+                setExplorerDrawerVisible(true);
+                setExplorerDrawerData(recordClone);
+              }
+            }}
+          >
+            {val}
+          </a>
         );
       },
     },
@@ -241,9 +239,15 @@ export default function index() {
     {
       title: t('note'),
       dataIndex: 'note',
-      ellipsis: { showTitle: false },
       render: (value) => {
-        return <EllipsisText text={value} />;
+        if (!value) return '-';
+        return (
+          <EllipsisText
+            text={value}
+            title={<Markdown content={value} inTooltip />}
+            tooltipProps={{ overlayClassName: 'ant-tooltip-max-width-600 ant-tooltip-with-link' }}
+          />
+        );
       },
     },
     updateByColumn({

--- a/src/pages/metricsBuiltin/List.tsx
+++ b/src/pages/metricsBuiltin/List.tsx
@@ -241,10 +241,13 @@ export default function index() {
       dataIndex: 'note',
       render: (value) => {
         if (!value) return '-';
+        // Cap width on the ellipsis node (not column.ellipsis) so the table stays
+        // tableLayout:auto and long notes truncate with a markdown tooltip.
         return (
           <EllipsisText
             text={value}
             title={<Markdown content={value} inTooltip />}
+            style={{ maxWidth: 320 }}
             tooltipProps={{ overlayClassName: 'ant-tooltip-max-width-600 ant-tooltip-with-link' }}
           />
         );

--- a/src/pages/notificationChannels/pages/ListNG/index.tsx
+++ b/src/pages/notificationChannels/pages/ListNG/index.tsx
@@ -84,20 +84,19 @@ export default function index() {
       doc='https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/notify-channel/'
     >
       <div className='n9e'>
-        <div className='flex h-full overflow-hidden'>
-          <div className='h-full shrink-0 overflow-hidden'>
-            <div className='flex h-full w-[360px] flex-col overflow-hidden'>
-              <div className='pr-[16px] mb-4 flex-0'>
-                <Input
-                  placeholder={t('types_search_placeholder')}
-                  value={typesSearch}
-                  onChange={(e) => {
-                    setTypesSearch(e.target.value);
-                  }}
-                />
-              </div>
-              <div className='pr-[10px] h-full min-h-0 best-looking-scroll'>
-                <div className='grid grid-cols-2 gap-3'>
+        <div className='flex items-start'>
+          <div className='w-[360px] shrink-0'>
+            <div className='pr-[16px] mb-4'>
+              <Input
+                placeholder={t('types_search_placeholder')}
+                value={typesSearch}
+                onChange={(e) => {
+                  setTypesSearch(e.target.value);
+                }}
+              />
+            </div>
+            <div className='pr-[10px]'>
+              <div className='grid grid-cols-2 gap-3'>
                   {map(filteredTypes, (val, key) => {
                     return (
                       <Link to={`/notification-channels/add?ident=${key}`} key={key}>
@@ -116,9 +115,8 @@ export default function index() {
                 </div>
               </div>
             </div>
-          </div>
-          <div className='w-px bg-fc-300'></div>
-          <div className='ml-4 w-full min-w-0 flex-1 flex flex-col gap-4'>
+          <div className='w-px self-stretch bg-fc-300'></div>
+          <div className='ml-4 min-w-0 flex-1 flex flex-col gap-4'>
             <div className='flex justify-between'>
               <Space>
                 <Input
@@ -229,8 +227,7 @@ export default function index() {
                 </Button>
               </Space>
             </div>
-            <div className='n9e-antd-table-height-full'>
-              <EnhancedTable
+            <EnhancedTable
                 size='small'
                 loading={loading}
                 rowKey='id'
@@ -359,9 +356,7 @@ export default function index() {
                   const saved = JSON.parse(window.sessionStorage.getItem(FILTER_SESSION_STORAGE_KEY) || '{}');
                   window.sessionStorage.setItem(FILTER_SESSION_STORAGE_KEY, JSON.stringify({ ...saved, current: pag.current || 1 }));
                 }}
-                scroll={{ y: 'calc(100% - 42px)' }}
               />
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Metric view: remove the note markdown tooltip from the name column; keep it on the description column via `EllipsisText` (only when truncated)
- Notification channels: drop full-height + `scroll.y` so the pager sits under the table, matching datasource

## Review
- Code-review pass on the branch diff vs `origin/main`
- No blockers; `.claude/` local files not included

## Verification
- `git diff --check`: clean on the changed files
- `tsc --noEmit`: no new errors in the touched files (existing Loki/LogQL baseline errors unchanged)
- Layout change is structural; please spot-check `/metrics-built-in` hover and `/notification-channels` pager placement

## Notes
- Companion →pre PR uses `conflict-metrics-note-tooltip-0811` (cherry-pick onto `pre`, clean feat branch stays for →main)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metric list readability by displaying names directly without note tooltips.
  * Empty metric notes now display as “-”, while nonempty notes support Markdown and accessible tooltips.
  * Preserved filtering and explorer drawer behavior when selecting metric names.

* **Style**
  * Simplified the notification channel page layout.
  * Improved sizing and scrolling between the channel browser and content pane.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->