### PR TITLE
perf(ai-chat): batch streaming renders, defer markdown and memoize blocks

### DIFF
--- a/src/components/AiChatNG/ChatPanel.tsx
+++ b/src/components/AiChatNG/ChatPanel.tsx
@@ -14,6 +14,7 @@ import { useAiChatStream } from './useStream';
 import { useAiChatContext } from './context';
 
 const POLLING_INTERVAL = 3000;
+const STREAM_RENDER_INTERVAL = 50;
 
 export default function ChatPanel(props: IAiChatProps) {
   const { t } = useTranslation(NAME_SPACE);
@@ -41,6 +42,7 @@ export default function ChatPanel(props: IAiChatProps) {
   const chatBodyRef = useRef<HTMLDivElement>(null);
   const chatContentRef = useRef<HTMLDivElement>(null);
   const pollingTimerRef = useRef<number>();
+  const streamRenderTimerRef = useRef<number>();
   const startStreamRef = useRef<(streamId: string) => Promise<void> | void>();
   const streamBufferRef = useRef<{ locator?: IAiChatMessageLocator; segments: IAiChatStreamSegment[] }>({ locator: undefined, segments: [] });
   const activeChatRef = useRef<IAiChatHistoryItem>();
@@ -81,6 +83,39 @@ export default function ChatPanel(props: IAiChatProps) {
   const mergeMessage = useCallback((message: IAiChatMessage) => {
     setMessages((previous) => upsertMessage(previous, message));
   }, []);
+
+  // 流式 chunk 先写入 ref 缓冲，再按固定节奏批量刷新到 React state，避免每个 chunk 都触发整棵消息树渲染。
+  const flushStreamingMessage = useCallback(() => {
+    const { locator, segments } = streamBufferRef.current;
+    if (!locator) return;
+
+    setMessages((previous) => {
+      const target = previous.find((item) => item.chat_id === locator.chat_id && item.seq_id === locator.seq_id);
+      if (!target) return previous;
+      return upsertMessage(previous, buildStreamingMessage(target, segments));
+    });
+  }, []);
+
+  const cancelScheduledStreamRender = useCallback(() => {
+    if (streamRenderTimerRef.current) {
+      window.clearTimeout(streamRenderTimerRef.current);
+      streamRenderTimerRef.current = undefined;
+    }
+  }, []);
+
+  const scheduleStreamRender = useCallback(() => {
+    if (streamRenderTimerRef.current) return;
+
+    streamRenderTimerRef.current = window.setTimeout(() => {
+      streamRenderTimerRef.current = undefined;
+      flushStreamingMessage();
+    }, STREAM_RENDER_INTERVAL);
+  }, [flushStreamingMessage]);
+
+  const flushStreamingMessageImmediately = useCallback(() => {
+    cancelScheduledStreamRender();
+    flushStreamingMessage();
+  }, [cancelScheduledStreamRender, flushStreamingMessage]);
 
   const syncMessageDetail = useCallback(
     async (locator: IAiChatMessageLocator, options?: { startStream?: boolean }) => {
@@ -129,22 +164,22 @@ export default function ChatPanel(props: IAiChatProps) {
       if (!locator) return;
 
       if (chunk.type === 'thinking' || chunk.type === 'text' || chunk.type === 'step') {
-        streamBufferRef.current.segments = applyStreamChunk(streamBufferRef.current.segments, chunk);
+        const previousSegments = streamBufferRef.current.segments;
+        const nextSegments = applyStreamChunk(previousSegments, chunk);
+        if (nextSegments !== previousSegments) {
+          streamBufferRef.current.segments = nextSegments;
+          scheduleStreamRender();
+        }
       }
 
       if (chunk.type === 'error' && chunk.error) {
         handleError(new Error(chunk.error));
       }
-
-      setMessages((previous) => {
-        const target = previous.find((item) => item.chat_id === locator.chat_id && item.seq_id === locator.seq_id);
-        if (!target) return previous;
-        return upsertMessage(previous, buildStreamingMessage(target, streamBufferRef.current.segments));
-      });
     },
     onFinish: () => {
       const locator = streamBufferRef.current.locator;
       if (!locator) return;
+      flushStreamingMessageImmediately();
       syncMessageDetail(locator).catch((error) => handleError(error instanceof Error ? error : new Error('sync message failed')));
     },
     onError: handleError,
@@ -233,10 +268,12 @@ export default function ChatPanel(props: IAiChatProps) {
   }, [cleanupPolling, stopStream]);
 
   useEffect(() => {
+    cancelScheduledStreamRender();
     cleanupPolling();
     stopStream();
     setSubmitting(false);
     setStreamingLocator(undefined);
+    // 切会话时未 flush 的流式缓冲有意丢弃：切回时由 loadMessages 从服务端重拉兜底。
     streamBufferRef.current = {
       locator: undefined,
       segments: [],
@@ -263,14 +300,15 @@ export default function ChatPanel(props: IAiChatProps) {
     activeChatRef.current = nextChat;
     setActiveChat(nextChat);
     loadMessages(chatId);
-  }, [chatId, cleanupPolling, loadMessages, queryPageFrom, stopStream]);
+  }, [cancelScheduledStreamRender, chatId, cleanupPolling, loadMessages, queryPageFrom, stopStream]);
 
   useEffect(() => {
     return () => {
+      cancelScheduledStreamRender();
       cleanupPolling();
       stopStream();
     };
-  }, [cleanupPolling, stopStream]);
+  }, [cancelScheduledStreamRender, cleanupPolling, stopStream]);
 
   const initialMessageSentRef = useRef(false);
 
@@ -377,6 +415,7 @@ export default function ChatPanel(props: IAiChatProps) {
   const handleStop = useCallback(async () => {
     if (!streamingLocator) return;
     try {
+      cancelScheduledStreamRender();
       stopStream();
       cleanupPolling();
       await cancelMessage(streamingLocator);
@@ -391,7 +430,7 @@ export default function ChatPanel(props: IAiChatProps) {
     } catch (error) {
       handleError(error instanceof Error ? error : new Error('cancel message failed'));
     }
-  }, [cleanupPolling, handleError, mergeMessage, stopStream, streamingLocator]);
+  }, [cancelScheduledStreamRender, cleanupPolling, handleError, mergeMessage, stopStream, streamingLocator]);
 
   const messageItems = useMemo(() => {
     return messages.map((messageItem) => (
@@ -401,7 +440,7 @@ export default function ChatPanel(props: IAiChatProps) {
         isStreaming={streamingLocator?.chat_id === messageItem.chat_id && streamingLocator?.seq_id === messageItem.seq_id}
         onExecuteQueryForQueryContent={onExecuteQueryForQueryContent}
         onActionClick={sendUserMessage}
-        onOKForFormSelectContent={(action, overrideContent) => sendUserMessage(action, overrideContent)}
+        onOKForFormSelectContent={sendUserMessage}
         maybeScrollToBottom={maybeScrollToBottom}
       />
     ));

--- a/src/components/AiChatNG/MessageBlocks.tsx
+++ b/src/components/AiChatNG/MessageBlocks.tsx
@@ -65,7 +65,14 @@ interface IAiChatResponseBlocksProps {
   maybeScrollToBottom?: (behavior?: ScrollBehavior) => void;
 }
 
-function ThinkingBlockComponent({ title, content, isFinish }: { title: string; content: string; isFinish?: boolean }) {
+interface IThinkingBlockProps {
+  title: string;
+  content: string;
+  isFinish?: boolean;
+  isStreaming?: boolean;
+}
+
+function ThinkingBlockComponent({ title, content, isFinish, isStreaming }: IThinkingBlockProps) {
   const { t } = useTranslation(NAME_SPACE);
   const userInteractedRef = React.useRef(false);
   const [activeKey, setActiveKey] = React.useState<string | undefined>('thinking');
@@ -94,7 +101,7 @@ function ThinkingBlockComponent({ title, content, isFinish }: { title: string; c
     >
       <Collapse.Panel header={<span className='text-sm font-medium text-main'>{displayTitle}</span>} key='thinking'>
         <div className='max-h-60 overflow-y-auto'>
-          {isFinish ? <Markdown content={content || ''} showCodeCopy /> : <div className='whitespace-pre-wrap break-words text-sm'>{content}</div>}
+          {!isStreaming && isFinish ? <Markdown content={content || ''} showCodeCopy /> : <div className='whitespace-pre-wrap break-words text-sm'>{content}</div>}
         </div>
       </Collapse.Panel>
     </Collapse>
@@ -114,7 +121,12 @@ export function HintBlock({ response }: { response: IAiChatMessageResponse }) {
   );
 }
 
-function MarkdownBlockComponent({ response, isStreaming }: { response: IAiChatMessageResponse; isStreaming?: boolean }) {
+interface IMarkdownBlockProps {
+  response: IAiChatMessageResponse;
+  isStreaming?: boolean;
+}
+
+function MarkdownBlockComponent({ response, isStreaming }: IMarkdownBlockProps) {
   return (
     <div className='rounded-lg border border-transparent bg-transparent text-main'>
       {isStreaming ? <div className='whitespace-pre-wrap break-words'>{response.content}</div> : <Markdown content={response.content || ''} showCodeCopy />}
@@ -214,9 +226,17 @@ export function ResponseBlocks(props: IAiChatResponseBlocksProps) {
         switch (contentType) {
           case EAiChatContentType.Thinking:
           case EAiChatContentType.Reasoning:
-            return <ThinkingBlock key={`${response.content_type}-${index}`} title={t('message.thinking')} content={response.content} isFinish={response.is_finish} />;
+            return (
+              <ThinkingBlock
+                key={`${response.content_type}-${index}`}
+                title={t('message.thinking')}
+                content={response.content}
+                isFinish={response.is_finish}
+                isStreaming={isStreaming}
+              />
+            );
           case EAiChatContentType.Markdown:
-            return <MarkdownBlock key={`${response.content_type}-${index}`} response={response} isStreaming={isStreaming && !response.is_finish} />;
+            return <MarkdownBlock key={`${response.content_type}-${index}`} response={response} isStreaming={isStreaming} />;
           case EAiChatContentType.Hint:
             return <HintBlock key={`${response.content_type}-${index}`} response={response} />;
           case EAiChatContentType.Query:

--- a/src/components/AiChatNG/MessageBlocks.tsx
+++ b/src/components/AiChatNG/MessageBlocks.tsx
@@ -65,7 +65,7 @@ interface IAiChatResponseBlocksProps {
   maybeScrollToBottom?: (behavior?: ScrollBehavior) => void;
 }
 
-export function ThinkingBlock({ title, content, isFinish }: { title: string; content: string; isFinish?: boolean }) {
+function ThinkingBlockComponent({ title, content, isFinish }: { title: string; content: string; isFinish?: boolean }) {
   const { t } = useTranslation(NAME_SPACE);
   const userInteractedRef = React.useRef(false);
   const [activeKey, setActiveKey] = React.useState<string | undefined>('thinking');
@@ -94,12 +94,14 @@ export function ThinkingBlock({ title, content, isFinish }: { title: string; con
     >
       <Collapse.Panel header={<span className='text-sm font-medium text-main'>{displayTitle}</span>} key='thinking'>
         <div className='max-h-60 overflow-y-auto'>
-          <Markdown content={content || ''} showCodeCopy />
+          {isFinish ? <Markdown content={content || ''} showCodeCopy /> : <div className='whitespace-pre-wrap break-words text-sm'>{content}</div>}
         </div>
       </Collapse.Panel>
     </Collapse>
   );
 }
+
+export const ThinkingBlock = React.memo(ThinkingBlockComponent);
 
 export function HintBlock({ response }: { response: IAiChatMessageResponse }) {
   const { t } = useTranslation(NAME_SPACE);
@@ -112,13 +114,22 @@ export function HintBlock({ response }: { response: IAiChatMessageResponse }) {
   );
 }
 
-export function MarkdownBlock({ response }: { response: IAiChatMessageResponse }) {
+function MarkdownBlockComponent({ response, isStreaming }: { response: IAiChatMessageResponse; isStreaming?: boolean }) {
   return (
     <div className='rounded-lg border border-transparent bg-transparent text-main'>
-      <Markdown content={response.content || ''} showCodeCopy />
+      {isStreaming ? <div className='whitespace-pre-wrap break-words'>{response.content}</div> : <Markdown content={response.content || ''} showCodeCopy />}
     </div>
   );
 }
+
+export const MarkdownBlock = React.memo(
+  MarkdownBlockComponent,
+  (previous, next) =>
+    previous.isStreaming === next.isStreaming &&
+    previous.response.content === next.response.content &&
+    previous.response.is_finish === next.response.is_finish &&
+    previous.response.content_type === next.response.content_type,
+);
 
 export function CurStepBlock({ curStep }: { curStep: string }) {
   return (
@@ -205,7 +216,7 @@ export function ResponseBlocks(props: IAiChatResponseBlocksProps) {
           case EAiChatContentType.Reasoning:
             return <ThinkingBlock key={`${response.content_type}-${index}`} title={t('message.thinking')} content={response.content} isFinish={response.is_finish} />;
           case EAiChatContentType.Markdown:
-            return <MarkdownBlock key={`${response.content_type}-${index}`} response={response} />;
+            return <MarkdownBlock key={`${response.content_type}-${index}`} response={response} isStreaming={isStreaming && !response.is_finish} />;
           case EAiChatContentType.Hint:
             return <HintBlock key={`${response.content_type}-${index}`} response={response} />;
           case EAiChatContentType.Query:
@@ -317,7 +328,7 @@ function shouldShowRunningStatusAtMessageBottom(isFinish?: boolean, responseList
   return bottomStatusContentTypes.includes(lastResponse.content_type as EAiChatContentType);
 }
 
-export function MessageItem({ message, isStreaming, onExecuteQueryForQueryContent, onActionClick, onOKForFormSelectContent, maybeScrollToBottom }: IAiChatResponseBlocksProps) {
+function MessageItemComponent({ message, isStreaming, onExecuteQueryForQueryContent, onActionClick, onOKForFormSelectContent, maybeScrollToBottom }: IAiChatResponseBlocksProps) {
   const { t } = useTranslation(NAME_SPACE);
   const showInitialRunningStatus = shouldShowInitialRunningStatus(message.is_finish, message.response);
   const showBottomRunningStatus = shouldShowRunningStatusAtMessageBottom(message.is_finish, message.response);
@@ -353,3 +364,5 @@ export function MessageItem({ message, isStreaming, onExecuteQueryForQueryConten
     </div>
   );
 }
+
+export const MessageItem = React.memo(MessageItemComponent);

--- a/src/components/AiChatNG/utils.ts
+++ b/src/components/AiChatNG/utils.ts
@@ -158,7 +158,7 @@ export function applyStreamChunk(segments: IAiChatStreamSegment[], chunk: IAiCha
     case 'thinking':
     case 'text': {
       const kind = chunk.type === 'thinking' ? 'thinking' : 'text';
-      if (!delta) return next;
+      if (!delta) return segments;
       if (last && !last.done && last.kind === kind) {
         // 同类未收口段 → 追加
         next[next.length - 1] = { ...last, content: last.content + delta };


### PR DESCRIPTION
## 背景

Agent 流式答复期间页面明显卡顿：每个 SSE chunk 都触发一次完整消息树渲染，ReactMarkdown 反复解析增长中的全文、代码块反复高亮，长回答/含代码块时主线程出现秒级长任务。

## 改动

1. **50ms 批量刷新**：`onChunk` 先写入 ref 缓冲，按 50ms 节奏批量 flush 到 React state，避免每个 chunk 都触发整棵消息树渲染（`ChatPanel.tsx`）。
2. **流式纯文本**：thinking 与正文在流式阶段用 `whitespace-pre-wrap` 纯文本，完成后才走 Markdown 解析与代码高亮（`MessageBlocks.tsx`）。
3. **组件 memo**：`ThinkingBlock`/`MarkdownBlock`/`MessageItem` 加 `React.memo`，隔离历史消息的无意义重渲染。
4. 空 delta chunk 不再触发无效刷新（`utils.ts`）。

## 效果（Chrome Performance Trace 对比）

| 指标 | 优化前 | 优化后 |
|---|---|---|
| 主线程 ≥50ms 长任务数 | 121 | 2 |
| 最大长任务 | 12.39s | 0.36s |
| Microtask 总耗时 | 86.5s | 0.37s |

## 验证

- `npx tsc --noEmit` 通过（零错误）
- Prettier 通过
- `npm run dev` 正常启动

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Improved AI chat streaming responsiveness by batching incoming content updates.
  - Reduced unnecessary rendering while messages stream.
  - Improved handling when switching chats, canceling responses, or closing the chat.

- **Display Improvements**
  - Thinking content now appears as plain text while streaming and formatted content once complete.
  - Preserved chat content more efficiently when empty streaming updates are received.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->