### PR TITLE
feat(side-menu): open a group's first child from the collapsed icon

### DIFF
--- a/src/components/SideMenu/MenuGroup.test.tsx
+++ b/src/components/SideMenu/MenuGroup.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// MenuList's module graph reaches `import.meta` (ESM-only), which ts-jest cannot parse.
+jest.mock('@/components/IconFont', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/utils/constant', () => ({ __esModule: true, IS_PLUS: false, IS_ENT: false, N9E_PATHNAME: 'n9e' }));
+jest.mock('react-i18next', () => ({ __esModule: true, useTranslation: () => ({ t: (key: string) => key }) }));
+// antd/es and lucide-react ship untranspiled ESM, which jest does not transform inside node_modules.
+jest.mock('antd/es/_util/placements', () => ({ __esModule: true, default: () => ({ rightTop: {} }) }));
+jest.mock('lucide-react', () => ({ __esModule: true, House: () => null, Sparkles: () => null }));
+
+import { MenuGroup } from './MenuList';
+import { IMenuItem } from './types';
+
+const baseProps = {
+  sideMenuBgColor: '#fff',
+  isCustomBg: false,
+  quickMenuRef: { current: { open: () => {} } },
+};
+
+const renderGroup = (item: IMenuItem, collapsed: boolean) => {
+  const { container } = render(
+    <MemoryRouter initialEntries={['/elsewhere']}>
+      <MenuGroup item={item} collapsed={collapsed} {...baseProps} />
+    </MemoryRouter>,
+  );
+  // The group row is the first child of MenuGroup's root; the submenu container is its sibling.
+  // Child rows are anchors too, so the row has to be addressed by position rather than by tag.
+  return { container, groupRow: container.firstElementChild?.firstElementChild };
+};
+
+describe('collapsed MenuGroup row', () => {
+  it('links the group icon to its first visible child', () => {
+    const item = {
+      key: 'explorer',
+      label: 'menu.explorer',
+      children: [
+        { key: 'metrics', label: 'menu.metrics', type: 'tabs', children: [{ key: '/metric/explorer', label: 'menu.metric_explorer' }] },
+        { key: '/log/explorer', label: 'menu.logs_explorer' },
+      ],
+    } satisfies IMenuItem;
+
+    const { groupRow } = renderGroup(item, true);
+
+    expect(groupRow?.tagName).toBe('A');
+    expect(groupRow).toHaveAttribute('href', '/metric/explorer');
+  });
+
+  it('skips a child that is filtered out of the visible list', () => {
+    const item = {
+      key: 'explorer',
+      label: 'menu.explorer',
+      children: [
+        // A tabs child with no children of its own is not rendered, so it must not be the target either.
+        { key: 'metrics', label: 'menu.metrics', type: 'tabs', children: [] },
+        { key: '/log/explorer', label: 'menu.logs_explorer' },
+      ],
+    } satisfies IMenuItem;
+
+    const { groupRow } = renderGroup(item, true);
+
+    expect(groupRow?.tagName).toBe('A');
+    expect(groupRow).toHaveAttribute('href', '/log/explorer');
+  });
+
+  it('leaves the row unclickable when the group has no visible child', () => {
+    const item = { key: 'explorer', label: 'menu.explorer', children: [] } satisfies IMenuItem;
+
+    const { groupRow } = renderGroup(item, true);
+
+    expect(groupRow?.tagName).toBe('DIV');
+  });
+
+  it('keeps the expanded group row a non-link toggle', () => {
+    const item = {
+      key: 'explorer',
+      label: 'menu.explorer',
+      children: [{ key: '/log/explorer', label: 'menu.logs_explorer' }],
+    } satisfies IMenuItem;
+
+    const { container, groupRow } = renderGroup(item, false);
+
+    // Expanded, the group row still just toggles; the only anchors are the child rows.
+    expect(groupRow?.tagName).toBe('DIV');
+    const hrefs = Array.from(container.querySelectorAll('a')).map((a) => a.getAttribute('href'));
+    expect(hrefs).toEqual(['/log/explorer']);
+  });
+});

--- a/src/components/SideMenu/MenuList.tsx
+++ b/src/components/SideMenu/MenuList.tsx
@@ -10,7 +10,7 @@ import IconFont from '@/components/IconFont';
 import { IS_ENT } from '@/utils/constant';
 
 import { IMenuItem } from './types';
-import { cn, getSavedPath } from './utils';
+import { cn, getMenuItemPath } from './utils';
 import DeprecatedIcon from './DeprecatedIcon';
 
 const SIDE_MENU_HOVER_TOOLTIP_PLACEMENTS = (() => {
@@ -180,28 +180,60 @@ export function MenuGroup(props: { item: IMenuItem } & IMenuProps) {
 
   const submenuOpen = isExpand && !collapsed && visibleChildren.length > 0;
 
+  // Collapsed rail: clicking the icon jumps straight to the group's first child.
+  // The hover panel stays the way to reach the remaining children.
+  const collapsedTarget = collapsed ? visibleChildren[0] : undefined;
+
+  const rowClassName = cn(
+    'group flex h-8 cursor-pointer items-center justify-between rounded-md px-3 transition-colors duration-75',
+    rowHover,
+    collapsed && isActive ? collapsedActiveBg : '',
+  );
+
+  const rowContent = (
+    <>
+      <div className='flex min-w-0 flex-1 items-center gap-2.5'>
+        <div className={cn('inline-flex h-[16px] w-[16px] shrink-0 items-center justify-center children-icon2:h-[16px] children-icon2:w-[16px]', iconColor)}>{item.icon}</div>
+        {!collapsed && <span className={cn('flex-1 text-left truncate text-[13px] leading-[18px] tracking-normal', titleClass)}>{t(item.label)}</span>}
+      </div>
+      {!collapsed && (
+        <RightIcon className={cn('shrink-0 transition', isExpand ? 'rotate-90' : '', isLight ? 'text-[var(--fc-sidemenu-item-icon)]' : '')} style={{ fontSize: 24 }} />
+      )}
+    </>
+  );
+
+  const renderRow = () => {
+    if (!collapsedTarget) {
+      return (
+        <div
+          onClick={() => {
+            // Collapsed group with no visible child: nothing to open.
+            if (collapsed) return;
+            setIsExpand(!isExpand);
+          }}
+          className={rowClassName}
+        >
+          {rowContent}
+        </div>
+      );
+    }
+    if (collapsedTarget.pathType === 'absolute') {
+      return (
+        <a href={collapsedTarget.path} target={collapsedTarget.target} className={rowClassName} onClick={() => props.onClick?.(collapsedTarget.key)}>
+          {rowContent}
+        </a>
+      );
+    }
+    return (
+      <Link to={getMenuItemPath(collapsedTarget)} className={rowClassName} onClick={() => props.onClick?.(collapsedTarget.key)}>
+        {rowContent}
+      </Link>
+    );
+  };
+
   return (
     <div className='w-full' ref={rootRef}>
-      <div
-        onClick={() => {
-          // Collapsed rail: the hover panel is the only way into a group's children.
-          if (collapsed) return;
-          setIsExpand(!isExpand);
-        }}
-        className={cn(
-          'group flex h-8 cursor-pointer items-center justify-between rounded-md px-3 transition-colors duration-75',
-          rowHover,
-          collapsed && isActive ? collapsedActiveBg : '',
-        )}
-      >
-        <div className='flex min-w-0 flex-1 items-center gap-2.5'>
-          <div className={cn('inline-flex h-[16px] w-[16px] shrink-0 items-center justify-center children-icon2:h-[16px] children-icon2:w-[16px]', iconColor)}>{item.icon}</div>
-          {!collapsed && <span className={cn('flex-1 text-left truncate text-[13px] leading-[18px] tracking-normal', titleClass)}>{t(item.label)}</span>}
-        </div>
-        {!collapsed && (
-          <RightIcon className={cn('shrink-0 transition', isExpand ? 'rotate-90' : '', isLight ? 'text-[var(--fc-sidemenu-item-icon)]' : '')} style={{ fontSize: 24 }} />
-        )}
-      </div>
+      {renderRow()}
       <div
         className={cn(submenuOpen ? 'mt-0.5' : 'mt-0', 'overflow-hidden transition-height')}
         style={{
@@ -261,8 +293,7 @@ export function MenuItem(props: { item: IMenuItem; isSub?: boolean; isBgBlack?: 
   const isBlueTheme = localStorage.getItem('n9e-dark-mode') === '3';
   const { item, isSub = false, isCustomBg, collapsed, selectedKeys, isBgBlack, onClick, isGoldTheme, isLight } = props;
   const isActive = item.type === 'tabs' ? selectedKeys?.some((k) => item.children?.some((c) => c.key === k)) : selectedKeys?.includes(item.key);
-  const path = item.type === 'tabs' ? item.children?.[0]?.key || item.key : item.key;
-  const savedPath = item.children ? getSavedPath(path) : item.key;
+  const to = getMenuItemPath(item);
 
   const isSubTreeLayout = Boolean(isSub && !collapsed);
 
@@ -319,7 +350,7 @@ export function MenuItem(props: { item: IMenuItem; isSub?: boolean; isBgBlack?: 
 
   const row = (
     <Link
-      to={savedPath || path}
+      to={to}
       className={cn(
         'group relative flex min-w-0 cursor-pointer items-center transition-colors duration-75',
         isSubTreeLayout ? 'h-7 rounded-md' : 'h-8 rounded-md',
@@ -645,6 +676,11 @@ export default function MenuList(
                         if (!hoverEnabled) return;
                         scheduleCloseHoverPanel();
                       }}
+                      onClick={() => {
+                        // Navigating from the collapsed icon must not leave the panel covering the new page.
+                        if (!hoverEnabled) return;
+                        closeHoverPanel();
+                      }}
                     >
                       <MenuGroup key={menu.key} item={menu} {...otherProps} isLight={isLight} />
                     </div>
@@ -688,8 +724,7 @@ export default function MenuList(
                           <div className='sidemenu-hover-panel-list'>
                             {hoverChildren.map((c) => {
                               const isItemActive = c.type === 'tabs' ? props.selectedKeys?.some((key) => c.children?.some((child) => child.key === key)) : props.selectedKeys?.includes(c.key);
-                              const itemPath = c.type === 'tabs' ? c.children?.[0]?.key || c.key : c.key;
-                              const savedItemPath = c.children ? getSavedPath(itemPath) : c.key;
+                              const itemTo = getMenuItemPath(c);
                               const itemClass = cn(
                                 'group relative flex h-7 min-w-0 cursor-pointer items-center gap-2 rounded-md px-2 text-[13px] leading-[18px] transition-colors duration-150',
                                 isItemActive
@@ -738,7 +773,7 @@ export default function MenuList(
                                 );
                               }
                               return (
-                                <Link key={c.key} to={savedItemPath || itemPath} className={itemClass} onClick={handleClick}>
+                                <Link key={c.key} to={itemTo} className={itemClass} onClick={handleClick}>
                                   {itemContent}
                                 </Link>
                               );

--- a/src/components/SideMenu/menu.test.ts
+++ b/src/components/SideMenu/menu.test.ts
@@ -58,15 +58,24 @@ describe('SideMenu hover panel styles', () => {
     expect(indexContent).toMatch(/const toggleCollapsed = \(\) => \{[\s\S]*?localStorage\.setItem\('menuCollapsed'/);
   });
 
-  it('labels collapsed top-level rows with a tooltip instead of expanding them', () => {
+  it('labels collapsed leaf rows with a tooltip', () => {
     const menuListPath = path.join(__dirname, 'MenuList.tsx');
     const menuListContent = fs.readFileSync(menuListPath, 'utf8');
 
     // Leaf rows (e.g. FlashAI) render icon-only when collapsed, so the label has to come from a tooltip.
     expect(menuListContent).toContain('function wrapCollapsedRowWithTooltip');
     expect(menuListContent.match(/return wrapCollapsedRowWithTooltip\(row, \{ collapsed, isSub, title: t\(item\.label\) \}\);/g)).toHaveLength(2);
-    // A collapsed group row must not act on click; its children are reachable through the hover panel.
-    expect(menuListContent).toMatch(/onClick=\{\(\) => \{[\s\S]{0,160}?if \(collapsed\) return;\s*setIsExpand\(!isExpand\);/);
+  });
+
+  it('opens the first child when a collapsed group icon is clicked', () => {
+    const menuListPath = path.join(__dirname, 'MenuList.tsx');
+    const menuListContent = fs.readFileSync(menuListPath, 'utf8');
+
+    // Clicking the icon is the one-step way into a group; hovering stays the way to reach the other children.
+    expect(menuListContent).toContain('const collapsedTarget = collapsed ? visibleChildren[0] : undefined;');
+    expect(menuListContent).toContain('<Link to={getMenuItemPath(collapsedTarget)}');
+    // The hover panel must not stay open on top of the page we just navigated to.
+    expect(menuListContent).toMatch(/onClick=\{\(\) => \{[\s\S]{0,160}?if \(!hoverEnabled\) return;\s*closeHoverPanel\(\);/);
   });
 
   it('clears profile submenus without changing their popup container', () => {

--- a/src/components/SideMenu/utils.test.ts
+++ b/src/components/SideMenu/utils.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+// utils.ts pulls in the real menu config, whose module graph uses `import.meta` (ESM-only).
+// ts-jest cannot parse that, so stub the two leaves that reach for it.
+jest.mock('@/components/IconFont', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/utils/constant', () => ({ __esModule: true, IS_PLUS: false, IS_ENT: false, N9E_PATHNAME: 'n9e' }));
+
+import { getMenuItemPath, getStorageKey } from './utils';
+
+describe('getMenuItemPath', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns the key itself for a leaf menu item', () => {
+    expect(getMenuItemPath({ key: '/log/explorer', label: 'menu.logs_explorer' })).toBe('/log/explorer');
+  });
+
+  it('falls back to the first tab for a tabs menu item that was never visited', () => {
+    expect(
+      getMenuItemPath({
+        key: 'metrics',
+        label: 'menu.metrics',
+        type: 'tabs',
+        children: [
+          { key: '/metric/explorer', label: 'menu.metric_explorer' },
+          { key: '/recording-rules', label: 'menu.recording_rules' },
+        ],
+      }),
+    ).toBe('/metric/explorer');
+  });
+
+  it('prefers the remembered tab for a tabs menu item visited before', () => {
+    localStorage.setItem(getStorageKey('metrics'), '/recording-rules');
+    expect(
+      getMenuItemPath({
+        key: 'metrics',
+        label: 'menu.metrics',
+        type: 'tabs',
+        children: [
+          { key: '/metric/explorer', label: 'menu.metric_explorer' },
+          { key: '/recording-rules', label: 'menu.recording_rules' },
+        ],
+      }),
+    ).toBe('/recording-rules');
+  });
+
+  it('falls back to the item key when a tabs menu item has no children', () => {
+    expect(getMenuItemPath({ key: 'devices', label: 'menu.devices', type: 'tabs', children: [] })).toBe('devices');
+  });
+});

--- a/src/components/SideMenu/utils.ts
+++ b/src/components/SideMenu/utils.ts
@@ -8,7 +8,7 @@ import { IS_PLUS } from '@/utils/constant';
 // @ts-ignore
 import getPlusMenuList from 'plus:/parcels/SideMenu/menu';
 
-import { MenuMatchResult } from './types';
+import { IMenuItem, MenuMatchResult } from './types';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -71,4 +71,18 @@ export const getSavedPath = (pathname: string) => {
     const storageKey = getStorageKey(currentMenu.parentItem.key);
     return localStorage.getItem(storageKey);
   }
+};
+
+/*
+ * Resolve the route a menu item navigates to when clicked.
+ * A menu with page-level tabs lands on its first tab, or on the tab remembered in
+ * localStorage from an earlier visit.
+ * @param item the menu item
+ * @returns the path to navigate to. Absolute-path menus (pathType === 'absolute') do not
+ * go through here; they link to item.path directly.
+ */
+export const getMenuItemPath = (item: IMenuItem): string => {
+  const path = item.type === 'tabs' ? item.children?.[0]?.key || item.key : item.key;
+  const savedPath = item.children ? getSavedPath(path) : item.key;
+  return savedPath || path;
 };


### PR DESCRIPTION
## What

When the side menu is collapsed, clicking a top-level group icon did nothing: the row's click handler returned early on `collapsed`, so the only way into a page was to hover the icon and then click an item in the flyout. The row still carried `cursor-pointer`, so it looked clickable and wasn't.

The collapsed row now links straight to the group's first visible child. Hovering remains the way to reach the other children, and the flyout closes on navigation so it does not sit on top of the page you just opened.

Expanded behaviour is unchanged — the group row still toggles.

## How

- `MenuGroup` renders the collapsed row as a `Link` (or an `a` when the first child is an absolute-path menu) instead of a plain `div`. Rendering a real link also gives middle-click-to-new-tab and a URL preview on hover.
- The target is the first entry of `visibleChildren`, i.e. the same filtered list the flyout renders, so a child hidden by permissions or by an empty tab group is never the destination. A group with no visible child keeps the old no-op row.
- Path resolution for tab menus (first tab, or the tab remembered in `localStorage`) was hand-copied in two places and this change needed it in a third, so it moves into `getMenuItemPath()` in `utils.ts` and all three call sites use it.

## Tests

`npx jest src/components/SideMenu` — 42 passing, 8 new:

- `utils.test.ts` covers `getMenuItemPath` directly: leaf item, tabs item never visited, tabs item with a remembered tab, tabs item with no children.
- `MenuGroup.test.tsx` renders `MenuGroup` and asserts the collapsed row is an anchor pointing at the first visible child, that a filtered-out child is skipped, that a group with no visible child stays a non-link, and that the expanded row is still a plain toggle.

Reverting `MenuList.tsx` alone makes the two behavioural cases fail, so they are pinned to this change rather than passing incidentally.

One existing assertion in `menu.test.ts` documented the old contract ("a collapsed group row must not act on click") and still passed after the change, which made it a false witness. It is replaced by an assertion of the new behaviour.
