### PR TITLE
fix(page-layout): keep header tab labels on one line in narrow headers

### DIFF
--- a/src/components/pageLayout/PageLayoutWithTabs/TabMenu.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/TabMenu.tsx
@@ -44,7 +44,7 @@ export const TabMenu: React.FC<TabMenuProps> = ({ currentMenu, onTabChange }) =>
       {_.map(permissionedMenus, (item) => (
         <div
           key={item.key}
-          className={`relative px-5 h-full header-tab-menu flex items-center cursor-pointer text-sm transition-colors duration-300 ${
+          className={`relative px-5 h-full header-tab-menu flex items-center whitespace-nowrap cursor-pointer text-sm transition-colors duration-300 ${
             activeTab === item.key ? `text-primary custom-tab-active ${darkMode ? 'bg-gray-700/20' : 'bg-gray-200/20'}` : ''
           }`}
           onClick={() => {

--- a/src/components/pageLayout/PageLayoutWithTabs/index.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/index.tsx
@@ -119,7 +119,9 @@ const PageLayout: React.FC<IPageLayoutProps> = ({
                   display: query.viewMode === 'fullscreen' ? 'none' : 'flex',
                 }}
               >
-                <div className='flex items-center min-w-0 flex-1'>
+                {/* No min-w-0 here: let this area's minimum width come from its content (the tab nav), so a narrow
+                    header shrinks the headerCenter prose instead of squeezing the tabs into per-character wrapping. */}
+                <div className='flex items-center flex-1'>
                   {!currentMenu?.parentItem?.label && (
                     <div className='page-header-title min-w-0'>
                       {showBack && window.history.state && (


### PR DESCRIPTION
## Problem

In the page header, the sub-navigation tab labels (e.g. the rule-management tabs) can collapse into a one-character-per-line vertical column, with the extra line boxes clipped by the fixed 50px tab strip.

It only shows up once the header row runs out of width — a narrower viewport, OS display scaling above 100%, a wider default CJK UI font, a space-consuming `headerCenter` slot, or a fuller right-hand action area will each push it closer to the threshold, and they add up.

## Root cause

Two things combine:

1. **The tab strip had no protected width.** Its wrapper was `flex-1 min-w-0`, i.e. it declares zero intrinsic width, while the right-hand action area is `flex-shrink-0` and `headerCenter` keeps an auto flex basis. So when the header got tight, the tab strip was the only region the layout could squeeze.
2. **The labels had no `whitespace-nowrap`.** CJK text may break between any two characters, so a squeezed tab wraps per character. The items are `h-full` inside a fixed 50px strip, so the resulting 4-line text overflowed and was visually clipped.

## Fix

- `TabMenu.tsx` — add `whitespace-nowrap` to the tab label, so a label never breaks mid-word.
- `PageLayoutWithTabs/index.tsx` — drop `min-w-0` from the left header area, so its minimum width is driven by its content (the tab nav).

Together these make a narrow header shrink the `headerCenter` prose — which is multi-line explanatory text and is meant to wrap — instead of the navigation.

`whitespace-nowrap` alone is not enough: the tabs would stop stacking vertically but would overflow horizontally over the neighbouring content. Both changes are needed.

## Verification

- Reproduced locally by constraining the header width, then confirmed the same constraint renders correctly after the change.
- With a `headerCenter` element present and the header constrained to 1150px: all four tabs keep their full width, and the prose wraps to two lines (36px, still inside the 50px header).
- Title pages are unaffected — the title element carries its own `min-w-0` and still shrinks; with a 40-character title at a 600px header the right-hand action area stays inside the header.
- `npx jest src/components/SideMenu src/components/pageLayout` — 20 suites / 66 tests pass.
