### PR TITLE
fix(notificationChannels): stop submitting blank request configs and bind feishu card credentials correctly

### DIFF
--- a/src/pages/notificationChannels/pages/Form/Feishu.tsx
+++ b/src/pages/notificationChannels/pages/Form/Feishu.tsx
@@ -11,7 +11,9 @@ interface Props {
 export default function Feishu(props: Props) {
   const { t } = useTranslation(NS);
   const { ident } = props;
-  const names = ['request_config', `${ident}_request_config`];
+  // 后端 RequestConfig 只有 feishu_request_config 这一个字段（feishucard/larkcard 的截图上传也读它），
+  // 按 ident 拼出来的 feishucard_/lark_/larkcard_request_config 后端不认识，提交上去会被直接丢掉。
+  const names = ['request_config', 'feishu_request_config'];
   let alert_shot_tip = t(`feishuapp_request_config.alert_shot_tip`);
 
   if (ident === 'lark' || ident === 'larkcard') {

--- a/src/pages/notificationChannels/types.ts
+++ b/src/pages/notificationChannels/types.ts
@@ -107,10 +107,9 @@ export interface ChannelItem {
     dingtalkapp_request_config: DingtalkAppRequestConfig;
     wecomapp_request_config: WecomAppRequestConfig;
     feishuapp_request_config: FeishuAppRequestConfig;
-    feishu_request_config: Omit<FeishuAppRequestConfig, 'app_id' | 'app_secret'>;
-    feishucard_request_config: Omit<FeishuAppRequestConfig, 'app_id' | 'app_secret'>;
-    lark_request_config: Omit<FeishuAppRequestConfig, 'app_id' | 'app_secret'>;
-    larkcard_request_config: Omit<FeishuAppRequestConfig, 'app_id' | 'app_secret'>;
-    dingtalk_request_config: Omit<DingtalkAppRequestConfig, 'app_key' | 'app_secret'>;
+    // 群机器人（webhook）类渠道只有上传告警截图用的应用凭证，字段名与后端 models.RequestConfig 一一对应：
+    // feishu / feishucard / lark / larkcard 共用 feishu_request_config，dingtalk 用 dingtalk_request_config
+    feishu_request_config: Pick<FeishuAppRequestConfig, 'app_id' | 'app_secret'>;
+    dingtalk_request_config: Pick<DingtalkAppRequestConfig, 'app_key' | 'app_secret'>;
   };
 }

--- a/src/pages/notificationChannels/utils/normalizeValues.test.ts
+++ b/src/pages/notificationChannels/utils/normalizeValues.test.ts
@@ -88,6 +88,53 @@ describe('normalizeFormValues (通知媒介)', () => {
       p1: 'v1',
     });
   });
+
+  it('应剔除全空的 xxx_request_config（空对象 / 字段全空）', () => {
+    const input = {
+      request_config: {
+        http_request_config: {
+          url: 'https://oapi.dingtalk.com/robot/send',
+          headers: [],
+          request: { parameters: [] },
+        },
+        // 折叠面板 forceRender 后必然被 getFieldsValue 带出来的空壳
+        dingtalk_request_config: { app_key: '', app_secret: '' },
+        feishu_request_config: {},
+        smtp_request_config: { host: undefined, port: null },
+      },
+    } as const;
+
+    const result = normalizeFormValues(input);
+    expect(result.request_config).not.toHaveProperty('dingtalk_request_config');
+    expect(result.request_config).not.toHaveProperty('feishu_request_config');
+    expect(result.request_config).not.toHaveProperty('smtp_request_config');
+    // http_request_config 是公共载体，即使没填内容也保留
+    expect(result.request_config.http_request_config.url).toBe('https://oapi.dingtalk.com/robot/send');
+  });
+
+  it('填过值的 xxx_request_config 必须原样保留', () => {
+    const input = {
+      request_config: {
+        http_request_config: { headers: [], request: { parameters: [] } },
+        dingtalk_request_config: { app_key: 'key', app_secret: '' },
+      },
+    } as const;
+
+    const result = normalizeFormValues(input);
+    expect(result.request_config.dingtalk_request_config).toEqual({ app_key: 'key', app_secret: '' });
+  });
+
+  it('0 与 false 是有效值，不能被当成空剔除', () => {
+    const input = {
+      request_config: {
+        http_request_config: { headers: [], request: { parameters: [] } },
+        smtp_request_config: { host: '', port: 0, insecure_skip_verify: false },
+      },
+    } as const;
+
+    const result = normalizeFormValues(input);
+    expect(result.request_config.smtp_request_config).toEqual({ host: '', port: 0, insecure_skip_verify: false });
+  });
 });
 
 // ---------- normalizeInitialValues 回归测试 ----------

--- a/src/pages/notificationChannels/utils/normalizeValues.ts
+++ b/src/pages/notificationChannels/utils/normalizeValues.ts
@@ -2,6 +2,27 @@ import _ from 'lodash';
 
 import { ChannelItem } from '../types';
 
