### PR TITLE
fix(AiChatNG): force drawer for ENT launches on FlashAI config pages

### DIFF
--- a/src/components/AiChatNG/FlashAiButton.test.ts
+++ b/src/components/AiChatNG/FlashAiButton.test.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import path from 'path';
+
+const source = fs.readFileSync(path.join(__dirname, 'FlashAiButton.tsx'), 'utf8');
+
+function extractUseAiEntClickHandler(code: string): string {
+  const start = code.indexOf('function useAiEntClickHandler');
+  expect(start).toBeGreaterThanOrEqual(0);
+  const callbackStart = code.indexOf('return React.useCallback(() => {', start);
+  expect(callbackStart).toBeGreaterThan(start);
+  let depth = 0;
+  let i = code.indexOf('{', callbackStart);
+  for (; i < code.length; i++) {
+    if (code[i] === '{') depth++;
+    else if (code[i] === '}') {
+      depth--;
+      if (depth === 0) return code.slice(callbackStart, i + 1);
+    }
+  }
+  throw new Error('unclosed useAiEntClickHandler callback');
+}
+
+describe('useAiEntClickHandler', () => {
+  const handler = extractUseAiEntClickHandler(source);
+
+  it('forces a drawer overlay so ConfigHost pages on /flashai* can still open chat', () => {
+    expect(handler).toMatch(/forceDrawer:\s*true/);
+  });
+
+  it('keeps forceDrawer after queryAction spread so call sites cannot wipe it', () => {
+    const customStart = handler.indexOf('custom:');
+    const customBlock = handler.slice(customStart);
+    const spreadAt = customBlock.indexOf('...queryAction');
+    const forceAt = customBlock.search(/forceDrawer:\s*true/);
+    expect(spreadAt).toBeGreaterThanOrEqual(0);
+    expect(forceAt).toBeGreaterThan(spreadAt);
+  });
+});

--- a/src/components/AiChatNG/FlashAiButton.tsx
+++ b/src/components/AiChatNG/FlashAiButton.tsx
@@ -53,6 +53,9 @@ function useAiEntClickHandler(options?: {
         createNew: true,
         ...queryPageFrom,
         ...queryAction,
+        // After spreads: ConfigHost pages live on /flashai*, where AiChat stays
+        // in page mode unless forceDrawer is set (knowledge / scheduled-task).
+        forceDrawer: true,
       } as any,
     });
   }, [setAiChatVisible, setAiHandleEvent, setAiExternalConfig, setParamsAiAction, onExecuteQueryForQueryContent, promptList, queryPageFrom, queryAction]);


### PR DESCRIPTION
## Summary
- ENT `AiButton` / `CustomAiButtonWrap` launches now set `forceDrawer: true`, so FlashAI config pages (task channel create / template execute) can overlay the chat drawer while already on `/flashai*`.
- `forceDrawer` is written after the `queryAction` spread so call sites cannot wipe it. Firemap / Polaris / Landing still open via `firemap`/`slo` params on non-FlashAI routes and are unchanged.

## Test plan
- [ ] Open FlashAI → 任务通道 → 任务列表, click 创建: chat drawer overlays the config page
- [ ] On the same page, template row 立即执行: drawer opens and sends the template prompt
- [ ] Knowledge-base「AI 创建」and scheduled-task「立即执行」still overlay as before
- [ ] Firemap / Polaris AI analysis still opens the drawer from those pages
- [ ] `npx jest src/components/AiChatNG/FlashAiButton.test.ts` (2 passed)

## Review
Code-review pass against `pre`: same 2-file diff as →main; no merge conflict with `origin/pre`.

## Verification
`npx jest src/components/AiChatNG/FlashAiButton.test.ts` → 2 passed.


Made with [Cursor](https://cursor.com)