### PR TITLE
fix: keep the port in the categraf install address

### DIFF
--- a/src/pages/hosts/pages/List/CollectSetup/index.tsx
+++ b/src/pages/hosts/pages/List/CollectSetup/index.tsx
@@ -18,7 +18,7 @@ import { localizeDocUrl } from '@/utils/docUrl';
 import { CATEGRAF_TROUBLESHOOT_DOC, NS, VERIFIED_DATASOURCE_IDS_KEY } from '../../../constants';
 import { CategrafInstallMeta, probeTargets } from '../../../services';
 import CommandBlock from '../components/CommandBlock';
-import { isValidServerAddr, normalizeServerAddr } from '../InstallCategraf/buildCommand';
+import { isValidServerAddr, pickDefaultServerAddr } from '../InstallCategraf/buildCommand';
 import { CollectComponent, CollectField, getTemplateUrl } from './catalog';
 import { buildToml, CollectFormValues } from './buildToml';
 import { buildCollectCommand, buildManualCollectCommand } from './buildCommand';
@@ -123,7 +123,7 @@ export default function CollectSetup(props: Props) {
   // 预览随表单联动；不用 Form.useWatch 是为了兼容仓库锁定的 antd 4 小版本
   const [previewTick, setPreviewTick] = useState(0);
 
-  const [addr, setAddr] = useState<string>(() => meta.base_url || normalizeServerAddr(siteInfo?.site_url) || window.location.origin);
+  const [addr, setAddr] = useState<string>(() => pickDefaultServerAddr({ metaBaseURL: meta.base_url, siteURL: siteInfo?.site_url, origin: window.location.origin }));
   const [authUser, setAuthUser] = useState('');
   const [authPass, setAuthPass] = useState('');
 

--- a/src/pages/hosts/pages/List/InstallCategraf/buildCommand.test.ts
+++ b/src/pages/hosts/pages/List/InstallCategraf/buildCommand.test.ts
@@ -1,0 +1,119 @@
+import { buildInstallCommand, buildManualCommand, pickDefaultServerAddr } from './buildCommand';
+
+// jest 跑在 node 环境，normalizeServerAddr 会读 window.location.protocol 给
+// 无协议的输入补协议，所以这里得给个最小 window
+beforeAll(() => {
+  (global as any).window = { location: { protocol: 'https:' } };
+});
+
+describe('pickDefaultServerAddr', () => {
+  // issue #3330：nginx 的 `proxy_set_header Host $host` 不带端口，服务端据此推出的
+  // base_url 就少了端口，装机命令里三处地址跟着一起错
+  it('takes the port from the browser when the proxy dropped it', () => {
+    expect(
+      pickDefaultServerAddr({
+        metaBaseURL: 'https://n9e.example.com',
+        origin: 'https://n9e.example.com:10443',
+      }),
+    ).toBe('https://n9e.example.com:10443');
+  });
+
+  // 漏配 X-Forwarded-Proto 时服务端推成 http，同样以浏览器为准
+  it('takes the scheme from the browser when X-Forwarded-Proto is missing', () => {
+    expect(
+      pickDefaultServerAddr({
+        metaBaseURL: 'http://n9e.example.com:10443',
+        origin: 'https://n9e.example.com:10443',
+      }),
+    ).toBe('https://n9e.example.com:10443');
+  });
+
+  // origin 里没有路径，只借 protocol+host，子路径反代不能被抹掉
+  it('keeps the reverse-proxy sub-path while fixing protocol and port', () => {
+    expect(
+      pickDefaultServerAddr({
+        metaBaseURL: 'https://n9e.example.com/n9e',
+        origin: 'https://n9e.example.com:10443',
+      }),
+    ).toBe('https://n9e.example.com:10443/n9e');
+  });
+
+  // hostname 不同 = 运维刻意配的对外地址，浏览器地址不能覆盖它
+  it('keeps a deliberately different host untouched', () => {
+    expect(
+      pickDefaultServerAddr({
+        metaBaseURL: 'https://agent-gw.example.com:8443',
+        origin: 'https://console.example.com',
+      }),
+    ).toBe('https://agent-gw.example.com:8443');
+  });
+
+  it('leaves an already-correct base_url alone', () => {
+    expect(
+      pickDefaultServerAddr({
+        metaBaseURL: 'https://n9e.example.com:10443',
+        origin: 'https://n9e.example.com:10443',
+      }),
+    ).toBe('https://n9e.example.com:10443');
+  });
+
+  // site_url 是管理员手填的，端口就算和浏览器不一致也照原样用
+  it('never rewrites an admin-configured site_url', () => {
+    expect(
+      pickDefaultServerAddr({
+        siteURL: 'https://n9e.example.com',
+        origin: 'https://n9e.example.com:10443',
+      }),
+    ).toBe('https://n9e.example.com');
+  });
+
+  it('falls back to site_url, then to the browser origin', () => {
+    expect(pickDefaultServerAddr({ siteURL: 'http://other.example.com:17000', origin: 'https://n9e.example.com:10443' })).toBe(
+      'http://other.example.com:17000',
+    );
+    expect(pickDefaultServerAddr({ origin: 'https://n9e.example.com:10443' })).toBe('https://n9e.example.com:10443');
+    expect(pickDefaultServerAddr({})).toBe('');
+  });
+
+  it('drops a trailing slash', () => {
+    expect(pickDefaultServerAddr({ metaBaseURL: 'https://n9e.example.com:10443/', origin: 'https://n9e.example.com:10443' })).toBe(
+      'https://n9e.example.com:10443',
+    );
+  });
+});
+
+describe('buildInstallCommand', () => {
+  const addr = 'https://n9e.example.com:10443';
+
+  // --download-base 是 issue #3330 的第三处：脚本里的 DOWNLOAD_BASE 由服务端渲染，
+  // 推错时内网下载必失败且用户无从补救，所以命令里显式带上它
+  it('pins the download source to the address shown in the UI', () => {
+    expect(buildInstallCommand({ serverAddr: addr })).toBe(
+      `curl -sSfL '${addr}/api/n9e/agents/categraf/install.sh' | sudo bash -s -- --server '${addr}' --download-base '${addr}'`,
+    );
+  });
+
+  it('appends auth after the address flags', () => {
+    const cmd = buildInstallCommand({ serverAddr: addr, basicAuthUser: 'u', basicAuthPass: 'p' });
+    expect(cmd).toBe(
+      `curl -sSfL -u 'u:p' '${addr}/api/n9e/agents/categraf/install.sh' | sudo bash -s -- --server '${addr}' --download-base '${addr}' --auth 'u:p'`,
+    );
+  });
+
+  it('returns empty for an unusable address', () => {
+    expect(buildInstallCommand({ serverAddr: '  ' })).toBe('');
+  });
+});
+
+describe('buildManualCommand', () => {
+  it('carries the same download source as the piped form', () => {
+    const addr = 'https://n9e.example.com:10443';
+    expect(buildManualCommand({ serverAddr: addr })).toBe(
+      [
+        `curl -sSfL '${addr}/api/n9e/agents/categraf/install.sh' -o install-categraf.sh`,
+        'less install-categraf.sh',
+        `sudo bash install-categraf.sh --server '${addr}' --download-base '${addr}'`,
+      ].join('\n'),
+    );
+  });
+});

--- a/src/pages/hosts/pages/List/InstallCategraf/buildCommand.ts
+++ b/src/pages/hosts/pages/List/InstallCategraf/buildCommand.ts
@@ -13,6 +13,41 @@ export function normalizeServerAddr(input?: string): string {
   return _.trimEnd(withProtocol, '/');
 }
 
+/**
+ * 选出「被监控机器该上报到哪」的默认地址。
+ *
+ * meta.base_url 是服务端从请求头推导的，反代下常常不可靠：nginx 最常见的那段
+ * `proxy_set_header Host $host` 会把端口吃掉（`$http_host` 才带端口），
+ * `X-Forwarded-Proto` 漏配则会把 https 推成 http。于是 https://n9e.example.com:10443
+ * 被推成 https://n9e.example.com，装机命令里的地址全少一截。
+ *
+ * 浏览器地址栏永远带着真实协议与端口，所以同一台机器（hostname 相同）上以浏览器
+ * 为准，只借用它的 protocol + host，保留 base_url 自己的子路径（反代子路径部署
+ * 如 /n9e，origin 里是没有的）。hostname 不同则说明服务端推出来的是另一个对外
+ * 地址，原样保留。
+ *
+ * 只订正 base_url：它是「推」出来的，可能错。site_url 是管理员在站点设置里一个字
+ * 一个字敲进去的，端口写成什么就是什么，拿浏览器地址去改写它是越权。
+ */
+export function pickDefaultServerAddr(options: { metaBaseURL?: string; siteURL?: string; origin?: string }): string {
+  const origin = normalizeServerAddr(options.origin);
+  const derived = normalizeServerAddr(options.metaBaseURL);
+  if (!derived) return normalizeServerAddr(options.siteURL) || origin;
+  if (!origin || derived === origin) return derived;
+  let derivedURL: URL;
+  let originURL: URL;
+  try {
+    derivedURL = new URL(derived);
+    originURL = new URL(origin);
+  } catch {
+    return origin; // base_url 解析不了，拿它也拼不出能用的命令
+  }
+  // URL 会把 :80 / :443 这类默认端口归一成空串，直接比 port 即可
+  if (derivedURL.hostname !== originURL.hostname) return derived;
+  if (derivedURL.port === originURL.port && derivedURL.protocol === originURL.protocol) return derived;
+  return _.trimEnd(`${originURL.origin}${derivedURL.pathname}`, '/');
+}
+
 export function isValidServerAddr(input?: string): boolean {
   const addr = normalizeServerAddr(input);
   if (!addr) return false;
@@ -45,6 +80,22 @@ function buildAuthParts(options: BuildCommandOptions): { curlAuth: string; authA
 }
 
 /**
+ * 安装脚本里的 DOWNLOAD_BASE 是服务端按请求头渲染进去的，脚本刻意不让 `--server`
+ * 或 `?host=` 影响它——那个地址下载的包会被 root 解开执行。可它推错时（反代吃掉
+ * 端口）内网下载必失败、只能回退公网，用户没有任何补救手段。
+ *
+ * 所以这里显式吐出 `--download-base`：值就是用户眼前这个地址，而且脚本本身就是从
+ * 它 curl 下来的，即被监控机器已证明能访问到；写进命令行也意味着操作者能看见自己
+ * 授权了哪个下载源，而不是被链接里的参数悄悄改掉。
+ *
+ * 前提：services.ts 拉 /agents/categraf/meta 时不带 `?host=`，这个输入框的默认值
+ * 就没有被链接参数注入的路径。改那个请求前先想清楚这条。
+ */
+function buildDownloadBaseArg(addr: string): string {
+  return ` --download-base ${shellQuote(addr)}`;
+}
+
+/**
  * 拼出一键安装命令。
  * 必须是 `bash -s --` 形式：`| sudo bash --force` 会把参数吃掉而不报错。
  */
@@ -52,7 +103,7 @@ export function buildInstallCommand(options: BuildCommandOptions): string {
   const addr = normalizeServerAddr(options.serverAddr);
   if (!addr) return '';
   const { curlAuth, authArg } = buildAuthParts(options);
-  return `curl -sSfL${curlAuth} ${shellQuote(`${addr}${INSTALL_SCRIPT_PATH}`)} | sudo bash -s -- --server ${shellQuote(addr)}${authArg}`;
+  return `curl -sSfL${curlAuth} ${shellQuote(`${addr}${INSTALL_SCRIPT_PATH}`)} | sudo bash -s -- --server ${shellQuote(addr)}${buildDownloadBaseArg(addr)}${authArg}`;
 }
 
 /** 不放心直接 pipe 到 bash 的用户，可以先下载审阅再执行 */
@@ -60,5 +111,5 @@ export function buildManualCommand(options: BuildCommandOptions): string {
   const addr = normalizeServerAddr(options.serverAddr);
   if (!addr) return '';
   const { curlAuth, authArg } = buildAuthParts(options);
-  return `curl -sSfL${curlAuth} ${shellQuote(`${addr}${INSTALL_SCRIPT_PATH}`)} -o install-categraf.sh\nless install-categraf.sh\nsudo bash install-categraf.sh --server ${shellQuote(addr)}${authArg}`;
+  return `curl -sSfL${curlAuth} ${shellQuote(`${addr}${INSTALL_SCRIPT_PATH}`)} -o install-categraf.sh\nless install-categraf.sh\nsudo bash install-categraf.sh --server ${shellQuote(addr)}${buildDownloadBaseArg(addr)}${authArg}`;
 }

--- a/src/pages/hosts/pages/List/InstallCategraf/index.tsx
+++ b/src/pages/hosts/pages/List/InstallCategraf/index.tsx
@@ -12,7 +12,7 @@ import { localizeDocUrl } from '@/utils/docUrl';
 import { CATEGRAF_TROUBLESHOOT_DOC, NS } from '../../../constants';
 import { CategrafInstallMeta } from '../../../services';
 import CommandBlock from '../components/CommandBlock';
-import { buildInstallCommand, buildManualCommand, isValidServerAddr, normalizeServerAddr } from './buildCommand';
+import { buildInstallCommand, buildManualCommand, isValidServerAddr, pickDefaultServerAddr } from './buildCommand';
 import useTargetArrival from './useTargetArrival';
 
 interface Props {
@@ -30,7 +30,7 @@ export default function InstallCategraf(props: Props) {
 
   // 输入框存原始字符串，只在拼命令与校验时 normalize，
   // 否则用户刚敲一个字符就被补成 http://x 很难继续输入
-  const [addr, setAddr] = useState<string>(() => meta.base_url || normalizeServerAddr(siteInfo?.site_url) || window.location.origin);
+  const [addr, setAddr] = useState<string>(() => pickDefaultServerAddr({ metaBaseURL: meta.base_url, siteURL: siteInfo?.site_url, origin: window.location.origin }));
   const [authUser, setAuthUser] = useState('');
   const [authPass, setAuthPass] = useState('');
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server address detection during host setup and Categraf installation.
  * Correctly handles proxy settings, browser protocols and ports, configured site URLs, subpaths, trailing slashes, and fallback addresses.
  * Preserves administrator-configured server addresses when generating installation commands.

* **New Features**
  * Installation commands now include the appropriate download base in both one-click and manual installation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->