### PR TITLE
fix(AiChatNG): bump launchTick on ENT create launches

### DIFF
--- a/src/components/AiChatNG/FlashAiButton.test.ts
+++ b/src/components/AiChatNG/FlashAiButton.test.ts
@@ -35,4 +35,15 @@ describe('useAiEntClickHandler', () => {
     expect(spreadAt).toBeGreaterThanOrEqual(0);
     expect(forceAt).toBeGreaterThan(spreadAt);
   });
+
+  it('bumps launchTick on every click so createNew-only re-launches re-run initSession', () => {
+    // createNew alone is a latch (true→true); launchTick must change so a prior
+    // knowledge-base prefill is cleared when ai-task "创建" opens the drawer again.
+    expect(handler).toMatch(/launchTick:\s*Date\.now\(\)/);
+    const customStart = handler.indexOf('custom:');
+    const customBlock = handler.slice(customStart);
+    const spreadAt = customBlock.indexOf('...queryAction');
+    const tickAt = customBlock.search(/launchTick:\s*Date\.now\(\)/);
+    expect(tickAt).toBeGreaterThan(spreadAt);
+  });
 });

--- a/src/components/AiChatNG/FlashAiButton.tsx
+++ b/src/components/AiChatNG/FlashAiButton.tsx
@@ -56,6 +56,10 @@ function useAiEntClickHandler(options?: {
         // After spreads: ConfigHost pages live on /flashai*, where AiChat stays
         // in page mode unless forceDrawer is set (knowledge / scheduled-task).
         forceDrawer: true,
+        // Edge every launch: createNew alone stays true→true when a prior launch
+        // left it latched, so initSession would not re-run and a knowledge-base
+        // prefill would remain in the composer (ai-task "创建" after "AI 创建").
+        launchTick: Date.now(),
       } as any,
     });
   }, [setAiChatVisible, setAiHandleEvent, setAiExternalConfig, setParamsAiAction, onExecuteQueryForQueryContent, promptList, queryPageFrom, queryAction]);


### PR DESCRIPTION
## Summary
- Stamp `launchTick: Date.now()` on every ENT Create click (`useAiEntClickHandler`), after the `queryAction` spread so call sites cannot wipe it.

## Review
- ai-task Create goes through this handler with `createNew: true` and no content. After a knowledge-base prefill, `createNew` can stay latched `true→true`, so FlashAI `initSession` never re-ran and left the draft in the composer.
- Companion srm-fe change consumes `launchTick` and clears leftover references.

## Verification
- `npm test -- --testPathPattern=FlashAiButton.test --watchAll=false` → pass
- Browser validation expected via the →pre companion after a joint 9000 build

## Notes/Risks
- Clean branch from `main` (cherry-picked). Companion PR targets `pre`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI chat launching so repeated clicks reliably start a fresh session, even when creating a new chat is already enabled.
  * Ensured each launch is recognized as a distinct action for more consistent chat reinitialization.

* **Tests**
  * Added coverage verifying that repeated AI chat launches receive unique timing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->