### PR TITLE
feat(list): persist page in URL and reset to 1 on save/group switch

### DIFF
--- a/src/pages/alertRules/Add.tsx
+++ b/src/pages/alertRules/Add.tsx
@@ -23,6 +23,7 @@ import PageLayout from '@/components/pageLayout';
 import { generateQueryNameByIndex } from '@/components/QueryName';
 import Form from './FormNG';
 import { defaultValues } from './Form/constants';
+import { getPageFromSearch } from '@/utils/urlPage';
 
 export default function Add() {
   const { t } = useTranslation('alertRules');
@@ -64,7 +65,7 @@ export default function Add() {
   }
 
   return (
-    <PageLayout title={t('title')} showBack backPath='/alert-rules'>
+    <PageLayout title={t('title')} showBack backPath={`/alert-rules?page=${getPageFromSearch(location.search)}`}>
       <div className='n9e h-full overflow-hidden p-0'>
         <Form initialValues={initialValues} />
       </div>

--- a/src/pages/alertRules/Edit.tsx
+++ b/src/pages/alertRules/Edit.tsx
@@ -24,6 +24,7 @@ import PageLayout from '@/components/pageLayout';
 import { getWarningStrategy } from '@/services/warning';
 import Form from './FormNG';
 import { getAlertRulePure } from './services';
+import { getPageFromSearch } from '@/utils/urlPage';
 
 export default function Edit() {
   const { t } = useTranslation('alertRules');
@@ -62,7 +63,7 @@ export default function Edit() {
   }, 2000);
 
   return (
-    <PageLayout title={t('title')} showBack backPath='/alert-rules'>
+    <PageLayout title={t('title')} showBack backPath={`/alert-rules?page=${getPageFromSearch(search)}`}>
       <div className='n9e h-full overflow-hidden p-0'>{!_.isEmpty(values) && <Form type={mode === 'clone' ? 2 : 1} initialValues={values} editable={editable} />}</div>
     </PageLayout>
   );

--- a/src/pages/alertRules/FormNG/index.tsx
+++ b/src/pages/alertRules/FormNG/index.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useEffect, useMemo, useState, useRef,
 import { Alert, Button, Card, Col, Form, Input, message, Row, Select, Space } from 'antd';
 import { Sparkles, ChevronsUpDown, ChevronsDownUp, PanelRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Link, useHistory, useParams } from 'react-router-dom';
+import { Link, useHistory, useParams, useLocation } from 'react-router-dom';
 import _ from 'lodash';
 
 import { CommonStateContext } from '@/App';
@@ -12,6 +12,7 @@ import { DatasourceCateSelectV2 } from '@/components/DatasourceSelect';
 import { addStrategy, EditStrategy } from '@/services/warning';
 import { scrollToFirstError } from '@/utils';
 import { IS_PLUS } from '@/utils/constant';
+import { getPageFromSearch } from '@/utils/urlPage';
 import RouterPrompt from '@/components/RouterPrompt';
 
 import { defaultValues } from '../Form/constants';
@@ -72,6 +73,7 @@ function AdvancedSettingsSection(props: {
 export default function FormNG(props: IProps) {
   const { type, initialValues, editable = true } = props;
   const history = useHistory();
+  const location = useLocation();
   const { bgid } = useParams<{ bgid: string }>();
   const { t, i18n } = useTranslation('alertRules');
 
@@ -194,6 +196,7 @@ export default function FormNG(props: IProps) {
   const leaveAfterSave = useCallback(() => {
     allowNextRouteRef.current = true;
     setAllowedLeave(true);
+    // 新增/编辑保存后回列表第一页（不带 page 参数，URL 默认第一页）
     history.push('/alert-rules');
   }, [history]);
 
@@ -592,7 +595,7 @@ export default function FormNG(props: IProps) {
                         {t('common:btn.save')}
                       </Button>
                       <TestFireModal bgid={initialValues?.group_id || Number(bgid)} buttonDisabled={editable === false} />
-                      <Link to='/alert-rules'>
+                      <Link to={{ pathname: '/alert-rules', search: `?page=${getPageFromSearch(location.search)}` }}>
                         <Button>{t('common:btn.cancel')}</Button>
                       </Link>
                     </Space>

--- a/src/pages/alertRules/List/ListNG.tsx
+++ b/src/pages/alertRules/List/ListNG.tsx
@@ -6,7 +6,7 @@ import { TriangleAlert, CircleCheckBig } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useDebounceFn } from 'ahooks';
 import _ from 'lodash';
-import { Link } from 'react-router-dom';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 
 import { CommonStateContext } from '@/App';
 import { updateAlertRules, deleteStrategy } from '@/services/warning';
@@ -22,10 +22,11 @@ import localeCompare from '@/pages/dashboard/Renderer/utils/localeCompare';
 import { getItems as getNotificationRules, RuleItem as NotificationRuleItem } from '@/pages/notificationRules/services';
 import { NS as notificationRulesNS } from '@/pages/notificationRules/constants';
 import { AlertRuleType, AlertRuleStatus } from '@/pages/alertRules/types';
-import { defaultColumnsConfigs, LOCAL_STORAGE_KEY } from '@/pages/alertRules/List/constants';
+import { defaultColumnsConfigs, LOCAL_STORAGE_KEY, FILTER_SESSION_STORAGE_KEY } from '@/pages/alertRules/List/constants';
 import EventsDrawer, { Props as EventsDrawerProps } from '@/pages/alertRules/List/EventsDrawer';
 import EvalRecordsDrawer, { Props as EvalRecordsDrawerProps } from '@/pages/alertRules/List/EvalRecordsDrawer';
 import { matchTriggerType, TRIGGER_TYPE_OPTIONS, TriggerType } from '@/pages/alertRules/List/utils';
+import { getPageFromSearch, setPageInSearch, removePageFromSearch } from '@/utils/urlPage';
 
 interface Filter {
   cate?: string;
@@ -37,7 +38,6 @@ interface Filter {
   triggerType?: TriggerType;
 }
 
-const FILTER_SESSION_STORAGE_KEY = 'alert-rules-filter';
 const includesProm = (datasourceList: any[], ids?: number[]) => {
   return _.some(ids, (id) => {
     return _.some(datasourceList, (item) => {
@@ -56,31 +56,52 @@ interface Props {
   setRefreshFlag?: (flag: string) => void;
   linkTarget?: string;
   emptyGuide?: React.ReactNode;
+  gids?: string;
+  groupSwitchCount?: number;
 }
 
 export default function AlertRules(props: Props) {
   const { t, i18n } = useTranslation('alertRules');
   const { busiGroups, datasourceList, feats } = useContext(CommonStateContext);
-  const { hideBusinessGroupColumn, showRowSelection, readonly, headerExtra, data, loading, setRefreshFlag, linkTarget, emptyGuide } = props;
+  const { hideBusinessGroupColumn, showRowSelection, readonly, headerExtra, data, loading, setRefreshFlag, linkTarget, emptyGuide, gids, groupSwitchCount } = props;
+  const history = useHistory();
+  const location = useLocation();
   let defaultFilter = {} as Filter;
-  let defaultPage = 1;
   try {
     const saved = JSON.parse(window.sessionStorage.getItem(FILTER_SESSION_STORAGE_KEY) || '{}');
     defaultFilter = saved;
-    defaultPage = saved.current || 1;
   } catch (e) {
     console.error(e);
   }
+  const defaultPage = getPageFromSearch(location.search);
   const [filter, setFilter] = useState<Filter>(defaultFilter);
   const [current, setCurrent] = useState<number>(defaultPage);
   const handleFilterChange = (newFilter: Filter) => {
     setFilter(newFilter);
     setCurrent(1);
-    window.sessionStorage.setItem(FILTER_SESSION_STORAGE_KEY, JSON.stringify({ ...newFilter, current: 1 }));
+    window.sessionStorage.setItem(FILTER_SESSION_STORAGE_KEY, JSON.stringify(newFilter));
+    history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, 1) });
   };
+  // 新增/编辑/批量操作保存成功后，记录的更新时间会变化，按更新时间倒序的列表会把刚操作的记录排到第一页，
+  // 因此保存后需要把页码重置为 1，避免停留在旧页码看不到刚操作的记录
+  const resetPaging = () => {
+    setCurrent(1);
+    clearSelection();
+    history.replace({ pathname: location.pathname, search: removePageFromSearch(location.search) });
+  };
+  // 切换业务组时重置到第一页（父组件在业务组选择源头递增计数触发，不依赖 gids 变化时序）
+  useEffect(() => {
+    if (groupSwitchCount) {
+      resetPaging();
+    }
+  }, [groupSwitchCount]);
   const [queryValue, setQueryValue] = useState<string | undefined>(defaultFilter.search);
   const [selectRowKeys, setSelectRowKeys] = useState<React.Key[]>([]);
   const [selectedRows, setSelectedRows] = useState<AlertRuleType<any>[]>([]);
+  const clearSelection = () => {
+    setSelectRowKeys([]);
+    setSelectedRows([]);
+  };
   const [visibleColumns, setVisibleColumns] = useState<string[]>(() => getDefaultColumnsConfigs(defaultColumnsConfigs, LOCAL_STORAGE_KEY));
   const pagination = usePagination({ PAGESIZE_KEY: 'alert-rules-pagesize' });
   const [eventsDrawerProps, setEventsDrawerProps] = useState<EventsDrawerProps>({
@@ -156,6 +177,7 @@ export default function AlertRules(props: Props) {
                 className='table-text'
                 to={{
                   pathname: `/alert-rules/edit/${record.id}`,
+                  search: `?page=${current}`,
                 }}
                 target={linkTarget}
               >
@@ -472,6 +494,7 @@ export default function AlertRules(props: Props) {
               selectRowKeys,
               selectedRows,
               getList: fetchData,
+              clearSelection,
             })}
           <TableColumnSelect
             options={buildColumnOptions(defaultColumnsConfigs, t)}
@@ -496,8 +519,7 @@ export default function AlertRules(props: Props) {
         pagination={{ ...pagination, current }}
         onChange={(pag) => {
           setCurrent(pag.current || 1);
-          const saved = JSON.parse(window.sessionStorage.getItem(FILTER_SESSION_STORAGE_KEY) || '{}');
-          window.sessionStorage.setItem(FILTER_SESSION_STORAGE_KEY, JSON.stringify({ ...saved, current: pag.current || 1 }));
+          history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, pag.current || 1) });
         }}
         loading={loading}
         dataSource={filterData()}

--- a/src/pages/alertRules/List/MoreOperations.tsx
+++ b/src/pages/alertRules/List/MoreOperations.tsx
@@ -35,6 +35,7 @@ interface MoreOperationsProps {
   selectRowKeys: React.Key[];
   selectedRows: any[];
   getAlertRules: () => void;
+  clearSelection?: () => void;
 }
 
 const ignoreFields = [
@@ -67,7 +68,7 @@ const ignoreFields = [
 
 export default function MoreOperations(props: MoreOperationsProps) {
   const { t } = useTranslation('alertRules');
-  const { bgid, isLeaf, selectRowKeys, selectedRows, getAlertRules } = props;
+  const { bgid, isLeaf, selectRowKeys, selectedRows, getAlertRules, clearSelection } = props;
   const [isModalVisible, setisModalVisible] = useState<boolean>(false);
   const { isPlus, busiGroups } = useContext(CommonStateContext);
 
@@ -103,6 +104,7 @@ export default function MoreOperations(props: MoreOperationsProps) {
                       onOk: () => {
                         deleteStrategy(selectRowKeys as number[], bgid!).then(() => {
                           message.success(t('batch.delete_success'));
+                          clearSelection?.();
                           getAlertRules();
                         });
                       },
@@ -140,7 +142,10 @@ export default function MoreOperations(props: MoreOperationsProps) {
                   CloneToBgids({
                     ids: selectRowKeys,
                     busiGroups,
-                    onOk: getAlertRules,
+                    onOk: () => {
+                      clearSelection?.();
+                      getAlertRules();
+                    },
                   });
                 }}
               >
@@ -159,7 +164,10 @@ export default function MoreOperations(props: MoreOperationsProps) {
                     gid: bgid!,
                     ids: selectRowKeys,
                     busiGroups,
-                    onOk: getAlertRules,
+                    onOk: () => {
+                      clearSelection?.();
+                      getAlertRules();
+                    },
                   });
                 }}
               >
@@ -211,6 +219,7 @@ export default function MoreOperations(props: MoreOperationsProps) {
               );
               if (!res.err) {
                 message.success(t('common:success.modify'));
+                clearSelection?.();
                 getAlertRules();
                 setisModalVisible(false);
               } else {
@@ -227,6 +236,7 @@ export default function MoreOperations(props: MoreOperationsProps) {
               );
               if (!res.err) {
                 message.success(t('common:success.modify'));
+                clearSelection?.();
                 getAlertRules();
                 setisModalVisible(false);
               } else {
@@ -245,6 +255,7 @@ export default function MoreOperations(props: MoreOperationsProps) {
               );
               if (!res.err) {
                 message.success(t('common:success.modify'));
+                clearSelection?.();
                 getAlertRules();
                 setisModalVisible(false);
               } else {

--- a/src/pages/alertRules/List/constants.ts
+++ b/src/pages/alertRules/List/constants.ts
@@ -18,6 +18,7 @@ import i18next from 'i18next';
  *
  */
 export const LOCAL_STORAGE_KEY = 'alertRules_columns_configs';
+export const FILTER_SESSION_STORAGE_KEY = 'alert-rules-filter';
 export const defaultColumnsConfigs = [
   {
     name: 'cur_event_count',

--- a/src/pages/alertRules/List/index.tsx
+++ b/src/pages/alertRules/List/index.tsx
@@ -16,6 +16,7 @@ import ListNG from './ListNG';
 
 interface ListProps {
   gids?: string;
+  groupSwitchCount?: number;
 }
 
 function HeaderExtra(
@@ -23,12 +24,13 @@ function HeaderExtra(
     selectRowKeys?: React.Key[];
     selectedRows?: AlertRuleType<any>[];
     getList?: () => void;
+    clearSelection?: () => void;
   },
 ) {
   const { t } = useTranslation('alertRules');
   const { businessGroup, groupedDatasourceList, reloadGroupedDatasourceList, datasourceCateOptions } = useContext(CommonStateContext);
   const history = useHistory();
-  const { gids, selectRowKeys = [], selectedRows = [], getList } = props;
+  const { gids, selectRowKeys = [], selectedRows = [], getList, clearSelection } = props;
 
   return (
     <Space>
@@ -67,6 +69,7 @@ function HeaderExtra(
           selectRowKeys={selectRowKeys}
           selectedRows={selectedRows}
           getAlertRules={getList}
+          clearSelection={clearSelection}
         />
       )}
     </Space>
@@ -77,7 +80,7 @@ export default function List(props: ListProps) {
   const { t } = useTranslation('alertRules');
   const { businessGroup, groupedDatasourceList, reloadGroupedDatasourceList, datasourceCateOptions } = useContext(CommonStateContext);
   const history = useHistory();
-  const { gids } = props;
+  const { gids, groupSwitchCount } = props;
   const [refreshFlag, setRefreshFlag] = useState<string>(_.uniqueId('refresh_'));
   const [data, setData] = useState<AlertRuleType<any>[]>([]);
   const [loading, setLoading] = useState(false);
@@ -107,6 +110,8 @@ export default function List(props: ListProps) {
       <ListNG
         hideBusinessGroupColumn={businessGroup.isLeaf && gids !== '-2'}
         showRowSelection
+        gids={gids}
+        groupSwitchCount={groupSwitchCount}
         headerExtra={<HeaderExtra gids={gids} />}
         data={data}
         loading={loading}

--- a/src/pages/alertRules/index.tsx
+++ b/src/pages/alertRules/index.tsx
@@ -38,6 +38,12 @@ export default function index() {
   const { businessGroup } = useContext(CommonStateContext);
   const { t } = useTranslation('alertRules');
   const [gids, setGids] = useState<string | undefined>(getDefaultGids(N9E_GIDS_LOCALKEY, businessGroup));
+  const [groupSwitchCount, setGroupSwitchCount] = useState(0);
+  // 切换业务组时通知列表重置到第一页（在业务组选择源头触发，不依赖 gids 变化时序）
+  const handleSelectGids = (ids: string) => {
+    setGids(ids);
+    setGroupSwitchCount((count) => count + 1);
+  };
 
   return (
     <PageLayout
@@ -47,8 +53,8 @@ export default function index() {
       headerCenter={IS_ENT ? <ObsLoopAlertRulesTip /> : undefined}
     >
       <div className='alert-rules-container'>
-        <BusinessGroupSideBarWithAll gids={gids} setGids={setGids} localeKey={N9E_GIDS_LOCALKEY} />
-        {businessGroup.ids ? <List gids={gids} /> : <BlankBusinessPlaceholder text={t('title')} />}
+        <BusinessGroupSideBarWithAll gids={gids} setGids={handleSelectGids} localeKey={N9E_GIDS_LOCALKEY} />
+        {businessGroup.ids ? <List gids={gids} groupSwitchCount={groupSwitchCount} /> : <BlankBusinessPlaceholder text={t('title')} />}
       </div>
     </PageLayout>
   );

--- a/src/pages/dashboard/Detail/Title.tsx
+++ b/src/pages/dashboard/Detail/Title.tsx
@@ -16,6 +16,7 @@
  */
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useHistory, useLocation, Link } from 'react-router-dom';
+import { getPageFromSearch } from '@/utils/urlPage';
 import querystring from 'query-string';
 import _ from 'lodash';
 import moment from 'moment';
@@ -105,6 +106,8 @@ export default function Title(props: IProps) {
   const [variablesWithOptions] = useGlobalState('variablesWithOptions');
   const query = querystring.parse(location.search);
   const { viewMode, __public__ } = query;
+  // 从列表进入详情时 URL 带 page 参数，返回列表时回到原页；其他入口回列表第一页
+  const goListPath = props.gobackPath || (getPageFromSearch(location.search) > 1 ? `/dashboards?page=${getPageFromSearch(location.search)}` : '/dashboards');
   // AI 分析仅在正常已保存的仪表盘下展示：匿名公开、模板预览、内置组件场景要么调不通 assistant 接口，要么没有真实 dashboard_id
   const showAiAnalysis = !isPreview && !isBuiltin && __public__ !== 'true' && !!dashboard.id;
   const isClickTrigger = useRef(false);
@@ -193,7 +196,7 @@ export default function Title(props: IProps) {
                     onClick={() => {
                       if (allowedLeave) {
                         goBack(history).catch(() => {
-                          history.push(props.gobackPath || '/dashboards');
+                          history.push(goListPath);
                         });
                       } else {
                         routerPromptRef.current.showPrompt();
@@ -204,7 +207,7 @@ export default function Title(props: IProps) {
               )}
               {!hideGoList && (
                 <Space className='pr-2'>
-                  <Link to={props.gobackPath || '/dashboards'} style={{ fontSize: 14 }}>
+                  <Link to={goListPath} style={{ fontSize: 14 }}>
                     {isBuiltin ? t('builtInComponents:title') : t('list')}
                   </Link>
                   {'/'}

--- a/src/pages/dashboard/List/BatchClone.tsx
+++ b/src/pages/dashboard/List/BatchClone.tsx
@@ -25,11 +25,12 @@ import { boardsClones } from '@/services/dashboardV2';
 interface IProps {
   board_ids: number[];
   busiGroups: any[];
+  onOk?: () => void;
 }
 
 function BatchClone(props: IProps & ModalWrapProps) {
   const { t } = useTranslation('dashboard');
-  const { visible, destroy, board_ids, busiGroups } = props;
+  const { visible, destroy, board_ids, busiGroups, onOk } = props;
   const [importResult, setImportResult] = useState<{ name: string; msg: string }[]>();
 
   return (
@@ -60,6 +61,7 @@ function BatchClone(props: IProps & ModalWrapProps) {
               setImportResult(dataSource);
               if (_.every(dataSource, (item) => !item.msg)) {
                 message.success(t('common:success.clone'));
+                onOk?.();
                 destroy();
               }
             })

--- a/src/pages/dashboard/List/Header.tsx
+++ b/src/pages/dashboard/List/Header.tsx
@@ -31,6 +31,7 @@ import BatchClone from './BatchClone';
 interface IProps {
   gids?: string;
   selectRowKeys: any[];
+  setSelectRowKeys: (keys: number[]) => void;
   refreshList: () => void;
   searchVal: string;
   onSearchChange: (val) => void;
@@ -44,7 +45,19 @@ interface IProps {
 export default function Header(props: IProps) {
   const { businessGroup, busiGroups } = useContext(CommonStateContext);
   const { t } = useTranslation('dashboard');
-  const { gids, selectRowKeys, refreshList, searchVal, onSearchChange, visibleColumns, setVisibleColumns, columnOptions, selectedBusinessGroup, setSelectedBusinessGroup } = props;
+  const {
+    gids,
+    selectRowKeys,
+    setSelectRowKeys,
+    refreshList,
+    searchVal,
+    onSearchChange,
+    visibleColumns,
+    setVisibleColumns,
+    columnOptions,
+    selectedBusinessGroup,
+    setSelectedBusinessGroup,
+  } = props;
   const [importData, setImportData] = React.useState<{
     visible: boolean;
     busiId?: number;
@@ -120,6 +133,9 @@ export default function Header(props: IProps) {
                           BatchClone({
                             board_ids: selectRowKeys,
                             busiGroups,
+                            onOk: () => {
+                              setSelectRowKeys([]);
+                            },
                           });
                         } else {
                           message.warning(t('batch.noSelected'));
@@ -137,6 +153,7 @@ export default function Header(props: IProps) {
                             onOk: async () => {
                               removeDashboards(selectRowKeys).then(() => {
                                 message.success(t('common:success.delete'));
+                                setSelectRowKeys([]);
                                 refreshList();
                               });
                             },

--- a/src/pages/dashboard/List/index.tsx
+++ b/src/pages/dashboard/List/index.tsx
@@ -18,12 +18,13 @@
  * 仪表盘列表页面
  */
 import React, { useState, useEffect, useContext } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { Button, Modal, Space, message, Tooltip } from 'antd';
 import { FundViewOutlined, EditOutlined, ShareAltOutlined } from '@ant-design/icons';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useUpdateEffect } from 'ahooks';
+import { getPageFromSearch, setPageInSearch, removePageFromSearch } from '@/utils/urlPage';
 import { useLocation } from 'react-router-dom';
 import queryString from 'query-string';
 
@@ -56,7 +57,6 @@ import './style.less';
 
 const N9E_GIDS_LOCALKEY = 'N9E_BOARD_NODE_ID';
 const SEARCH_SESSION_STORAGE_KEY = 'n9e_dashboard_search';
-const DASHBOARD_PAGE_SESSION_KEY = 'n9e_dashboard_page';
 const PUBLIC_SELECT_GIDS_LOCALKEY = 'N9E_PUBLIC_SELECT_GIDS';
 const getDefaultPublicSelectGids = (localKey: string) => {
   const valueStr = localStorage.getItem(localKey);
@@ -67,16 +67,15 @@ const getDefaultPublicSelectGids = (localKey: string) => {
 export default function index() {
   const { t } = useTranslation('dashboard');
   const { businessGroup, perms } = useContext(CommonStateContext);
-  const queryParams = queryString.parse(useLocation().search);
+  const history = useHistory();
+  const location = useLocation();
+  const queryParams = queryString.parse(location.search);
   const [gids, setGids] = useState<string | undefined>(() => getDashboardCompatibleGids(getDefaultGidsInDashboard(queryParams, N9E_GIDS_LOCALKEY, businessGroup)));
   const [list, setList] = useState<any[]>([]);
   const [selectRowKeys, setSelectRowKeys] = useState<number[]>([]);
   const [refreshKey, setRefreshKey] = useState(_.uniqueId('refreshKey_'));
   const [searchVal, setsearchVal] = useState<string>(sessionStorage.getItem(SEARCH_SESSION_STORAGE_KEY) || '');
-  const [current, setCurrent] = useState<number>(() => {
-    const saved = sessionStorage.getItem(DASHBOARD_PAGE_SESSION_KEY);
-    return saved ? Number(saved) : 1;
-  });
+  const [current, setCurrent] = useState<number>(() => getPageFromSearch(location.search));
   const [selectedBusinessGroup, setSelectedBusinessGroup] = useState<number[] | undefined>(getDefaultPublicSelectGids(PUBLIC_SELECT_GIDS_LOCALKEY)); // 目前只有公开仪表盘会用到
   const [busiGroups, setBusiGroups] = useState<any[]>([]);
   const pagination = usePagination({ PAGESIZE_KEY: 'dashboard-pagesize' });
@@ -89,8 +88,15 @@ export default function index() {
     setsearchVal('');
     setCurrent(1);
     sessionStorage.removeItem(SEARCH_SESSION_STORAGE_KEY);
-    sessionStorage.removeItem(DASHBOARD_PAGE_SESSION_KEY);
+    history.replace({ pathname: location.pathname, search: removePageFromSearch(location.search) });
   }, [businessGroup.ids]);
+  // 侧边栏切换业务组只更新本地 gids（不更新全局 businessGroup.ids），这里在业务组选择源头重置页码到第一页
+  const handleSelectGids = (ids: string) => {
+    setGids(ids);
+    setCurrent(1);
+    setSelectRowKeys([]);
+    history.replace({ pathname: location.pathname, search: removePageFromSearch(location.search) });
+  };
 
   useEffect(() => {
     if (gids === '-1') {
@@ -132,7 +138,7 @@ export default function index() {
       <div style={{ display: 'flex' }}>
         <BusinessGroupSideBarWithAll
           gids={gids}
-          setGids={setGids}
+          setGids={handleSelectGids}
           localeKey={N9E_GIDS_LOCALKEY}
           showPublicOption={_.includes(perms, '/public-dashboards')}
           publicOptionLabel={t('default_filter.public')}
@@ -145,6 +151,7 @@ export default function index() {
           <Header
             gids={gids}
             selectRowKeys={selectRowKeys}
+            setSelectRowKeys={setSelectRowKeys}
             refreshList={() => {
               setRefreshKey(_.uniqueId('refreshKey_'));
             }}
@@ -153,7 +160,7 @@ export default function index() {
               setsearchVal(val);
               setCurrent(1);
               sessionStorage.setItem(SEARCH_SESSION_STORAGE_KEY, val);
-              sessionStorage.setItem(DASHBOARD_PAGE_SESSION_KEY, '1');
+              history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, 1) });
             }}
             visibleColumns={visibleColumns}
             setVisibleColumns={setVisibleColumns}
@@ -182,7 +189,7 @@ export default function index() {
                           className='table-active-text'
                           to={{
                             pathname: `/dashboards/${record.ident || record.id}`,
-                            search: gids === '-1' ? '__public__=true' : '', // 加上 __public__ 参数，用于在详情页判断是否为公开仪表盘
+                            search: gids === '-1' ? `__public__=true&page=${current}` : `?page=${current}`, // __public__ 用于详情页判断公开仪表盘
                           }}
                         >
                           {text}
@@ -395,7 +402,7 @@ export default function index() {
               current,
               onChange: (page: number) => {
                 setCurrent(page);
-                sessionStorage.setItem(DASHBOARD_PAGE_SESSION_KEY, String(page));
+                history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, page) });
               },
             }}
             locale={{

--- a/src/pages/notificationChannels/constants.ts
+++ b/src/pages/notificationChannels/constants.ts
@@ -2,6 +2,7 @@ import i18next from 'i18next';
 
 export const NS = 'notification-channels';
 export const PERM = `/${NS}`;
+export const FILTER_SESSION_STORAGE_KEY = 'notification-channels-filter';
 export const DEFAULT_VALUES = {
   enable: true,
   param_config: {

--- a/src/pages/notificationChannels/pages/Add.tsx
+++ b/src/pages/notificationChannels/pages/Add.tsx
@@ -33,7 +33,6 @@ export default function Add() {
         </Space>
       }
       showBack
-      backPath={`/${NS}`}
     >
       <div className='n9e'>
         <Form

--- a/src/pages/notificationChannels/pages/Edit.tsx
+++ b/src/pages/notificationChannels/pages/Edit.tsx
@@ -45,7 +45,6 @@ export default function Add() {
         </Space>
       }
       showBack
-      backPath={`/${NS}`}
     >
       <div className='n9e'>
         {data ? (

--- a/src/pages/notificationChannels/pages/Form/index.tsx
+++ b/src/pages/notificationChannels/pages/Form/index.tsx
@@ -3,10 +3,11 @@ import _ from 'lodash';
 import { Form, Space, Input, Switch, Button, Row, Col, Tooltip } from 'antd';
 import { MinusCircleOutlined, PlusCircleOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import { SIZE } from '@/utils/constant';
 import { scrollToFirstError } from '@/utils';
+import { getPageFromSearch } from '@/utils/urlPage';
 import { Document } from '@/components/DocumentDrawer';
 import Splitter from '@/components/Splitter';
 
@@ -30,6 +31,7 @@ interface Props {
 
 export default function FormCpt(props: Props) {
   const { t } = useTranslation(NS);
+  const location = useLocation();
   const [form] = Form.useForm();
   const requestType = Form.useWatch('request_type', form);
   const ident = Form.useWatch('ident', form);
@@ -194,7 +196,7 @@ export default function FormCpt(props: Props) {
                       })
                     }
                   />
-                  <Link to={`/${NS}`}>
+                  <Link to={{ pathname: `/${NS}`, search: `?page=${getPageFromSearch(location.search)}` }}>
                     <Button>{t('common:btn.cancel')}</Button>
                   </Link>
                 </Space>

--- a/src/pages/notificationChannels/pages/ListNG/index.tsx
+++ b/src/pages/notificationChannels/pages/ListNG/index.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Input, Select, Space, Button, Modal, Switch, message } from 'antd';
 import { NotificationOutlined, PlusOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { map, upperCase, includes, filter } from 'lodash';
-import { Link } from 'react-router-dom';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 import { useRequest } from 'ahooks';
 import moment from 'moment';
 
@@ -13,9 +13,10 @@ import { Import, Export } from '@/components/ExportImport';
 import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { dateColumn, updateByColumn } from '@/components/EnhancedTable/columns';
 
-import { NS, getNotificationChannelTypes } from '../../constants';
+import { NS, getNotificationChannelTypes, FILTER_SESSION_STORAGE_KEY } from '../../constants';
 import { getItems, getItem, putItem, deleteItems, postItems } from '../../services';
 import { ChannelItem } from '../../types';
+import { getPageFromSearch, setPageInSearch } from '@/utils/urlPage';
 
 interface Filter {
   search?: string;
@@ -23,10 +24,10 @@ interface Filter {
   idents?: string[];
 }
 
-const FILTER_SESSION_STORAGE_KEY = 'notification-channels-filter';
-
 export default function index() {
   const { t } = useTranslation(NS);
+  const history = useHistory();
+  const location = useLocation();
   const channelTypes = getNotificationChannelTypes();
   const pagination = usePagination({ PAGESIZE_KEY: 'notification-channels-pagesize' });
 
@@ -43,20 +44,20 @@ export default function index() {
 
   const { data, loading, run, mutate } = useRequest(getItems);
   let defaultFilter = {} as Filter;
-  let defaultPage = 1;
   try {
     const saved = JSON.parse(window.sessionStorage.getItem(FILTER_SESSION_STORAGE_KEY) || '{}');
     defaultFilter = saved;
-    defaultPage = saved.current || 1;
   } catch (e) {
     console.error(e);
   }
+  const defaultPage = getPageFromSearch(location.search);
   const [filters, setFilters] = useState<Filter>(defaultFilter);
   const [current, setCurrent] = useState<number>(defaultPage);
   const handleFilterChange = (newFilter: Filter) => {
     setFilters(newFilter);
     setCurrent(1);
-    window.sessionStorage.setItem(FILTER_SESSION_STORAGE_KEY, JSON.stringify({ ...newFilter, current: 1 }));
+    window.sessionStorage.setItem(FILTER_SESSION_STORAGE_KEY, JSON.stringify(newFilter));
+    history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, 1) });
   };
   const [selectedRows, setSelectedRows] = useState<ChannelItem[]>([]);
   const [togglingId, setTogglingId] = useState<number>();
@@ -247,6 +248,7 @@ export default function index() {
                           className='block truncate'
                           to={{
                             pathname: `/${NS}/edit/${record.id}`,
+                            search: `?page=${current}`,
                           }}
                         >
                           {val}
@@ -356,8 +358,7 @@ export default function index() {
                 pagination={{ ...pagination, current }}
                 onChange={(pag) => {
                   setCurrent(pag.current || 1);
-                  const saved = JSON.parse(window.sessionStorage.getItem(FILTER_SESSION_STORAGE_KEY) || '{}');
-                  window.sessionStorage.setItem(FILTER_SESSION_STORAGE_KEY, JSON.stringify({ ...saved, current: pag.current || 1 }));
+                  history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, pag.current || 1) });
                 }}
                 scroll={{ y: 'calc(100% - 42px)' }}
               />

--- a/src/pages/notificationRules/constants.ts
+++ b/src/pages/notificationRules/constants.ts
@@ -3,6 +3,7 @@ import moment from 'moment';
 export const NS = 'notification-rules';
 export const CN = 'n9e-notification-rules';
 export const PERM = `/${NS}`;
+export const FILTER_SESSION_STORAGE_KEY = 'notification-rules-filter';
 export const DEFAULT_VALUES = {
   enable: true,
   notify_configs: [

--- a/src/pages/notificationRules/pages/Add.tsx
+++ b/src/pages/notificationRules/pages/Add.tsx
@@ -14,7 +14,7 @@ export default function Add() {
   const history = useHistory();
 
   return (
-    <PageLayout title={t('title')} showBack backPath={`/${NS}`} doc='https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/quickstart/notify-rules/'>
+    <PageLayout title={t('title')} showBack doc='https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/quickstart/notify-rules/'>
       <div className='n9e'>
         <Form
           onOk={(values) => {

--- a/src/pages/notificationRules/pages/Detail/index.tsx
+++ b/src/pages/notificationRules/pages/Detail/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useLocation } from 'react-router-dom';
 import { Row, Col, Select, Card, Space, Tag, Tooltip, Button } from 'antd';
 import { InfoCircleOutlined, TeamOutlined } from '@ant-design/icons';
 
@@ -13,6 +13,7 @@ import { getBrainLicense } from 'plus:/components/License/services';
 
 import { NS, CN } from '../../constants';
 import { getNotifyStatistics, NotifyStatistics, getItem, RuleItem } from '../../services';
+import { getPageFromSearch } from '@/utils/urlPage';
 import { UpIcon, DownIcon } from '../../components/Icon';
 import Events from './Events';
 import AlertRules from './AlertRules';
@@ -21,6 +22,7 @@ import SubscribeRules from './SubscribeRules';
 export default function Detail() {
   const { t } = useTranslation(NS);
   const { id } = useParams<{ id: string }>();
+  const location = useLocation();
   const [days, setDays] = useState(7);
   const [notifyStatistics, setNotifyStatistics] = useState<NotifyStatistics>();
   const [activeTabKey, setActiveTabKey] = useState('events');
@@ -66,7 +68,7 @@ export default function Detail() {
   };
 
   return (
-    <PageLayout title={t('title')} showBack backPath={`/${NS}`}>
+    <PageLayout title={t('title')} showBack backPath={`/${NS}?page=${getPageFromSearch(location.search)}`}>
       <div className={`n9e ${CN} overflow-hidden`}>
         <div className='h-full flex flex-col gap-4'>
           <div className='flex-shrink-0 flex justify-between'>
@@ -98,6 +100,7 @@ export default function Detail() {
               <Link
                 to={{
                   pathname: `/${NS}/edit/${itemData?.id}`,
+                  search: `?page=${getPageFromSearch(location.search)}`,
                 }}
               >
                 <Button type='primary'>{t('common:btn.edit')}</Button>

--- a/src/pages/notificationRules/pages/Edit.tsx
+++ b/src/pages/notificationRules/pages/Edit.tsx
@@ -29,7 +29,7 @@ export default function Add() {
   }, []);
 
   return (
-    <PageLayout title={t('title')} showBack backPath={`/${NS}`} doc='https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/quickstart/notify-rules/'>
+    <PageLayout title={t('title')} showBack doc='https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/quickstart/notify-rules/'>
       <div className={`n9e ${CN}`}>
         {data ? (
           <Form

--- a/src/pages/notificationRules/pages/Form/index.tsx
+++ b/src/pages/notificationRules/pages/Form/index.tsx
@@ -5,12 +5,13 @@ import { PlusOutlined } from '@ant-design/icons';
 import AffixWrapper from '@/components/AffixWrapper';
 import { ChevronsUpDown, ChevronsDownUp } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import { getTeamInfoList } from '@/services/manage';
 import { getBusiGroupsAlertRules } from '@/services/warning';
 import { SIZE } from '@/utils/constant';
 import { scrollToFirstError } from '@/utils';
+import { getPageFromSearch } from '@/utils/urlPage';
 import SectionCard, { SectionItem } from '@/pages/alertRules/FormNG/components/SectionCard';
 import { ChannelItem, getSimplifiedItems as getNotificationChannels } from '@/pages/notificationChannels/services';
 
@@ -47,6 +48,7 @@ function buildAutoName(channelName: string | undefined, notifyConfig: any, teams
 export default function FormCpt(props: Props) {
   const { t, i18n } = useTranslation(NS);
   const { disabled, initialValues, onOk, onCancel } = props;
+  const location = useLocation();
   const [form] = Form.useForm();
   const [userGroups, setUserGroups] = useState<{ id: number; name: string }[]>([]);
   const [activeIndex, setActiveIndex] = useState<number>();
@@ -327,7 +329,7 @@ export default function FormCpt(props: Props) {
               {onCancel ? (
                 <Button onClick={onCancel}>{t('common:btn.cancel')}</Button>
               ) : (
-                <Link to={`/${NS}`}>
+                <Link to={{ pathname: `/${NS}`, search: `?page=${getPageFromSearch(location.search)}` }}>
                   <Button>{t('common:btn.cancel')}</Button>
                 </Link>
               )}

--- a/src/pages/notificationRules/pages/List.tsx
+++ b/src/pages/notificationRules/pages/List.tsx
@@ -3,7 +3,7 @@ import { Space, Button, Switch, Modal, Input } from 'antd';
 import { NotificationOutlined, SearchOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 
 import { IS_PLUS } from '@/utils/constant';
 import PageLayout from '@/components/pageLayout';
@@ -16,35 +16,35 @@ import { getTeamInfoList } from '@/services/manage';
 import usePagination from '@/components/usePagination';
 
 import { getItems, putItem, deleteItems } from '../services';
-import { NS, CN, TABLE_PAGINATION_CACHE_KEY } from '../constants';
+import { NS, CN, TABLE_PAGINATION_CACHE_KEY, FILTER_SESSION_STORAGE_KEY } from '../constants';
 import { RuleItem } from '../types';
+import { getPageFromSearch, setPageInSearch } from '@/utils/urlPage';
 
 interface Filter {
   search?: string;
 }
 
-const FILTER_SESSION_STORAGE_KEY = 'notification-rules-filter';
-
 export default function List() {
   const { t } = useTranslation(NS);
   const history = useHistory();
+  const location = useLocation();
   const pagination = usePagination({ PAGESIZE_KEY: TABLE_PAGINATION_CACHE_KEY });
   const [loading, setLoading] = useState(false);
   let defaultFilter = {} as Filter;
-  let defaultPage = 1;
   try {
     const saved = JSON.parse(window.sessionStorage.getItem(FILTER_SESSION_STORAGE_KEY) || '{}');
     defaultFilter = saved;
-    defaultPage = saved.current || 1;
   } catch (e) {
     console.error(e);
   }
+  const defaultPage = getPageFromSearch(location.search);
   const [filter, setFilter] = useState<Filter>(defaultFilter);
   const [current, setCurrent] = useState<number>(defaultPage);
   const handleFilterChange = (newFilter: Filter) => {
     setFilter(newFilter);
     setCurrent(1);
-    window.sessionStorage.setItem(FILTER_SESSION_STORAGE_KEY, JSON.stringify({ ...newFilter, current: 1 }));
+    window.sessionStorage.setItem(FILTER_SESSION_STORAGE_KEY, JSON.stringify(newFilter));
+    history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, 1) });
   };
   const [data, setData] = useState<RuleItem[]>([]);
   const [userGroups, setUserGroups] = useState<{ id: number; name: string }[]>([]);
@@ -154,8 +154,7 @@ export default function List() {
           pagination={{ ...pagination, current }}
           onChange={(pag) => {
             setCurrent(pag.current || 1);
-            const saved = JSON.parse(window.sessionStorage.getItem(FILTER_SESSION_STORAGE_KEY) || '{}');
-            window.sessionStorage.setItem(FILTER_SESSION_STORAGE_KEY, JSON.stringify({ ...saved, current: pag.current || 1 }));
+            history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, pag.current || 1) });
           }}
           columns={[
             {
@@ -166,6 +165,7 @@ export default function List() {
                   <Link
                     to={{
                       pathname: IS_PLUS ? `/${NS}/detail/${record.id}` : `/${NS}/edit/${record.id}`,
+                      search: `?page=${current}`,
                     }}
                   >
                     {val}
@@ -250,7 +250,7 @@ export default function List() {
           ]}
           rowActions={(record) => ({
             inline: [
-              { key: 'edit', icon: 'edit', text: t('common:btn.edit'), onClick: () => history.push({ pathname: `/${NS}/edit/${record.id}` }) },
+              { key: 'edit', icon: 'edit', text: t('common:btn.edit'), onClick: () => history.push({ pathname: `/${NS}/edit/${record.id}`, search: `?page=${current}` }) },
               { key: 'clone', icon: 'copy', text: t('common:btn.clone'), onClick: () => window.open(`/${NS}/edit/${record.id}?mode=clone`) },
               {
                 key: 'delete',

--- a/src/pages/recordingRules/PageTable.tsx
+++ b/src/pages/recordingRules/PageTable.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo, useContext } from 'react';
 import { Button, Modal, message, Dropdown, Switch, Select, Space } from 'antd';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ColumnType } from 'antd/lib/table';
 import _ from 'lodash';
@@ -19,9 +19,11 @@ import usePagination from '@/components/usePagination';
 import EditModal from './components/editModal';
 import Import from './components/Import';
 import Export from './components/Export';
+import { getPageFromSearch, setPageInSearch, removePageFromSearch } from '@/utils/urlPage';
 
 interface Props {
   gids?: string;
+  groupSwitchCount?: number;
 }
 
 interface Filter {
@@ -30,7 +32,7 @@ interface Filter {
   disabled?: 0 | 1;
 }
 
-const FILTER_SESSION_STORAGE_KEY = 'recording-rules-filter';
+export const FILTER_SESSION_STORAGE_KEY = 'recording-rules-filter';
 
 const { confirm } = Modal;
 const exportIgnoreAttrsObj = {
@@ -43,22 +45,26 @@ const exportIgnoreAttrsObj = {
   update_by: undefined,
 };
 
-const PageTable: React.FC<Props> = ({ gids }) => {
+const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
   const [severity] = useState<number>();
   const { t } = useTranslation('recordingRules');
   const history = useHistory();
+  const location = useLocation();
   const [selectRowKeys, setSelectRowKeys] = useState<React.Key[]>([]);
   const [selectedRows, setSelectedRows] = useState<strategyItem[]>([]);
+  const clearSelection = () => {
+    setSelectRowKeys([]);
+    setSelectedRows([]);
+  };
   const { groupedDatasourceList, businessGroup, busiGroups } = useContext(CommonStateContext);
   let defaultFilter = {} as Filter;
-  let defaultPage = 1;
   try {
     const saved = JSON.parse(window.sessionStorage.getItem(FILTER_SESSION_STORAGE_KEY) || '{}');
     defaultFilter = saved;
-    defaultPage = saved.current || 1;
   } catch (e) {
     console.error(e);
   }
+  const defaultPage = getPageFromSearch(location.search);
   const [query, setQuery] = useState<string>(defaultFilter.query ?? '');
   const [isModalVisible, setisModalVisible] = useState<boolean>(false);
   const [currentStrategyDataAll, setCurrentStrategyDataAll] = useState([]);
@@ -116,12 +122,24 @@ const PageTable: React.FC<Props> = ({ gids }) => {
   };
 
   const handleClickEdit = (id, isClone = false) => {
-    history.push(`/recording-rules/edit/${id}${isClone ? '?mode=clone' : ''}`);
+    history.push(`/recording-rules/edit/${id}${isClone ? '?mode=clone&' : '?'}fromGids=${gids ?? '-2'}&page=${current}`);
   };
 
   const refreshList = () => {
     getRecordingRules();
   };
+  // 重置到第一页：清除 URL 里的 page 参数（切换业务组时调用，保留其余筛选条件）
+  const resetPaging = () => {
+    setCurrent(1);
+    clearSelection();
+    history.replace({ pathname: location.pathname, search: removePageFromSearch(location.search) });
+  };
+  // 切换业务组时重置到第一页（父组件在业务组选择源头递增计数触发，不依赖 gids 变化时序）
+  useEffect(() => {
+    if (groupSwitchCount) {
+      resetPaging();
+    }
+  }, [groupSwitchCount]);
 
   const columns: ColumnType<strategyItem>[] = _.concat([
     {
@@ -259,6 +277,7 @@ const PageTable: React.FC<Props> = ({ gids }) => {
                   if (businessGroup.id) {
                     deleteRecordingRule(selectRowKeys as number[], businessGroup.id).then(() => {
                       message.success(t('common:success.delete'));
+                      clearSelection();
                       refreshList();
                     });
                   }
@@ -300,6 +319,7 @@ const PageTable: React.FC<Props> = ({ gids }) => {
       );
       if (!res.err) {
         message.success(t('common:success.edit'));
+        clearSelection();
         refreshList();
         setisModalVisible(false);
       } else {
@@ -329,7 +349,8 @@ const PageTable: React.FC<Props> = ({ gids }) => {
             onChange={(val) => {
               setDatasourceIds(val);
               setCurrent(1);
-              saveState({ datasourceIds: val, current: 1 });
+              saveState({ datasourceIds: val });
+              history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, 1) });
             }}
           >
             {_.map(groupedDatasourceList?.prometheus, (item) => (
@@ -344,7 +365,8 @@ const PageTable: React.FC<Props> = ({ gids }) => {
             onSearch={(val) => {
               setQuery(val);
               setCurrent(1);
-              saveState({ query: val, current: 1 });
+              saveState({ query: val });
+              history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, 1) });
             }}
             allowClear
           />
@@ -359,7 +381,8 @@ const PageTable: React.FC<Props> = ({ gids }) => {
             onChange={(val) => {
               setFilterDisabled(val);
               setCurrent(1);
-              saveState({ disabled: val, current: 1 });
+              saveState({ disabled: val });
+              history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, 1) });
             }}
           />
         </Space>
@@ -397,7 +420,7 @@ const PageTable: React.FC<Props> = ({ gids }) => {
           current,
           onChange: (page) => {
             setCurrent(page);
-            saveState({ current: page });
+            history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, page) });
           },
         }}
         loading={loading}

--- a/src/pages/recordingRules/components/operateForm.tsx
+++ b/src/pages/recordingRules/components/operateForm.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect } from 'react';
 import _ from 'lodash';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
+import queryString from 'query-string';
 import { Form, Input, Button, Modal, message, Space, Select, notification } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { useRequest } from 'ahooks';
@@ -16,6 +17,7 @@ import { CommonStateContext } from '@/App';
 import CronPattern from '@/components/CronPattern';
 import KVTagSelect, { validatorOfKVTagSelect } from '@/components/KVTagSelect';
 import { getBusiGroups } from '@/components/BusinessGroup/services';
+import { getPageFromSearch } from '@/utils/urlPage';
 
 const DATASOURCE_ALL = 0;
 
@@ -34,6 +36,9 @@ const OperateForm: React.FC<Props> = ({ type, initialValues = {} }) => {
   const { t } = useTranslation('recordingRules');
   const { i18n } = useTranslation();
   const history = useHistory(); // 创建的时候默认选中的值
+  const location = useLocation();
+  // 编辑/克隆入口会带上原列表的业务组上下文（fromGids），保存后跳回原上下文而不是记录的 group_id
+  const fromGids = queryString.parse(location.search)?.fromGids;
   const [form] = Form.useForm();
   const { groupedDatasourceList } = useContext(CommonStateContext);
   const { openAiChat } = useAiChatContext();
@@ -65,7 +70,7 @@ const OperateForm: React.FC<Props> = ({ type, initialValues = {} }) => {
           message.success(t('common:success.edit'));
           history.push({
             pathname: goListPath,
-            search: `ids=${values.group_id}&isLeaf=true`,
+            search: fromGids ? `ids=${fromGids}&isLeaf=true` : `ids=${values.group_id}&isLeaf=true`,
           });
         }
       } else {
@@ -80,7 +85,7 @@ const OperateForm: React.FC<Props> = ({ type, initialValues = {} }) => {
           message.success(`${type === 2 ? t('common:success.clone') : t('common:success.add')}`);
           history.push({
             pathname: goListPath,
-            search: `ids=${values.group_id}&isLeaf=true`,
+            search: fromGids ? `ids=${fromGids}&isLeaf=true` : `ids=${values.group_id}&isLeaf=true`,
           });
         } else {
           message.error(t(msg));
@@ -213,7 +218,10 @@ const OperateForm: React.FC<Props> = ({ type, initialValues = {} }) => {
 
               <Button
                 onClick={() => {
-                  history.push('/recording-rules');
+                  history.push({
+                    pathname: goListPath,
+                    search: fromGids ? `ids=${fromGids}&isLeaf=true&page=${getPageFromSearch(location.search)}` : `?page=${getPageFromSearch(location.search)}`,
+                  });
                 }}
               >
                 {t('common:btn.cancel')}

--- a/src/pages/recordingRules/index.tsx
+++ b/src/pages/recordingRules/index.tsx
@@ -17,12 +17,18 @@ const Strategy: React.FC = () => {
   const { businessGroup } = useContext(CommonStateContext);
   const { t } = useTranslation('recordingRules');
   const [gids, setGids] = useState<string | undefined>(getDefaultGids(N9E_GIDS_LOCALKEY, businessGroup));
+  const [groupSwitchCount, setGroupSwitchCount] = useState(0);
+  // 切换业务组时通知列表重置到第一页（在业务组选择源头触发，不依赖 gids 变化时序）
+  const handleSelectGids = (ids: string) => {
+    setGids(ids);
+    setGroupSwitchCount((count) => count + 1);
+  };
 
   return (
     <PageLayout title={t('title')} icon={<SettingOutlined />} doc='https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/usage/data-query/metrics/recording-rules/'>
       <div className='strategy-content'>
-        <BusinessGroupSideBarWithAll gids={gids} setGids={setGids} localeKey={N9E_GIDS_LOCALKEY} />
-        <PageTable gids={gids} />
+        <BusinessGroupSideBarWithAll gids={gids} setGids={handleSelectGids} localeKey={N9E_GIDS_LOCALKEY} />
+        <PageTable gids={gids} groupSwitchCount={groupSwitchCount} />
       </div>
     </PageLayout>
   );

--- a/src/pages/task/add.tsx
+++ b/src/pages/task/add.tsx
@@ -17,12 +17,13 @@
 import React, { useState, useEffect, useContext, useRef } from 'react';
 import { Button, Spin, Row, Col, Card, Alert, message } from 'antd';
 import { RollbackOutlined } from '@ant-design/icons';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import _ from 'lodash';
 import queryString from 'query-string';
 import { useTranslation } from 'react-i18next';
 
 import PageLayout from '@/components/pageLayout';
+import { getPageFromSearch } from '@/utils/urlPage';
 import request from '@/utils/request';
 import api from '@/utils/api';
 import { CommonStateContext } from '@/App';
@@ -31,6 +32,7 @@ import TplForm from '../taskTpl/tplForm';
 
 const Add = (props: any) => {
   const history = useHistory();
+  const location = useLocation();
   const query = queryString.parse(_.get(props, 'location.search'));
   const { businessGroup } = useContext(CommonStateContext);
   const curBusiId = (query.gid as string) || businessGroup.id!;
@@ -101,12 +103,12 @@ const Add = (props: any) => {
       title={
         query.tpl ? (
           <>
-            <RollbackOutlined className='back' onClick={() => history.push('/job-tpls')} />
+            <RollbackOutlined className='back' onClick={() => history.push(`/job-tpls?page=${getPageFromSearch(location.search)}`)} />
             {t('tpl')}
           </>
         ) : (
           <>
-            <RollbackOutlined className='back' onClick={() => history.push('/job-tasks')} />
+            <RollbackOutlined className='back' onClick={() => history.push(`/job-tasks?page=${getPageFromSearch(location.search)}`)} />
             {t('task')}
           </>
         )

--- a/src/pages/task/detail.tsx
+++ b/src/pages/task/detail.tsx
@@ -15,7 +15,7 @@
  *
  */
 import React, { useState, useEffect, useContext } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 import { Spin, Divider, Button, Card } from 'antd';
 import { RollbackOutlined } from '@ant-design/icons';
 import moment from 'moment';
@@ -24,12 +24,14 @@ import { useTranslation } from 'react-i18next';
 import request from '@/utils/request';
 import api from '@/utils/api';
 import PageLayout from '@/components/pageLayout';
+import { getPageFromSearch } from '@/utils/urlPage';
 import { CommonStateContext } from '@/App';
 import Editor from '../taskTpl/editor';
 import './style.less';
 
 const Detail = (props: any) => {
   const history = useHistory();
+  const location = useLocation();
   const { businessGroup } = useContext(CommonStateContext);
   const curBusiId = businessGroup.id!;
   const { t } = useTranslation('common');
@@ -59,7 +61,7 @@ const Detail = (props: any) => {
     <PageLayout
       title={
         <>
-          <RollbackOutlined className='back' onClick={() => history.push('/job-tasks')} />
+          <RollbackOutlined className='back' onClick={() => history.push(`/job-tasks?page=${getPageFromSearch(location.search)}`)} />
           {t('task')}
         </>
       }

--- a/src/pages/task/index.tsx
+++ b/src/pages/task/index.tsx
@@ -15,13 +15,14 @@
  *
  */
 import React, { useContext, useState, useEffect } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 import { Checkbox, Row, Col, Select, Button, Space } from 'antd';
 import { CodeOutlined } from '@ant-design/icons';
 import { ColumnProps } from 'antd/lib/table';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useAntdTable } from 'ahooks';
+import { getPageFromSearch, setPageInSearch, removePageFromSearch } from '@/utils/urlPage';
 import EnhancedTable from '@/components/EnhancedTable';
 import { updateByColumn, dateColumn } from '@/components/EnhancedTable/columns';
 
@@ -45,7 +46,6 @@ interface DataItem {
 const N9E_GIDS_LOCALKEY = 'N9E_TASK_NODE_ID';
 
 const FILTER_SESSION_KEY = 'task_filter';
-const PAGE_SESSION_KEY = 'task_page';
 
 function getDefaultFilter() {
   try {
@@ -58,7 +58,6 @@ function getDefaultFilter() {
 function getTableData(options: any, gids: string | undefined, query: string, mine: boolean, days: number) {
   if (gids) {
     const ids = gids === '-2' ? undefined : gids;
-    sessionStorage.setItem(PAGE_SESSION_KEY, String(options.current));
     return request(`/api/n9e/busi-groups/tasks`, {
       method: RequestMethod.Get,
       params: {
@@ -78,6 +77,7 @@ function getTableData(options: any, gids: string | undefined, query: string, min
 
 const index = (_props: any) => {
   const history = useHistory();
+  const location = useLocation();
   const { t } = useTranslation('common');
   const defaultFilter = getDefaultFilter();
   const [query, setQuery] = useState(defaultFilter.query || '');
@@ -97,12 +97,18 @@ const index = (_props: any) => {
     window.sessionStorage.setItem(FILTER_SESSION_KEY, JSON.stringify({ query, mine, days }));
   }, [query, mine, days]);
 
-  const defaultPage = Number(sessionStorage.getItem(PAGE_SESSION_KEY) || '1');
-  const { tableProps } = useAntdTable((options) => getTableData(options, gids, query, mine, days), {
+  const defaultPage = getPageFromSearch(location.search);
+  const { tableProps, pagination: tablePagination } = useAntdTable((options) => getTableData(options, gids, query, mine, days), {
     refreshDeps: [gids, query, mine, days, refreshFlag],
     defaultPageSize: pagination.pageSize,
     defaultCurrent: defaultPage,
   });
+  // 切换业务组时重置到第一页（在业务组选择源头触发，不依赖 gids 变化时序）
+  const handleSelectGids = (ids: string) => {
+    setGids(ids);
+    tablePagination.changeCurrent(1);
+    history.replace({ pathname: location.pathname, search: removePageFromSearch(location.search) });
+  };
 
   const handleOpenMetaDrawer = (record: any) => {
     setMetaDrawerTaskId(String(record.id));
@@ -134,7 +140,7 @@ const index = (_props: any) => {
           const groupName = _.find(busiGroups, { id: record.group_id })?.name;
           return (
             <div className='flex flex-col gap-0.5'>
-              <Link to={{ pathname: `/job-tasks/${record.id}/result` }}>{text}</Link>
+              <Link to={{ pathname: `/job-tasks/${record.id}/result`, search: `?page=${tableProps.pagination?.current || 1}` }}>{text}</Link>
               <span className='text-soft text-xs inline-flex items-center gap-2'>
                 <span>ID: {record.id}</span>
                 {showBusinessGroup && groupName && <span>{groupName}</span>}
@@ -145,8 +151,8 @@ const index = (_props: any) => {
       },
     ] as any,
     [
-      dateColumn({ title: t('task.created'), dataIndex: 'create_at', unix: true, sortable: true }),
-      updateByColumn({ title: t('task.creator'), dataIndex: 'create_by', nickname: 'create_by_nickname' }),
+      dateColumn({ title: t('task.created'), dataIndex: 'create_at', unix: true }),
+      updateByColumn({ title: t('task.creator'), dataIndex: 'create_by', nickname: 'create_by_nickname', filterMode: 'none' }),
     ] as any,
   );
 
@@ -157,7 +163,7 @@ const index = (_props: any) => {
       doc='https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/self-healing/create-temporary-task/'
     >
       <div style={{ display: 'flex' }}>
-        <BusinessGroupSideBarWithAll gids={gids} setGids={setGids} localeKey={N9E_GIDS_LOCALKEY} allOptionLabel={t('common:task.allOptionLabel')} />
+        <BusinessGroupSideBarWithAll gids={gids} setGids={handleSelectGids} localeKey={N9E_GIDS_LOCALKEY} allOptionLabel={t('common:task.allOptionLabel')} />
         {gids ? (
           <div className='fc-border rounded-lg p-4' style={{ flex: 1 }}>
             <Row>
@@ -203,7 +209,7 @@ const index = (_props: any) => {
                   <Button
                     type='primary'
                     onClick={() => {
-                      history.push('/job-tasks/add');
+                      history.push({ pathname: '/job-tasks/add', search: `?page=${tableProps.pagination?.current || 1}` });
                     }}
                   >
                     {t('task.temporary.create')}
@@ -222,13 +228,17 @@ const index = (_props: any) => {
                     key: 'clone',
                     icon: 'copy',
                     text: t('task.clone'),
-                    onClick: () => history.push({ pathname: '/job-tasks/add', search: `task=${record.id}` }),
+                    onClick: () => history.push({ pathname: '/job-tasks/add', search: `task=${record.id}&page=${tableProps.pagination?.current || 1}` }),
                   },
                   { key: 'meta', icon: 'view', text: t('task.meta'), onClick: () => handleOpenMetaDrawer(record) },
                 ],
               })}
               actionColumn={{ title: t('table.operations'), width: 64 }}
               {...(tableProps as any)}
+              onChange={(pag: any, filters?: any, sorter?: any) => {
+                tableProps.onChange?.(pag, filters, sorter);
+                history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, pag.current || 1) });
+              }}
               pagination={{
                 ...pagination,
                 ...tableProps.pagination,

--- a/src/pages/task/result.tsx
+++ b/src/pages/task/result.tsx
@@ -15,17 +15,19 @@
  *
  */
 import React, { useContext } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { RollbackOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 
 import PageLayout from '@/components/pageLayout';
+import { getPageFromSearch } from '@/utils/urlPage';
 import { CommonStateContext } from '@/App';
 
 import ResultContent from './ResultContent';
 
 const index = (props: any) => {
   const history = useHistory();
+  const location = useLocation();
   const { businessGroup } = useContext(CommonStateContext);
   const curBusiId = businessGroup.id!;
   const { params } = props.match;
@@ -36,7 +38,7 @@ const index = (props: any) => {
     <PageLayout
       title={
         <>
-          <RollbackOutlined className='back' onClick={() => history.push('/job-tasks')} />
+          <RollbackOutlined className='back' onClick={() => history.push(`/job-tasks?page=${getPageFromSearch(location.search)}`)} />
           {t('task')}
         </>
       }

--- a/src/pages/taskTpl/add.tsx
+++ b/src/pages/taskTpl/add.tsx
@@ -19,6 +19,7 @@ import { Button, Card, message } from 'antd';
 import { RollbackOutlined } from '@ant-design/icons';
 import _ from 'lodash';
 import { useHistory, useLocation } from 'react-router-dom';
+import { getPageFromSearch } from '@/utils/urlPage';
 import queryString from 'query-string';
 import { useTranslation } from 'react-i18next';
 import PageLayout from '@/components/pageLayout';
@@ -42,7 +43,7 @@ const Add = (props: any) => {
     }).then(() => {
       message.success(t('msg.create.success'));
       // TODO: 这里返回列表页时需要获取参数里的 ids，不能用 history.push
-      window.location.href = `/job-tpls?ids=${curBusiId}&isLeaf=true`;
+      window.location.href = `/job-tpls?ids=${curBusiId}&isLeaf=true&page=${getPageFromSearch(location.search)}`;
     });
   };
 
@@ -50,7 +51,7 @@ const Add = (props: any) => {
     <PageLayout
       title={
         <>
-          <RollbackOutlined className='back' onClick={() => history.push('/job-tpls')} />
+          <RollbackOutlined className='back' onClick={() => history.push(`/job-tpls?page=${getPageFromSearch(location.search)}`)} />
           {t('tpl')}
         </>
       }

--- a/src/pages/taskTpl/clone.tsx
+++ b/src/pages/taskTpl/clone.tsx
@@ -19,6 +19,7 @@ import { Button, Card, Spin, message } from 'antd';
 import { RollbackOutlined } from '@ant-design/icons';
 import _ from 'lodash';
 import { useHistory, useLocation } from 'react-router-dom';
+import { getPageFromSearch } from '@/utils/urlPage';
 import queryString from 'query-string';
 import { useTranslation } from 'react-i18next';
 import PageLayout from '@/components/pageLayout';
@@ -48,7 +49,7 @@ const Add = (props: any) => {
       message.success(t('msg.create.success'));
       props.history.push({
         pathname: `/job-tpls`,
-        search: `ids=${curBusiId}&isLeaf=true`,
+        search: `ids=${curBusiId}&isLeaf=true&page=${getPageFromSearch(location.search)}`,
       });
     });
   };
@@ -75,7 +76,7 @@ const Add = (props: any) => {
     <PageLayout
       title={
         <>
-          <RollbackOutlined className='back' onClick={() => history.push('/job-tpls')} />
+          <RollbackOutlined className='back' onClick={() => history.push(`/job-tpls?page=${getPageFromSearch(location.search)}`)} />
           {t('tpl')}
         </>
       }

--- a/src/pages/taskTpl/detail.tsx
+++ b/src/pages/taskTpl/detail.tsx
@@ -16,6 +16,7 @@
  */
 import React, { useState, useEffect, useContext } from 'react';
 import { Link, useHistory, useLocation } from 'react-router-dom';
+import { getPageFromSearch } from '@/utils/urlPage';
 import { Button, Spin, Divider, Card } from 'antd';
 import { RollbackOutlined } from '@ant-design/icons';
 import _ from 'lodash';
@@ -64,7 +65,7 @@ const Detail = (props: any) => {
     <PageLayout
       title={
         <>
-          <RollbackOutlined className='back' onClick={() => history.push('/job-tpls')} />
+          <RollbackOutlined className='back' onClick={() => history.push(`/job-tpls?page=${getPageFromSearch(location.search)}`)} />
           {t('tpl')}
         </>
       }
@@ -136,12 +137,12 @@ const Detail = (props: any) => {
               </div>
             </div>
             <div style={{ marginTop: 10 }}>
-              <Link to={{ pathname: `/job-tpls/${id}/modify`, search: `gid=${curBusiId}` }}>
+              <Link to={{ pathname: `/job-tpls/${id}/modify`, search: `gid=${curBusiId}&page=${getPageFromSearch(location.search)}` }}>
                 <Button type='primary' style={{ marginRight: 10 }}>
                   {t('tpl.modify')}
                 </Button>
               </Link>
-              <Link to={{ pathname: `/job-tpls/add/task`, search: `tpl=${id}&gid=${curBusiId}` }}>
+              <Link to={{ pathname: `/job-tpls/add/task`, search: `tpl=${id}&gid=${curBusiId}&page=${getPageFromSearch(location.search)}` }}>
                 <Button type='primary'>{t('tpl.create.task')}</Button>
               </Link>
             </div>

--- a/src/pages/taskTpl/index.tsx
+++ b/src/pages/taskTpl/index.tsx
@@ -15,12 +15,13 @@
  *
  */
 import React, { useState, useContext, useEffect } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 import { Modal, Row, Col, Button, Dropdown, Menu, message, Space } from 'antd';
 import { DownOutlined, CodeOutlined } from '@ant-design/icons';
 import { ColumnProps } from 'antd/lib/table';
 import _ from 'lodash';
 import { useAntdTable } from 'ahooks';
+import { getPageFromSearch, setPageInSearch, removePageFromSearch } from '@/utils/urlPage';
 import { useTranslation } from 'react-i18next';
 
 import EnhancedTable from '@/components/EnhancedTable';
@@ -41,12 +42,10 @@ import UnBindTags from './unBindTags';
 
 const N9E_GIDS_LOCALKEY = 'N9E_TASK_TPL_NODE_ID';
 const SEARCH_SESSION_KEY = 'taskTpl_query';
-const PAGE_SESSION_KEY = 'taskTpl_page';
 
 function getTableData(options: any, gids: string | undefined, query: string) {
   if (gids) {
     const ids = gids === '-2' ? undefined : gids;
-    sessionStorage.setItem(PAGE_SESSION_KEY, String(options.current));
     return request(`/api/n9e/busi-groups/task-tpls`, {
       method: RequestMethod.Get,
       params: {
@@ -65,6 +64,7 @@ function getTableData(options: any, gids: string | undefined, query: string) {
 const index = (_props: any) => {
   const { t, i18n } = useTranslation('common');
   const history = useHistory();
+  const location = useLocation();
   const [query, setQuery] = useState(() => sessionStorage.getItem(SEARCH_SESSION_KEY) || '');
   const { busiGroups, businessGroup } = useContext(CommonStateContext);
   const [selectedIds, setSelectedIds] = useState([] as any[]);
@@ -73,12 +73,23 @@ const index = (_props: any) => {
     sessionStorage.setItem(SEARCH_SESSION_KEY, query);
   }, [query]);
 
-  const defaultPage = Number(sessionStorage.getItem(PAGE_SESSION_KEY) || '1');
-  const { tableProps, refresh } = useAntdTable<any, any>((options) => getTableData(options, gids, query), {
+  const defaultPage = getPageFromSearch(location.search);
+  const {
+    tableProps,
+    refresh,
+    pagination: tablePagination,
+  } = useAntdTable<any, any>((options) => getTableData(options, gids, query), {
     refreshDeps: [gids, query],
     debounceWait: 300,
     defaultParams: [{ current: defaultPage, pageSize: 10 }],
   });
+  // 切换业务组时重置到第一页（在业务组选择源头触发，不依赖 gids 变化时序）
+  const handleSelectGids = (ids: string) => {
+    setGids(ids);
+    tablePagination.changeCurrent(1);
+    setSelectedIds([]);
+    history.replace({ pathname: location.pathname, search: removePageFromSearch(location.search) });
+  };
   const pagination = usePagination({ PAGESIZE_KEY: 'job-tpls' });
 
   function handleTagClick(tag: string) {
@@ -95,6 +106,7 @@ const index = (_props: any) => {
         selectedIds,
         busiId: businessGroup.id,
         onOk: () => {
+          setSelectedIds([]);
           refresh();
         },
       });
@@ -114,6 +126,7 @@ const index = (_props: any) => {
         uniqueTags,
         busiId: businessGroup.id,
         onOk: () => {
+          setSelectedIds([]);
           refresh();
         },
       });
@@ -131,7 +144,7 @@ const index = (_props: any) => {
           const groupName = _.find(busiGroups, { id: record.group_id })?.name;
           return (
             <div className='flex flex-col gap-0.5'>
-              <Link to={{ pathname: `/job-tpls/${record.id}/detail`, search: `gid=${record.group_id}` }}>{text}</Link>
+              <Link to={{ pathname: `/job-tpls/${record.id}/detail`, search: `gid=${record.group_id}&page=${tableProps.pagination?.current || 1}` }}>{text}</Link>
               <span className='text-soft text-xs inline-flex items-center gap-2'>
                 <span>ID: {record.id}</span>
                 {showBusinessGroup && groupName && <span>{groupName}</span>}
@@ -143,8 +156,8 @@ const index = (_props: any) => {
     ] as any,
     [
       tagsColumn({ title: t('tpl.tags'), dataIndex: 'tags', maxWidth: 180, onTagClick: handleTagClick }),
-      updateByColumn({ title: t('common:table.update_by'), dataIndex: 'update_by', nickname: 'update_by_nickname' }),
-      dateColumn({ title: t('common:table.update_at'), dataIndex: 'update_at', unix: true, sortable: true }),
+      updateByColumn({ title: t('common:table.update_by'), dataIndex: 'update_by', nickname: 'update_by_nickname', filterMode: 'none' }),
+      dateColumn({ title: t('common:table.update_at'), dataIndex: 'update_at', unix: true }),
     ] as any,
   );
 
@@ -155,7 +168,7 @@ const index = (_props: any) => {
       doc='https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/self-healing/self-healing-script/'
     >
       <div style={{ display: 'flex' }}>
-        <BusinessGroupSideBarWithAll gids={gids} setGids={setGids} localeKey={N9E_GIDS_LOCALKEY} allOptionLabel={t('common:tpl.allOptionLabel')} />
+        <BusinessGroupSideBarWithAll gids={gids} setGids={handleSelectGids} localeKey={N9E_GIDS_LOCALKEY} allOptionLabel={t('common:tpl.allOptionLabel')} />
         {gids ? (
           <div className='fc-border rounded-lg p-4' style={{ flex: 1, minWidth: 0, overflowY: 'auto' }}>
             <Row>
@@ -219,19 +232,19 @@ const index = (_props: any) => {
                   {
                     key: 'create',
                     text: t('task.create'),
-                    onClick: () => history.push({ pathname: `/job-tpls/add/task`, search: `tpl=${record.id}&gid=${record.group_id}` }),
+                    onClick: () => history.push({ pathname: `/job-tpls/add/task`, search: `tpl=${record.id}&gid=${record.group_id}&page=${tableProps.pagination?.current || 1}` }),
                   },
                   {
                     key: 'edit',
                     icon: 'edit',
                     text: t('common:btn.edit'),
-                    onClick: () => history.push({ pathname: `/job-tpls/${record.id}/modify`, search: `gid=${record.group_id}` }),
+                    onClick: () => history.push({ pathname: `/job-tpls/${record.id}/modify`, search: `gid=${record.group_id}&page=${tableProps.pagination?.current || 1}` }),
                   },
                   {
                     key: 'clone',
                     icon: 'copy',
                     text: t('common:btn.clone'),
-                    onClick: () => history.push({ pathname: `/job-tpls/${record.id}/clone`, search: `gid=${record.group_id}` }),
+                    onClick: () => history.push({ pathname: `/job-tpls/${record.id}/clone`, search: `gid=${record.group_id}&page=${tableProps.pagination?.current || 1}` }),
                   },
                   {
                     key: 'delete',
@@ -256,6 +269,10 @@ const index = (_props: any) => {
               })}
               actionColumn={{ title: t('table.operations'), width: 130 }}
               {...(tableProps as any)}
+              onChange={(pag: any, filters?: any, sorter?: any) => {
+                tableProps.onChange?.(pag, filters, sorter);
+                history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, pag.current || 1) });
+              }}
               rowSelection={{
                 selectedRowKeys: selectedIds,
                 onChange: (selectedRowKeys) => {

--- a/src/pages/taskTpl/modify.tsx
+++ b/src/pages/taskTpl/modify.tsx
@@ -16,6 +16,7 @@
  */
 import React, { useState, useEffect, useContext } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
+import { getPageFromSearch } from '@/utils/urlPage';
 import { Button, Spin, Card, message, Space } from 'antd';
 import { RollbackOutlined, CopyOutlined } from '@ant-design/icons';
 import _ from 'lodash';
@@ -47,7 +48,7 @@ const Modify = (props: any) => {
       message.success(t('msg.modify.success'));
       props.history.push({
         pathname: `/job-tpls`,
-        search: `ids=${curBusiId}&isLeaf=true`,
+        search: `ids=${curBusiId}&isLeaf=true&page=${getPageFromSearch(location.search)}`,
       });
     });
   };
@@ -74,7 +75,7 @@ const Modify = (props: any) => {
     <PageLayout
       title={
         <>
-          <RollbackOutlined className='back' onClick={() => history.push('/job-tpls')} />
+          <RollbackOutlined className='back' onClick={() => history.push(`/job-tpls?page=${getPageFromSearch(location.search)}`)} />
           {t('tpl')}
         </>
       }

--- a/src/pages/warning/shield/index.tsx
+++ b/src/pages/warning/shield/index.tsx
@@ -21,7 +21,7 @@ import { CloseCircleOutlined, ExclamationCircleOutlined, SearchOutlined } from '
 import moment from 'moment';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { useHistory, Link } from 'react-router-dom';
+import { useHistory, Link, useLocation } from 'react-router-dom';
 
 import Tags from '@/components/TableTags/Tags';
 import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
@@ -34,6 +34,7 @@ import RefreshIcon from '@/components/RefreshIcon';
 import { DatasourceSelect } from '@/components/DatasourceSelect';
 import { CommonStateContext } from '@/App';
 import usePagination from '@/components/usePagination';
+import { getPageFromSearch, setPageInSearch, removePageFromSearch } from '@/utils/urlPage';
 import { allCates, getCateDisplayLabel } from '@/components/AdvancedWrap/utils';
 import DocumentDrawer from '@/components/DocumentDrawer';
 import EmptyGuide from '@/components/EmptyGuide';
@@ -54,23 +55,23 @@ interface Filter {
   disabled?: 0 | 1;
 }
 
-const FILTER_SESSION_STORAGE_KEY = 'alert-mutes-filter';
+export const FILTER_SESSION_STORAGE_KEY = 'alert-mutes-filter';
 const DOC_PATH = 'https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/rules/alert-mute/';
 
 const Shield: React.FC = () => {
   const { t, i18n } = useTranslation('alertMutes');
   const history = useHistory();
+  const location = useLocation();
   const { datasourceList, groupedDatasourceList, businessGroup, busiGroups, darkMode } = useContext(CommonStateContext);
   const [gids, setGids] = useState<string | undefined>(getDefaultGids(N9E_GIDS_LOCALKEY, businessGroup));
   let defaultFilter = {} as Filter;
-  let defaultPage = 1;
   try {
     const saved = JSON.parse(window.sessionStorage.getItem(FILTER_SESSION_STORAGE_KEY) || '{}');
     defaultFilter = saved;
-    defaultPage = saved.current || 1;
   } catch (e) {
     console.error(e);
   }
+  const defaultPage = getPageFromSearch(location.search);
   const [query, setQuery] = useState<string>(defaultFilter.query ?? '');
   const [currentShieldDataAll, setCurrentShieldDataAll] = useState<Array<shieldItem>>([]);
   const [currentShieldData, setCurrentShieldData] = useState<Array<shieldItem>>([]);
@@ -84,6 +85,12 @@ const Shield: React.FC = () => {
     const prev = JSON.parse(window.sessionStorage.getItem(FILTER_SESSION_STORAGE_KEY) || '{}');
     window.sessionStorage.setItem(FILTER_SESSION_STORAGE_KEY, JSON.stringify({ ...prev, ...patch }));
   };
+  // 切换业务组时清除 URL 里的页码，回到第一页（在业务组选择源头触发，不依赖 gids 变化时序）
+  const handleSelectGids = (ids: string) => {
+    setGids(ids);
+    setCurrent(1);
+    history.replace({ pathname: location.pathname, search: removePageFromSearch(location.search) });
+  };
   const columns: ColumnsType = [
     {
       title: t('note'),
@@ -95,7 +102,7 @@ const Shield: React.FC = () => {
             <Link
               to={{
                 pathname: `/alert-mutes/edit/${record.id}`,
-                search: `?bgid=${record.group_id}`,
+                search: `?bgid=${record.group_id}&page=${current}`,
               }}
             >
               {data}
@@ -329,7 +336,8 @@ const Shield: React.FC = () => {
     let val = e.target.value;
     setQuery(val);
     setCurrent(1);
-    saveState({ query: val, current: 1 });
+    saveState({ query: val });
+    history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, 1) });
   };
 
   // 只有选中了叶子业务组才能新建屏蔽规则
@@ -347,7 +355,7 @@ const Shield: React.FC = () => {
   return (
     <PageLayout title={t('title')} icon={<CloseCircleOutlined />} doc={DOC_PATH}>
       <div className='shield-content'>
-        <BusinessGroupSideBarWithAll gids={gids} setGids={setGids} localeKey={N9E_GIDS_LOCALKEY} />
+        <BusinessGroupSideBarWithAll gids={gids} setGids={handleSelectGids} localeKey={N9E_GIDS_LOCALKEY} />
         <div className='shield-index fc-border rounded-lg' style={{ height: '100%', overflowY: 'auto' }}>
           <div className='flex justify-between'>
             <Space>
@@ -363,7 +371,8 @@ const Shield: React.FC = () => {
                 onChange={(val) => {
                   setDatasourceIds(val);
                   setCurrent(1);
-                  saveState({ datasourceIds: val, current: 1 });
+                  saveState({ datasourceIds: val });
+                  history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, 1) });
                 }}
               />
               <Input
@@ -386,7 +395,8 @@ const Shield: React.FC = () => {
                 onChange={(val) => {
                   setFilterDisabled(val);
                   setCurrent(1);
-                  saveState({ disabled: val, current: 1 });
+                  saveState({ disabled: val });
+                  history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, 1) });
                 }}
               />
             </Space>
@@ -420,7 +430,7 @@ const Shield: React.FC = () => {
             pagination={{ ...pagination, current }}
             onChange={(pag) => {
               setCurrent(pag.current || 1);
-              saveState({ current: pag.current || 1 });
+              history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, pag.current || 1) });
             }}
             loading={loading}
             dataSource={currentShieldData}
@@ -465,7 +475,7 @@ const Shield: React.FC = () => {
                   onClick: () => {
                     history.push({
                       pathname: `/alert-mutes/edit/${record.id}`,
-                      search: `?mode=clone&bgid=${record.group_id}`,
+                      search: `?mode=clone&bgid=${record.group_id}&page=${current}`,
                     });
                   },
                 },

--- a/src/pages/warning/subscribe/ListNG.tsx
+++ b/src/pages/warning/subscribe/ListNG.tsx
@@ -2,7 +2,7 @@ import React, { useState, useContext, useEffect } from 'react';
 import { Button, Input, message, Modal, Space, Switch, Tag, Tooltip, Select } from 'antd';
 import { ExclamationCircleOutlined, SearchOutlined } from '@ant-design/icons';
 import { ColumnsType } from 'antd/lib/table';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
 
@@ -26,6 +26,7 @@ import { getItems as getNotificationRules, RuleItem as NotificationRuleItem } fr
 import { useIsAuthorized } from '@/components/AuthorizationWrapper';
 
 import { defaultColumnsConfigs, LOCAL_STORAGE_KEY, DOC_URL } from './constants';
+import { getPageFromSearch, setPageInSearch, removePageFromSearch } from '@/utils/urlPage';
 import ScenarioList from './components/ScenarioList';
 import './locale';
 import './index.less';
@@ -39,7 +40,7 @@ interface Filter {
   disabled?: 0 | 1;
 }
 
-const FILTER_SESSION_STORAGE_KEY = 'alert-subscribes-filter';
+export const FILTER_SESSION_STORAGE_KEY = 'alert-subscribes-filter';
 
 const { confirm } = Modal;
 
@@ -53,24 +54,26 @@ interface Props {
   loading: boolean;
   setRefreshFlag: (flag: string) => void;
   linkTarget?: string;
+  gids?: string;
+  groupSwitchCount?: number;
 }
 
 const Subscribe = (props: Props) => {
   const { t, i18n } = useTranslation('alertSubscribes');
   const history = useHistory();
+  const location = useLocation();
   const { datasourceList, busiGroups, darkMode } = useContext(CommonStateContext);
-  const { hideBusinessGroupColumn, readonly, canCreate, headerExtra, data, loading, setRefreshFlag, linkTarget } = props;
+  const { hideBusinessGroupColumn, readonly, canCreate, headerExtra, data, loading, setRefreshFlag, linkTarget, gids, groupSwitchCount } = props;
   const [visibleColumns, setVisibleColumns] = useState<string[]>(() => getDefaultColumnsConfigs(defaultColumnsConfigs, LOCAL_STORAGE_KEY));
   const columnOptions = buildColumnOptions(defaultColumnsConfigs, t);
   let defaultFilter = {} as Filter;
-  let defaultPage = 1;
   try {
     const saved = JSON.parse(window.sessionStorage.getItem(FILTER_SESSION_STORAGE_KEY) || '{}');
     defaultFilter = saved;
-    defaultPage = saved.current || 1;
   } catch (e) {
     console.error(e);
   }
+  const defaultPage = getPageFromSearch(location.search);
   const [query, setQuery] = useState<string>(defaultFilter.query ?? '');
   const [datasourceIds, setDatasourceIds] = useState<number[] | undefined>(defaultFilter.datasourceIds);
   const [filterDisabled, setFilterDisabled] = useState<0 | 1 | undefined>(defaultFilter.disabled);
@@ -79,6 +82,13 @@ const Subscribe = (props: Props) => {
     const prev = JSON.parse(window.sessionStorage.getItem(FILTER_SESSION_STORAGE_KEY) || '{}');
     window.sessionStorage.setItem(FILTER_SESSION_STORAGE_KEY, JSON.stringify({ ...prev, ...patch }));
   };
+  // 切换业务组时清除 URL 里的页码，回到第一页（父组件在业务组选择源头递增计数触发，不依赖 gids 变化时序）
+  useEffect(() => {
+    if (groupSwitchCount) {
+      setCurrent(1);
+      history.replace({ pathname: location.pathname, search: removePageFromSearch(location.search) });
+    }
+  }, [groupSwitchCount]);
   const [notificationRules, setNotificationRules] = useState<NotificationRuleItem[]>();
   const notificationRulesAuthorized = useIsAuthorized([notificationRulesPerm]);
 
@@ -94,6 +104,7 @@ const Subscribe = (props: Props) => {
               <Link
                 to={{
                   pathname: `/alert-subscribes/edit/${record.id}`,
+                  search: `?page=${current}`,
                   state: record,
                 }}
                 target={linkTarget}
@@ -357,7 +368,8 @@ const Subscribe = (props: Props) => {
             onChange={(val) => {
               setDatasourceIds(val);
               setCurrent(1);
-              saveState({ datasourceIds: val, current: 1 });
+              saveState({ datasourceIds: val });
+              history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, 1) });
             }}
           />
           <Input
@@ -366,7 +378,8 @@ const Subscribe = (props: Props) => {
             onChange={(e) => {
               setQuery(e.target.value);
               setCurrent(1);
-              saveState({ query: e.target.value, current: 1 });
+              saveState({ query: e.target.value });
+              history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, 1) });
             }}
             prefix={<SearchOutlined />}
             placeholder={t('search_placeholder')}
@@ -382,7 +395,8 @@ const Subscribe = (props: Props) => {
             onChange={(val) => {
               setFilterDisabled(val);
               setCurrent(1);
-              saveState({ disabled: val, current: 1 });
+              saveState({ disabled: val });
+              history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, 1) });
             }}
           />
         </Space>
@@ -410,7 +424,7 @@ const Subscribe = (props: Props) => {
         pagination={{ ...pagination, current }}
         onChange={(pag) => {
           setCurrent(pag.current || 1);
-          saveState({ current: pag.current || 1 });
+          history.replace({ pathname: location.pathname, search: setPageInSearch(location.search, pag.current || 1) });
         }}
         loading={loading}
         // 仅在「确实一条订阅都没有」时展示引导；搜索命中为空时回退到默认空态，避免误导
@@ -469,13 +483,13 @@ const Subscribe = (props: Props) => {
                     key: 'edit',
                     icon: 'edit',
                     text: t('common:btn.edit'),
-                    onClick: () => history.push({ pathname: `/alert-subscribes/edit/${record.id}` }),
+                    onClick: () => history.push({ pathname: `/alert-subscribes/edit/${record.id}`, search: `?page=${current}` }),
                   },
                   {
                     key: 'clone',
                     icon: 'copy',
                     text: t('common:btn.clone'),
-                    onClick: () => history.push({ pathname: `/alert-subscribes/edit/${record.id}`, search: 'mode=clone' }),
+                    onClick: () => history.push({ pathname: `/alert-subscribes/edit/${record.id}`, search: `mode=clone&page=${current}` }),
                   },
                   {
                     key: 'delete',

--- a/src/pages/warning/subscribe/index.tsx
+++ b/src/pages/warning/subscribe/index.tsx
@@ -26,6 +26,12 @@ export default function List() {
   const history = useHistory();
   const { businessGroup } = useContext(CommonStateContext);
   const [gids, setGids] = useState<string | undefined>(getDefaultGids(N9E_GIDS_LOCALKEY, businessGroup)); // -2: 所有告警策略
+  const [groupSwitchCount, setGroupSwitchCount] = useState(0);
+  // 切换业务组时通知列表重置到第一页（在业务组选择源头触发，不依赖 gids 变化时序）
+  const handleSelectGids = (ids: string) => {
+    setGids(ids);
+    setGroupSwitchCount((count) => count + 1);
+  };
   const [refreshFlag, setRefreshFlag] = useState<string>(_.uniqueId('refresh_'));
   const [data, setData] = useState<Array<subscribeItem>>([]);
   const [loading, setLoading] = useState<boolean>(false);
@@ -48,7 +54,7 @@ export default function List() {
   return (
     <PageLayout title={t('title')} icon={<CopyOutlined />} doc={DOC_URL}>
       <div className='shield-content'>
-        <BusinessGroupSideBarWithAll gids={gids} setGids={setGids} localeKey={N9E_GIDS_LOCALKEY} />
+        <BusinessGroupSideBarWithAll gids={gids} setGids={handleSelectGids} localeKey={N9E_GIDS_LOCALKEY} />
         <div
           className='fc-border rounded-lg p-4'
           style={{
@@ -59,6 +65,8 @@ export default function List() {
           <ListNG
             hideBusinessGroupColumn={businessGroup.isLeaf && gids !== '-2'}
             canCreate={businessGroup.isLeaf && gids !== '-2'}
+            gids={gids}
+            groupSwitchCount={groupSwitchCount}
             headerExtra={
               businessGroup.isLeaf && gids !== '-2' ? (
                 <div>

--- a/src/utils/urlPage.test.ts
+++ b/src/utils/urlPage.test.ts
@@ -1,0 +1,45 @@
+import { getPageFromSearch, setPageInSearch, removePageFromSearch } from './urlPage';
+
+describe('getPageFromSearch', () => {
+  it('缺省或空 search 返回 1', () => {
+    expect(getPageFromSearch('')).toBe(1);
+    expect(getPageFromSearch('?')).toBe(1);
+    expect(getPageFromSearch('?foo=1')).toBe(1);
+  });
+
+  it('读取有效页码', () => {
+    expect(getPageFromSearch('?page=3')).toBe(3);
+    expect(getPageFromSearch('?foo=1&page=7')).toBe(7);
+    expect(getPageFromSearch('?page=10&bar=x')).toBe(10);
+  });
+
+  it('非法页码回退到 1', () => {
+    expect(getPageFromSearch('?page=abc')).toBe(1);
+    expect(getPageFromSearch('?page=0')).toBe(1);
+    expect(getPageFromSearch('?page=-2')).toBe(1);
+    expect(getPageFromSearch('?page=1.5')).toBe(1);
+  });
+});
+
+describe('setPageInSearch', () => {
+  it('空 search 时仅输出 page', () => {
+    expect(setPageInSearch('', 3)).toBe('page=3');
+  });
+
+  it('保留既有参数并更新 page', () => {
+    expect(setPageInSearch('?foo=1&page=2', 5)).toBe('foo=1&page=5');
+    expect(setPageInSearch('?foo=1', 2)).toBe('foo=1&page=2');
+  });
+});
+
+describe('removePageFromSearch', () => {
+  it('移除 page 参数，保留其余参数', () => {
+    expect(removePageFromSearch('?foo=1&page=3')).toBe('foo=1');
+    expect(removePageFromSearch('?page=3')).toBe('');
+  });
+
+  it('无 page 时原样返回', () => {
+    expect(removePageFromSearch('?foo=1')).toBe('foo=1');
+    expect(removePageFromSearch('')).toBe('');
+  });
+});

--- a/src/utils/urlPage.ts
+++ b/src/utils/urlPage.ts
@@ -1,0 +1,22 @@
+import queryString from 'query-string';
+
+// 从 URL search 中读取页码（?page=N），缺省/非法时回退到 1
+export function getPageFromSearch(search: string): number {
+  const parsed = queryString.parse(search);
+  const page = Array.isArray(parsed.page) ? parsed.page[0] : parsed.page;
+  const num = Number(page);
+  return Number.isInteger(num) && num > 0 ? num : 1;
+}
+
+// 在现有 search 上设置/更新 page 参数，保留其余参数（幂等）
+export function setPageInSearch(search: string, page: number): string {
+  const parsed = queryString.parse(search);
+  return queryString.stringify({ ...parsed, page });
+}
+
+// 从 search 中移除 page 参数，保留其余参数（幂等）
+export function removePageFromSearch(search: string): string {
+  const parsed = queryString.parse(search);
+  delete parsed.page;
+  return queryString.stringify(parsed);
+}


### PR DESCRIPTION
Move list pagination from sessionStorage to URL ?page=N across list pages. Reset to page 1 after create/edit/batch ops and on business-group switch (via a groupSwitchCount counter). Clear row selection on group switch to prevent stale cross-group IDs reaching batch operations. Add urlPage util (getPageFromSearch/setPageInSearch/removePageFromSearch) with unit tests.

Note: task/taskTpl tables drop column sortable/filterMode alongside the custom onChange override for pagination sync.