### PR TITLE
fix(side-menu): keep the rail collapsed when a menu row is clicked

### DIFF
--- a/src/components/SideMenu/MenuList.tsx
+++ b/src/components/SideMenu/MenuList.tsx
@@ -24,7 +24,7 @@ const SIDE_MENU_HOVER_TOOLTIP_PLACEMENTS = (() => {
 interface IMenuProps {
   collapsed: boolean;
   selectedKeys?: string[];
-  onClick?: (key: any, opts?: { keepCollapsed?: boolean }) => void;
+  onClick?: (key: any) => void;
   sideMenuBgColor: string;
   isCustomBg: boolean;
   quickMenuRef: React.MutableRefObject<{ open: () => void }>;
@@ -88,6 +88,21 @@ function getMenuGroupIconColorClass(opts: {
     return '';
   }
   return 'text-[#6E6587]';
+}
+
+/**
+ * Collapsed top-level rows show an icon only, so the label has to come from a tooltip.
+ * Sub rows live inside the hover panel, which already renders their labels.
+ */
+function wrapCollapsedRowWithTooltip(row: React.ReactElement, opts: { collapsed: boolean; isSub: boolean; title: React.ReactNode }) {
+  if (!opts.collapsed || opts.isSub) {
+    return row;
+  }
+  return (
+    <Tooltip title={opts.title} placement='right'>
+      {row}
+    </Tooltip>
+  );
 }
 
 function chunkMenusBySection(items: IMenuItem[]) {
@@ -169,10 +184,8 @@ export function MenuGroup(props: { item: IMenuItem } & IMenuProps) {
     <div className='w-full' ref={rootRef}>
       <div
         onClick={() => {
-          if (collapsed) {
-            otherProps.onClick?.(item.key);
-            return;
-          }
+          // Collapsed rail: the hover panel is the only way into a group's children.
+          if (collapsed) return;
           setIsExpand(!isExpand);
         }}
         className={cn(
@@ -304,7 +317,7 @@ export function MenuItem(props: { item: IMenuItem; isSub?: boolean; isBgBlack?: 
     ? 'hover:bg-[rgba(204,204,220,0.12)]'
     : 'hover:bg-fc-200';
 
-  return (
+  const row = (
     <Link
       to={savedPath || path}
       className={cn(
@@ -397,6 +410,8 @@ export function MenuItem(props: { item: IMenuItem; isSub?: boolean; isBgBlack?: 
       )}
     </Link>
   );
+
+  return wrapCollapsedRowWithTooltip(row, { collapsed, isSub, title: t(item.label) });
 }
 
 function AbsoluteMenuItem(props: { item: IMenuItem; isSub?: boolean; isBgBlack?: boolean } & IMenuProps) {
@@ -418,7 +433,7 @@ function AbsoluteMenuItem(props: { item: IMenuItem; isSub?: boolean; isBgBlack?:
     ? 'px-3.5 text-[var(--fc-sidemenu-item-text)] hover:bg-[var(--fc-sidemenu-item-hover-bg)]'
     : cn('px-3.5', isCustomBg ? 'text-[#ccccdc]' : 'text-main', 'hover:bg-[rgba(204,204,220,0.12)]');
 
-  return (
+  const row = (
     <a
       href={item.path}
       target={item.target}
@@ -462,6 +477,8 @@ function AbsoluteMenuItem(props: { item: IMenuItem; isSub?: boolean; isBgBlack?:
       )}
     </a>
   );
+
+  return wrapCollapsedRowWithTooltip(row, { collapsed, isSub, title: t(item.label) });
 }
 
 export default function MenuList(
@@ -710,7 +727,7 @@ export default function MenuList(
                                 </>
                               );
                               const handleClick = () => {
-                                props.onClick?.(c.key, { keepCollapsed: true });
+                                props.onClick?.(c.key);
                                 closeHoverPanel();
                               };
                               if (c.pathType === 'absolute') {

--- a/src/components/SideMenu/index.tsx
+++ b/src/components/SideMenu/index.tsx
@@ -480,13 +480,7 @@ const SideMenu = (props: SideMenuProps) => {
                 isCustomBg={isCustomBg}
                 quickMenuRef={quickMenuRef}
                 topExtra={topExtra}
-                onClick={(key, opts) => {
-                  if (collapsed && !opts?.keepCollapsed) {
-                    setCollapsed(false);
-                    localStorage.setItem('menuCollapsed', '0');
-                  }
-                  onMenuClick?.(key);
-                }}
+                onClick={onMenuClick}
                 isGoldTheme={isGoldTheme}
               />
             </ScrollArea>

--- a/src/components/SideMenu/menu.test.ts
+++ b/src/components/SideMenu/menu.test.ts
@@ -45,6 +45,30 @@ describe('SideMenu hover panel styles', () => {
     expect(menuListContent).toContain('const hoverChildren = visibleChildren;');
   });
 
+  it('never re-opens the collapsed rail from a menu click', () => {
+    const indexPath = path.join(__dirname, 'index.tsx');
+    const menuListPath = path.join(__dirname, 'MenuList.tsx');
+    const indexContent = fs.readFileSync(indexPath, 'utf8');
+    const menuListContent = fs.readFileSync(menuListPath, 'utf8');
+
+    // The collapse toggle in the header is the only writer, so no click path needs to opt out of expanding.
+    expect(indexContent).not.toContain('keepCollapsed');
+    expect(menuListContent).not.toContain('keepCollapsed');
+    expect(indexContent.match(/localStorage\.setItem\('menuCollapsed'/g)).toHaveLength(1);
+    expect(indexContent).toMatch(/const toggleCollapsed = \(\) => \{[\s\S]*?localStorage\.setItem\('menuCollapsed'/);
+  });
+
+  it('labels collapsed top-level rows with a tooltip instead of expanding them', () => {
+    const menuListPath = path.join(__dirname, 'MenuList.tsx');
+    const menuListContent = fs.readFileSync(menuListPath, 'utf8');
+
+    // Leaf rows (e.g. FlashAI) render icon-only when collapsed, so the label has to come from a tooltip.
+    expect(menuListContent).toContain('function wrapCollapsedRowWithTooltip');
+    expect(menuListContent.match(/return wrapCollapsedRowWithTooltip\(row, \{ collapsed, isSub, title: t\(item\.label\) \}\);/g)).toHaveLength(2);
+    // A collapsed group row must not act on click; its children are reachable through the hover panel.
+    expect(menuListContent).toMatch(/onClick=\{\(\) => \{[\s\S]{0,160}?if \(collapsed\) return;\s*setIsExpand\(!isExpand\);/);
+  });
+
   it('clears profile submenus without changing their popup container', () => {
     const indexPath = path.join(__dirname, 'index.tsx');
     const indexContent = fs.readFileSync(indexPath, 'utf8');


### PR DESCRIPTION
## Summary

Clicking any row in the collapsed side menu expanded the whole rail. Group rows and top-level leaf rows (for example FlashAI) both routed their click through the shared `onClick` handler in `SideMenu/index.tsx`, which called `setCollapsed(false)`. The hardcoded home link was the only row that behaved correctly, because it never calls `onClick`.

- Remove the auto-expand, so the header toggle is the only thing that changes the collapsed state. The `keepCollapsed` opt-out existed solely to let the hover panel escape that auto-expand, so it goes away with it.
- A collapsed group row no longer acts on click. Its children stay reachable through the existing hover panel.
- Collapsed top-level rows render icon-only, so they now carry a tooltip with their label. This is applied to every top-level leaf rather than special-cased for one entry, which is what gives FlashAI its hover tooltip.

## Verification

- `npx jest src/components/SideMenu` — 11/11 pass.
- Two regression tests added to `menu.test.ts`, following the existing source-assertion style in this suite (Jest here runs in a `node` environment with no DOM testing library, so component rendering cannot be asserted). Both were confirmed to fail against the pre-fix source and pass after it.

## Notes

- Not exercised in a browser: verification was limited to the unit suite at the requester's direction.
- `src/components/SideMenu/menu.less` is untouched; the collapsed hover panel keeps its current styling.
