### PR TITLE
feat(TimeRangePicker): support hiding the refresh button and dismissing the range tooltip

### DIFF
--- a/src/components/TimeRangePicker/TimeRangePickerWithRefresh.tsx
+++ b/src/components/TimeRangePicker/TimeRangePickerWithRefresh.tsx
@@ -26,34 +26,37 @@ import { ITimeRangePickerWithRefreshProps } from './types';
 import { valueAsString } from './utils';
 
 export default function TimeRangePickerWithRefresh(props: ITimeRangePickerWithRefreshProps) {
-  const { value, onChange, style, refreshTooltip, intervalTooltip, timeRangeTooltip, dateFormat = 'YYYY-MM-DD HH:mm', localKey, onRefresh } = props;
+  const { value, onChange, style, refreshTooltip, intervalTooltip, timeRangeTooltip, showRefreshButton = true, dateFormat = 'YYYY-MM-DD HH:mm', localKey, onRefresh } = props;
   const [globalVar] = useGlobalVar();
+  const [timeRangeTooltipVisible, setTimeRangeTooltipVisible] = React.useState(false);
 
   return (
     <Space style={style}>
-      <AutoRefresh
-        localKey={localKey && `${localKey}_refresh`}
-        tooltip={refreshTooltip}
-        intervalTooltip={intervalTooltip}
-        onRefresh={() => {
-          if (value && onChange) {
-            onChange({
-              ...value,
-              refreshFlag: _.uniqueId('refreshFlag_'),
-            });
-          }
-          if (onRefresh) {
-            onRefresh();
-          }
-        }}
-        intervalSeconds={props.intervalSeconds}
-        onIntervalSecondsChange={props.onIntervalSecondsChange}
-      />
-      <Tooltip title={timeRangeTooltip}>
-        <span style={{ display: 'inline-flex' }}>
+      {showRefreshButton && (
+        <AutoRefresh
+          localKey={localKey && `${localKey}_refresh`}
+          tooltip={refreshTooltip}
+          intervalTooltip={intervalTooltip}
+          onRefresh={() => {
+            if (value && onChange) {
+              onChange({
+                ...value,
+                refreshFlag: _.uniqueId('refreshFlag_'),
+              });
+            }
+            if (onRefresh) {
+              onRefresh();
+            }
+          }}
+          intervalSeconds={props.intervalSeconds}
+          onIntervalSecondsChange={props.onIntervalSecondsChange}
+        />
+      )}
+      <Tooltip title={timeRangeTooltip} visible={timeRangeTooltip ? timeRangeTooltipVisible : false} onVisibleChange={setTimeRangeTooltipVisible}>
+        <span style={{ display: 'inline-flex' }} onClickCapture={() => setTimeRangeTooltipVisible(false)}>
           <TimeRangePicker
             limitHour={globalVar.RangePickerHour ? Number(globalVar.RangePickerHour) : undefined}
-            {..._.omit(props, ['style', 'refreshTooltip', 'intervalTooltip', 'timeRangeTooltip', 'intervalSeconds', 'onIntervalSecondsChange', 'onRefresh'])}
+            {..._.omit(props, ['style', 'refreshTooltip', 'intervalTooltip', 'timeRangeTooltip', 'showRefreshButton', 'intervalSeconds', 'onIntervalSecondsChange', 'onRefresh'])}
             onChange={(val) => {
               if (localKey) {
                 localStorage.setItem(

--- a/src/components/TimeRangePicker/types.ts
+++ b/src/components/TimeRangePicker/types.ts
@@ -87,6 +87,7 @@ export interface ITimeRangePickerWithRefreshProps extends ITimeRangePickerProps 
   refreshTooltip?: string;
   intervalTooltip?: React.ReactNode;
   timeRangeTooltip?: React.ReactNode;
+  showRefreshButton?: boolean;
   intervalSeconds?: number;
   onIntervalSecondsChange?: (value: number) => void;
   onRefresh?: () => void;


### PR DESCRIPTION
## Why

`TimeRangePickerWithRefresh` bundles three things on top of the refresh control: the range tooltip, the global `RangePickerHour` limit, and `localKey` persistence. A caller that wants those but not the auto-refresh button had no way to say so.

## What

- `showRefreshButton` (default `true`) gates `AutoRefresh`, so existing callers are unaffected.
- A click inside the picker now dismisses the range tooltip (`visible` / `onVisibleChange`); it previously stayed up until the pointer left, sitting on top of the panel the click had just opened.

## Verification

- `npx prettier --check` clean on both changed files.