### PR TITLE
fix(mcp): pin OAuth consent decision to the /api/n9e prefix

### DIFF
--- a/src/pages/oauthConsent/index.tsx
+++ b/src/pages/oauthConsent/index.tsx
@@ -34,7 +34,6 @@ import { ApiOutlined } from '@ant-design/icons';
 import request from '@/utils/request';
 import { RequestMethod } from '@/store/common';
 import { CommonStateContext } from '@/App';
-import { N9E_PATHNAME } from '@/utils/constant';
 
 import { NAME_SPACE } from './constants';
 
@@ -103,7 +102,7 @@ export default function OAuthConsent() {
   const decide = (decision: 'allow' | 'deny') => {
     setSubmitting(decision);
     setError(null);
-    request(`/api/${N9E_PATHNAME}/mcp/oauth/authorize`, {
+    request('/api/n9e/mcp/oauth/authorize', {
       method: RequestMethod.Post,
       data: { req, decision },
     })


### PR DESCRIPTION
Backport of #2281 to `release-26`.

## Problem

The MCP OAuth consent screen POSTs its decision to `/api/${N9E_PATHNAME}/mcp/oauth/authorize`, so the path becomes `/api/n9e-plus/...` in builds where `N9E_PATHNAME` resolves to `n9e-plus`.

That route does not exist. The built-in MCP/A2A OAuth 2.1 Authorization Server is mounted only under the fixed `/api/n9e` prefix (`pagesPrefix` in `center/router/router.go`, `a2aMountPrefix` in `center/router/router_a2a.go`), which is also the issuer it advertises in its `/.well-known/oauth-authorization-server` metadata and binds into issued tokens. Clicking Allow therefore fails whenever the prefix switch is active.

## Fix

Pin the consent decision path to `/api/n9e` and drop the now-unused `N9E_PATHNAME` import.

## Scope

One file, +1/-2. Cherry-picked cleanly with no conflict; the file was byte-identical on `main` and `release-26`.