### PR TITLE
feat(TimeRangePicker): add intervalTooltip to AutoRefresh

### DIFF
--- a/src/components/TimeRangePicker/AutoRefresh/index.tsx
+++ b/src/components/TimeRangePicker/AutoRefresh/index.tsx
@@ -25,7 +25,8 @@ const refreshMap = {
 
 interface IProps {
   disabled?: boolean;
-  tooltip?: string;
+  tooltip?: React.ReactNode;
+  intervalTooltip?: React.ReactNode;
   onRefresh: () => void;
   localKey?: string;
   intervalSeconds?: number;
@@ -100,40 +101,49 @@ function Refresh(props: IProps, ref) {
       <Tooltip title={props.tooltip}>
         <Button disabled={props.disabled} icon={<SyncOutlined className={intervalSeconds ? 'rotate-icon' : ''} />} onClick={props.onRefresh} />
       </Tooltip>
-      <Dropdown
-        disabled={props.disabled}
-        trigger={['click']}
-        visible={visible}
-        onVisibleChange={(visible) => {
-          setVisible(visible);
-        }}
-        overlay={
-          <Menu
-            onClick={(e) => {
-              setIntervalSeconds(_.toNumber(e.key));
-              props.localKey && window.localStorage.setItem(props.localKey, e.key);
-              props.onIntervalSecondsChange && props.onIntervalSecondsChange(_.toNumber(e.key));
-              setVisible(false);
-            }}
-          >
-            {_.map(refreshMap, (text, value) => {
-              return <Menu.Item key={value}>{text}</Menu.Item>;
-            })}
-          </Menu>
-        }
+      <Tooltip
+        // 浮层落在展开后的菜单前两项上且层级更高，必须让它不参与命中测试，
+        // 否则会吞掉这两项的点击；同时浮层不可悬浮，移向菜单时才能正常消失
+        overlayStyle={{ maxWidth: 320, pointerEvents: 'none' }}
+        title={props.intervalTooltip}
       >
-        <Button
-          onClick={() => {
-            setVisible(!visible);
-          }}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-          }}
-        >
-          {refreshMap[intervalSeconds]} {visible ? <UpOutlined /> : <DownOutlined style={{ fontSize: 12 }} />}
-        </Button>
-      </Dropdown>
+        <span>
+          <Dropdown
+            disabled={props.disabled}
+            trigger={['click']}
+            visible={visible}
+            onVisibleChange={(visible) => {
+              setVisible(visible);
+            }}
+            overlay={
+              <Menu
+                onClick={(e) => {
+                  setIntervalSeconds(_.toNumber(e.key));
+                  props.localKey && window.localStorage.setItem(props.localKey, e.key);
+                  props.onIntervalSecondsChange && props.onIntervalSecondsChange(_.toNumber(e.key));
+                  setVisible(false);
+                }}
+              >
+                {_.map(refreshMap, (text, value) => {
+                  return <Menu.Item key={value}>{text}</Menu.Item>;
+                })}
+              </Menu>
+            }
+          >
+            <Button
+              onClick={() => {
+                setVisible(!visible);
+              }}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+              }}
+            >
+              {refreshMap[intervalSeconds]} {visible ? <UpOutlined /> : <DownOutlined style={{ fontSize: 12 }} />}
+            </Button>
+          </Dropdown>
+        </span>
+      </Tooltip>
     </div>
   );
 }

--- a/src/components/TimeRangePicker/TimeRangePickerWithRefresh.tsx
+++ b/src/components/TimeRangePicker/TimeRangePickerWithRefresh.tsx
@@ -26,7 +26,7 @@ import { ITimeRangePickerWithRefreshProps } from './types';
 import { valueAsString } from './utils';
 
 export default function TimeRangePickerWithRefresh(props: ITimeRangePickerWithRefreshProps) {
-  const { value, onChange, style, refreshTooltip, timeRangeTooltip, showRefreshButton = true, dateFormat = 'YYYY-MM-DD HH:mm', localKey, onRefresh } = props;
+  const { value, onChange, style, refreshTooltip, intervalTooltip, timeRangeTooltip, showRefreshButton = true, dateFormat = 'YYYY-MM-DD HH:mm', localKey, onRefresh } = props;
   const [globalVar] = useGlobalVar();
   const [timeRangeTooltipVisible, setTimeRangeTooltipVisible] = React.useState(false);
 
@@ -36,6 +36,7 @@ export default function TimeRangePickerWithRefresh(props: ITimeRangePickerWithRe
         <AutoRefresh
           localKey={localKey && `${localKey}_refresh`}
           tooltip={refreshTooltip}
+          intervalTooltip={intervalTooltip}
           onRefresh={() => {
             if (value && onChange) {
               onChange({
@@ -55,7 +56,7 @@ export default function TimeRangePickerWithRefresh(props: ITimeRangePickerWithRe
         <span style={{ display: 'inline-flex' }} onClickCapture={() => setTimeRangeTooltipVisible(false)}>
           <TimeRangePicker
             limitHour={globalVar.RangePickerHour ? Number(globalVar.RangePickerHour) : undefined}
-            {..._.omit(props, ['style', 'timeRangeTooltip', 'showRefreshButton'])}
+            {..._.omit(props, ['style', 'refreshTooltip', 'intervalTooltip', 'timeRangeTooltip', 'showRefreshButton', 'intervalSeconds', 'onIntervalSecondsChange', 'onRefresh'])}
             onChange={(val) => {
               if (localKey) {
                 localStorage.setItem(

--- a/src/components/TimeRangePicker/types.ts
+++ b/src/components/TimeRangePicker/types.ts
@@ -85,6 +85,7 @@ export interface ITimeRangePickerProps {
 
 export interface ITimeRangePickerWithRefreshProps extends ITimeRangePickerProps {
   refreshTooltip?: string;
+  intervalTooltip?: React.ReactNode;
   timeRangeTooltip?: React.ReactNode;
   showRefreshButton?: boolean;
   intervalSeconds?: number;


### PR DESCRIPTION
Follow-up to #2264. Brings the remaining `TimeRangePicker` delta on `main` in line with `pre`.

## What

- `intervalTooltip` lets a caller explain what the refresh-interval control does, mirroring `timeRangeTooltip` on the range control.
- The overlay is excluded from hit testing and made non-hoverable, because it lands on top of the first entries of the opened menu and would otherwise swallow clicks on them.
- `tooltip` widens from `string` to `React.ReactNode` alongside it.

After this, `src/components/TimeRangePicker/` is byte-identical between `main` and `pre` (`git diff origin/pre -- src/components/TimeRangePicker/` is empty).

## Verification

- `npx prettier --check` clean on all three changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tooltip support for auto-refresh interval selections.
  - Tooltips can now include rich content, including custom React elements.
  - Improved tooltip display with non-interactive behavior and constrained width.
- **Bug Fixes**
  - Prevented refresh and interval-specific settings from being passed to unrelated time range controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->