### PR TITLE
fix(mcp): pin OAuth consent decision to the /api/n9e prefix

### DIFF
--- a/src/pages/oauthConsent/index.tsx
+++ b/src/pages/oauthConsent/index.tsx
@@ -34,7 +34,6 @@ import { ApiOutlined } from '@ant-design/icons';
 import request from '@/utils/request';
 import { RequestMethod } from '@/store/common';
 import { CommonStateContext } from '@/App';
-import { N9E_PATHNAME } from '@/utils/constant';
 
 import { NAME_SPACE } from './constants';
 
@@ -103,7 +102,7 @@ export default function OAuthConsent() {
   const decide = (decision: 'allow' | 'deny') => {
     setSubmitting(decision);
     setError(null);
-    request(`/api/${N9E_PATHNAME}/mcp/oauth/authorize`, {
+    request('/api/n9e/mcp/oauth/authorize', {
       method: RequestMethod.Post,
       data: { req, decision },
     })


### PR DESCRIPTION
## Problem

The MCP OAuth consent screen POSTs its decision to `/api/${N9E_PATHNAME}/mcp/oauth/authorize`, so the path becomes `/api/n9e-plus/...` in builds where `N9E_PATHNAME` resolves to `n9e-plus`.

That route does not exist. The built-in MCP/A2A OAuth 2.1 Authorization Server is mounted only under the fixed `/api/n9e` prefix:

- `center/router/router.go` — `pagesPrefix := "/api/n9e"`, and the decision endpoint is registered on that group as `pages.POST("/mcp/oauth/authorize", ...)`
- `center/router/router_a2a.go` — `const a2aMountPrefix = "/api/n9e"`

`/api/n9e` is also the issuer the Authorization Server advertises in its `/.well-known/oauth-authorization-server` metadata and binds into issued tokens, so it is part of the OAuth contract rather than an internal console path. Clicking Allow therefore fails whenever the prefix switch is active.

## Fix

Pin the consent decision path to `/api/n9e` and drop the now-unused `N9E_PATHNAME` import. This restores the file to its state before the prefix switch was applied to this call site.

The sibling `/api/${N9E_PATHNAME}/mcp-servers` call is unrelated and intentionally left as is — MCP server management is a separate, console-side API.

## Scope

One file, +1/-2. No behavior change for builds where `N9E_PATHNAME` is already `n9e`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth authorization request handling by using a consistent authorization endpoint.
  * Removed an unused configuration reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->