### PR TITLE
feat(TimeRangePicker): support hiding the refresh button and a range tooltip

### DIFF
--- a/src/components/TimeRangePicker/TimeRangePickerWithRefresh.tsx
+++ b/src/components/TimeRangePicker/TimeRangePickerWithRefresh.tsx
@@ -15,7 +15,7 @@
  *
  */
 import React from 'react';
-import { Space } from 'antd';
+import { Space, Tooltip } from 'antd';
 import _ from 'lodash';
 
 import { useGlobalVar } from '@/utils/useHook';
@@ -26,48 +26,55 @@ import { ITimeRangePickerWithRefreshProps } from './types';
 import { valueAsString } from './utils';
 
 export default function TimeRangePickerWithRefresh(props: ITimeRangePickerWithRefreshProps) {
-  const { value, onChange, style, refreshTooltip, dateFormat = 'YYYY-MM-DD HH:mm', localKey, onRefresh } = props;
+  const { value, onChange, style, refreshTooltip, timeRangeTooltip, showRefreshButton = true, dateFormat = 'YYYY-MM-DD HH:mm', localKey, onRefresh } = props;
   const [globalVar] = useGlobalVar();
+  const [timeRangeTooltipVisible, setTimeRangeTooltipVisible] = React.useState(false);
 
   return (
     <Space style={style}>
-      <AutoRefresh
-        localKey={localKey && `${localKey}_refresh`}
-        tooltip={refreshTooltip}
-        onRefresh={() => {
-          if (value && onChange) {
-            onChange({
-              ...value,
-              refreshFlag: _.uniqueId('refreshFlag_'),
-            });
-          }
-          if (onRefresh) {
-            onRefresh();
-          }
-        }}
-        intervalSeconds={props.intervalSeconds}
-        onIntervalSecondsChange={props.onIntervalSecondsChange}
-      />
-      <TimeRangePicker
-        limitHour={globalVar.RangePickerHour ? Number(globalVar.RangePickerHour) : undefined}
-        {..._.omit(props, ['style'])}
-        onChange={(val) => {
-          if (localKey) {
-            localStorage.setItem(
-              localKey,
-              val
-                ? JSON.stringify({
-                    start: valueAsString(val.start, dateFormat),
-                    end: valueAsString(val.end, dateFormat),
-                  })
-                : '',
-            );
-          }
-          if (onChange) {
-            onChange(val);
-          }
-        }}
-      />
+      {showRefreshButton && (
+        <AutoRefresh
+          localKey={localKey && `${localKey}_refresh`}
+          tooltip={refreshTooltip}
+          onRefresh={() => {
+            if (value && onChange) {
+              onChange({
+                ...value,
+                refreshFlag: _.uniqueId('refreshFlag_'),
+              });
+            }
+            if (onRefresh) {
+              onRefresh();
+            }
+          }}
+          intervalSeconds={props.intervalSeconds}
+          onIntervalSecondsChange={props.onIntervalSecondsChange}
+        />
+      )}
+      <Tooltip title={timeRangeTooltip} visible={timeRangeTooltip ? timeRangeTooltipVisible : false} onVisibleChange={setTimeRangeTooltipVisible}>
+        <span style={{ display: 'inline-flex' }} onClickCapture={() => setTimeRangeTooltipVisible(false)}>
+          <TimeRangePicker
+            limitHour={globalVar.RangePickerHour ? Number(globalVar.RangePickerHour) : undefined}
+            {..._.omit(props, ['style', 'timeRangeTooltip', 'showRefreshButton'])}
+            onChange={(val) => {
+              if (localKey) {
+                localStorage.setItem(
+                  localKey,
+                  val
+                    ? JSON.stringify({
+                        start: valueAsString(val.start, dateFormat),
+                        end: valueAsString(val.end, dateFormat),
+                      })
+                    : '',
+                );
+              }
+              if (onChange) {
+                onChange(val);
+              }
+            }}
+          />
+        </span>
+      </Tooltip>
     </Space>
   );
 }

--- a/src/components/TimeRangePicker/types.ts
+++ b/src/components/TimeRangePicker/types.ts
@@ -85,6 +85,8 @@ export interface ITimeRangePickerProps {
 
 export interface ITimeRangePickerWithRefreshProps extends ITimeRangePickerProps {
   refreshTooltip?: string;
+  timeRangeTooltip?: React.ReactNode;
+  showRefreshButton?: boolean;
   intervalSeconds?: number;
   onIntervalSecondsChange?: (value: number) => void;
   onRefresh?: () => void;


### PR DESCRIPTION
Brings `main` in line with #2263, which landed on `pre`.

## Why

`TimeRangePickerWithRefresh` bundles the global `RangePickerHour` limit and `localKey` persistence together with the refresh control. A caller that wants those but not the refresh button had no way to say so, and no way to attach an explanation to the range control either.

## What

- `showRefreshButton` (default `true`) gates `AutoRefresh`, so existing callers are unaffected.
- `timeRangeTooltip` renders a tooltip over the picker, dismissed on click so it does not cover the panel that the click opens.
- Both props are omitted from the spread onto `TimeRangePicker` so they never reach the DOM.

## Verification

- `npx prettier --check` clean on both changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional tooltip support to the time-range control.
  * Added the ability to show or hide the refresh button.
  * Tooltips can be dismissed by clicking the time-range control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->