### PR TITLE
fix(side-menu): align leaf menu icon spacing with groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist-ssr
 *.local
 .vscode
 .idea/*
+.claude/
 pub
 deploy.sh
 src/Packages/*

--- a/src/components/SideMenu/MenuList.tsx
+++ b/src/components/SideMenu/MenuList.tsx
@@ -378,7 +378,7 @@ export function MenuItem(props: { item: IMenuItem; isSub?: boolean; isBgBlack?: 
                   : 'text-[#fff]'
                 : 'text-title'
               : '',
-            !collapsed ? 'mr-4' : '',
+            !collapsed ? 'mr-2.5' : '',
           )}
         >
           {item.icon}
@@ -444,7 +444,7 @@ function AbsoluteMenuItem(props: { item: IMenuItem; isSub?: boolean; isBgBlack?:
         <div
           className={cn(
             'inline-flex h-[16px] w-[16px] shrink-0 items-center justify-center children-icon2:h-[16px] children-icon2:w-[16px]',
-            !collapsed ? 'mr-4' : '',
+            !collapsed ? 'mr-2.5' : '',
             isLight ? 'text-[var(--fc-sidemenu-item-icon)] group-hover:text-[var(--fc-sidemenu-item-hover-text)]' : '',
           )}
         >


### PR DESCRIPTION
## Summary
- Align top-level leaf side menu rows (`MenuItem` / `AbsoluteMenuItem`) icon spacing from `mr-4` to `mr-2.5`, matching `MenuGroup` rows and fixing FlashAI label offset.
- Ignore local `.claude/` config via `.gitignore`.

## Review
- `/cmt strict` review performed; no blockers found.

## Verification
- `git diff --check`
- `npm test -- --runInBand src/components/SideMenu/menu.test.ts src/components/SideMenu/header-layout.test.ts src/components/SideMenu/profile.test.ts` (11 passed)

## Notes/Risks
- Merged into `pre` and pushed before opening this PR.
- Visual check in srm-fe sidebar recommended after integrate/build.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved side menu spacing by reducing the gap between icons and labels when the menu is expanded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->