### PR TITLE
fix(metricsBuiltin): cap note column ellipsis width at 320px

### DIFF
--- a/src/pages/metricsBuiltin/List.tsx
+++ b/src/pages/metricsBuiltin/List.tsx
@@ -241,10 +241,13 @@ export default function index() {
       dataIndex: 'note',
       render: (value) => {
         if (!value) return '-';
+        // Cap width on the ellipsis node (not column.ellipsis) so the table stays
+        // tableLayout:auto and long notes truncate with a markdown tooltip.
         return (
           <EllipsisText
             text={value}
             title={<Markdown content={value} inTooltip />}
+            style={{ maxWidth: 320 }}
             tooltipProps={{ overlayClassName: 'ant-tooltip-max-width-600 ant-tooltip-with-link' }}
           />
         );


### PR DESCRIPTION
## Summary
- Cap metric-view note `EllipsisText` at `maxWidth: 320` so long notes truncate and the markdown tooltip can show
- Follow-up to #2251: removing `column.ellipsis` left the note cell unbounded and crushed the expression column

## Review
- Cherry-picked onto `origin/pre` with no conflicts
- Clean feat commit remains on `fix-metrics-note-tooltip-0811` (updates open →main #2250)

## Verification
- Structural layout fix; spot-check `/metrics-built-in` note truncation + hover markdown/link


Made with [Cursor](https://cursor.com)