### PR TITLE
Revert "fix(page-layout): keep header tab labels on one line in narrow headers"

### DIFF
--- a/src/components/pageLayout/PageLayoutWithTabs/TabMenu.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/TabMenu.tsx
@@ -44,7 +44,7 @@ export const TabMenu: React.FC<TabMenuProps> = ({ currentMenu, onTabChange }) =>
       {_.map(permissionedMenus, (item) => (
         <div
           key={item.key}
-          className={`relative px-5 h-full header-tab-menu flex items-center whitespace-nowrap cursor-pointer text-sm transition-colors duration-300 ${
+          className={`relative px-5 h-full header-tab-menu flex items-center cursor-pointer text-sm transition-colors duration-300 ${
             activeTab === item.key ? `text-primary custom-tab-active ${darkMode ? 'bg-gray-700/20' : 'bg-gray-200/20'}` : ''
           }`}
           onClick={() => {

--- a/src/components/pageLayout/PageLayoutWithTabs/index.tsx
+++ b/src/components/pageLayout/PageLayoutWithTabs/index.tsx
@@ -119,9 +119,7 @@ const PageLayout: React.FC<IPageLayoutProps> = ({
                   display: query.viewMode === 'fullscreen' ? 'none' : 'flex',
                 }}
               >
-                {/* No min-w-0 here: let this area's minimum width come from its content (the tab nav), so a narrow
-                    header shrinks the headerCenter prose instead of squeezing the tabs into per-character wrapping. */}
-                <div className='flex items-center flex-1'>
+                <div className='flex items-center min-w-0 flex-1'>
                   {!currentMenu?.parentItem?.label && (
                     <div className='page-header-title min-w-0'>
                       {showBack && window.history.state && (


### PR DESCRIPTION
Reverts n9e/fe#2283