+/**
+ * 判断一份配置是否「全空」：所有叶子都是 undefined / null / 空串（0 和 false 是有效值，不算空）
+ */
+function isBlankConfig(value: any): boolean {
+  if (value === undefined || value === null || value === '') return true;
+  if (_.isArray(value) || _.isPlainObject(value)) return _.every(value, isBlankConfig);
+  return false;
+}
+
+/**
+ * 表单一次性挂载了所有渠道的字段（各自用 display:none 隐藏，折叠面板也是 forceRender），
+ * 于是 getFieldsValue() 会带出一堆字段全空的 xxx_request_config。这些空壳提交上去后端只判
+ * 结构体非 nil 就会走进对应分支，例如钉钉群机器人会被空的 dingtalk_request_config 拐进应用
+ * 模式、报 app key cannot be empty。这里按「是否全空」剔除，而不是按当前渠道类型保留：
+ * 折叠面板里用户填过的值必须原样提交，这正是 forceRender 要解决的问题。
+ * http_request_config 是所有 http 类渠道的公共载体，历来就会提交，保持原样不动。
+ */
+function omitBlankRequestConfigs(request_config: Record<string, any>): Record<string, any> {
+  return _.omitBy(request_config, (value, key) => key !== 'http_request_config' && _.endsWith(key, '_request_config') && isBlankConfig(value));
+}
+
 export function normalizeFormValues(values: ChannelItem): any {
   values = _.cloneDeep(values);
   const request_config = values.request_config ?? {};
@@ -10,7 +31,7 @@ export function normalizeFormValues(values: ChannelItem): any {
   return {
     ...values,
     request_config: {
-      ...request_config,
+      ...omitBlankRequestConfigs(request_config),
       http_request_config: {
         ...http_request_config,
         // 将 headers: {key: string, value: string}[] 转换成 {[key: string]: string}


### PR DESCRIPTION
### Background

`ccfos/nightingale#3309` fixed the backend half of this problem. This PR is the frontend half; without it the root cause is still there and a second, frontend-only bug remains completely unfixed.

### 1. Stop submitting blank `xxx_request_config` shells

`Form/index.tsx` mounts every channel-specific form at once (each hides itself with `display:none`, and the advanced-settings `Collapse.Panel` uses `forceRender`). Every one of those `Form.Item`s registers, so `validateFields()` returns a payload carrying ~8 all-blank `xxx_request_config` objects regardless of which channel is being edited.

The backend used to branch on `DingtalkRequestConfig != nil` alone, so a blank `dingtalk_request_config: {app_key: "", app_secret: ""}` dragged group-robot notifications into DingTalk *app* mode, which then failed with `app key cannot be empty` — the webhook was never called at all. Saving a DingTalk channel once from the UI was enough to break its notifications.

`normalizeValues.ts` now drops `xxx_request_config` entries whose leaves are all blank:

- Filtering is by "is it entirely blank", **not** by "does it match the current channel type". Values the user typed inside a collapsed panel must still be submitted — that is exactly what `forceRender` is there for.
- `0` and `false` count as real values (`smtp_request_config.port: 0`, `insecure_skip_verify: false`).
- `http_request_config` is the shared carrier for all HTTP channels and is left untouched.

Three unit tests cover those three points.

Existing rows keep their blank shells until the channel is next saved, at which point `Select("*").Updates` replaces the whole `request_config` column and the shells disappear. With #3309 merged they are harmless in the meantime, so no data migration is needed.

### 2. Bind Feishu/Lark card credentials to the field the backend actually reads

`Form/Feishu.tsx` built its field path as `${ident}_request_config`, producing `feishucard_request_config` / `lark_request_config` / `larkcard_request_config`. `models.RequestConfig` has no such fields — only `feishu_request_config`, which is also what `FeishuCardProvider` and `LarkCardProvider` read for screenshot upload. Those keys were dropped at `BindJSON` time, so the credentials were silently discarded on save and the field came back empty on edit.

Note that `constants.ts` already seeds the correct key for both card types (`feishucard` and `larkcard` default values both contain `feishu_request_config`), and `Form/Dingtalk.tsx` already hardcodes `dingtalk_request_config`. The form was the odd one out; this change makes it agree with the seed data and with its DingTalk sibling.

Effect: alert-screenshot upload was inert for 100% of the channels that consume this config. `feishu` and `lark` are commented out in the channel type table and are served by `simpleHTTPProvider`, which never reads it — so `feishucard` and `larkcard` were the only two consumers, and both were broken.

`types.ts` is corrected alongside: `Omit<..., 'app_id' | 'app_secret'>` excluded precisely the two fields the form edits, and the three request-config fields that do not exist on the backend are removed. Both are now `Pick<...>` of exactly the keys used, matching the shapes seeded in `constants.ts`.

No backend change is required for this half — it aligns with fields that already exist.

### Compatibility

Independent of backend version. Dropping the blank `dingtalk_request_config` yields `nil` on the backend, which both the pre-#3309 and post-#3309 code paths skip, so this is a fix against either. The Feishu key rename targets an existing backend field.

### Verification

`node_modules` is absent in this environment, so `tsc --noEmit`, `npm run build` and the Jest suite could not be run locally, and this repository has no pull-request CI (`package.yml` is `workflow_dispatch`, `release.yml` triggers on push). Verified instead by inspection:

- Rebased onto current `main`; the net diff is byte-identical to the pre-rebase diff, and none of the four touched files had been modified by the 138 intervening commits.
- The three type fields removed from `ChannelItem` have zero references anywhere under `src/`.
- The `Pick<...>` field sets match the shapes seeded in `constants.ts` (`dingtalk_request_config` at L203, `feishucard` at L303, `larkcard` at L399) and the paths bound in `Form/Dingtalk.tsx` and `Form/Feishu.tsx`.

The two commits were previously validated end-to-end against a running backend (A/B against the same payload: `app key cannot be empty` before, `success: true` with a real webhook POST after).

Please run the build once locally or in CI before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification channel form handling by removing empty optional configurations while preserving valid values such as `0` and `false`.
  * Ensured HTTP request settings are retained when saving notification channels.
  * Standardized Feishu and DingTalk webhook configuration fields for more consistent channel setup.

* **Tests**
  * Added regression coverage for empty configurations and valid falsy values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->