### PR TITLE
fix(mcp): pin OAuth consent decision to the /api/n9e prefix

### DIFF
--- a/src/pages/oauthConsent/index.tsx
+++ b/src/pages/oauthConsent/index.tsx
@@ -34,7 +34,6 @@ import { ApiOutlined } from '@ant-design/icons';
 import request from '@/utils/request';
 import { RequestMethod } from '@/store/common';
 import { CommonStateContext } from '@/App';
-import { N9E_PATHNAME } from '@/utils/constant';
 
 import { NAME_SPACE } from './constants';
 
@@ -103,7 +102,9 @@ export default function OAuthConsent() {
   const decide = (decision: 'allow' | 'deny') => {
     setSubmitting(decision);
     setError(null);
-    request(`/api/${N9E_PATHNAME}/mcp/oauth/authorize`, {
+    // The prefix is deliberately fixed: the built-in Authorization Server is mounted
+    // only under /api/n9e (its advertised issuer), so this never follows N9E_PATHNAME.
+    request('/api/n9e/mcp/oauth/authorize', {
       method: RequestMethod.Post,
       data: { req, decision },
     })


### PR DESCRIPTION
## Problem

The OAuth consent screen submitted its allow/deny decision to `` `/api/${N9E_PATHNAME}/mcp/oauth/authorize` ``, i.e. it followed the build-time API prefix switch. The built-in MCP OAuth Authorization Server is not mounted behind that switch.

In the nightingale backend the consent-decision route lives under a hardcoded prefix:

- `center/router/router.go`: `pagesPrefix := "/api/n9e"`
- `center/router/router.go`: `pages.POST("/mcp/oauth/authorize", rt.auth(), rt.user(), rt.MCPOAuthDecision)`
- `center/router/router_a2a.go`: `const a2aMountPrefix = "/api/n9e"`

`/api/n9e` is also the Authorization Server's advertised issuer, so the path is part of the OAuth metadata contract rather than a per-build detail. Any build whose prefix is not `n9e` therefore POSTed to a route that does not exist, and clicking **Allow** failed with a 404 instead of completing the authorization code flow.

## Fix

Pin the request to the literal `/api/n9e/mcp/oauth/authorize`, drop the now-unused `N9E_PATHNAME` import, and leave a short comment so the fixed prefix is not "corrected" back to the switch later.

## Impact

- Consent decisions work in every build, not only those served under the `n9e` prefix.
- No behavior change for builds that already used the `n9e` prefix — the resolved URL is identical.
- Scope is one file; MCP server management APIs, which are genuinely prefix-dependent, are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth consent authorization requests to consistently use the correct built-in authorization server endpoint.
  * Improved reliability when the application is configured with a different path setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->