### PR TITLE
fix(table): cap kebab trigger layout height to keep 40px row rhythm

### DIFF
--- a/src/components/EnhancedTable/style.less
+++ b/src/components/EnhancedTable/style.less
@@ -85,6 +85,11 @@
   width: 28px;
   height: 28px;
   padding: 0;
+  // Cap layout footprint at 24px (same as sort buttons / inline icons) so rows keep the
+  // 40px rhythm (8px padding + 24px content); the 28px paint/hit area overflows into the
+  // cell padding instead of stretching every row to 45px.
+  margin-top: -2px;
+  margin-bottom: -2px;
   border-radius: 6px;
   color: var(--fc-text-3);
 


### PR DESCRIPTION
## Changes

The row-action kebab trigger in EnhancedTable is sized 28x28 for a comfortable click target. Being the tallest element in a row, it stretched every row that renders the kebab to 45px (8px vertical padding + 28px button + 1px border) instead of the intended 40px row height (8px padding + 24px content).

This adds -2px vertical margins to the trigger so its layout footprint becomes 24px — the same as sort buttons and inline icon action buttons — while the 28px paint and hit area stays unchanged, overflowing into the existing cell padding.

## Effect

- Rows containing the kebab trigger: 45px -> 41px (same rhythm as the 40px header + 1px separator)
- Button visuals, hover pill, and click target: unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented table rows from expanding when using the kebab action trigger.
  * Preserved the trigger’s larger visual and hit area without affecting table layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->