### PR TITLE
fix(side-menu): keep collapsed group icons visible on a colored sidebar

### DIFF
--- a/src/components/SideMenu/MenuGroup.test.tsx
+++ b/src/components/SideMenu/MenuGroup.test.tsx
@@ -22,10 +22,10 @@ const baseProps = {
   quickMenuRef: { current: { open: () => {} } },
 };
 
-const renderGroup = (item: IMenuItem, collapsed: boolean) => {
+const renderGroup = (item: IMenuItem, collapsed: boolean, overrides: Partial<typeof baseProps> & { isLight?: boolean } = {}) => {
   const { container } = render(
     <MemoryRouter initialEntries={['/elsewhere']}>
-      <MenuGroup item={item} collapsed={collapsed} {...baseProps} />
+      <MenuGroup item={item} collapsed={collapsed} {...baseProps} {...overrides} />
     </MemoryRouter>,
   );
   // The group row is the first child of MenuGroup's root; the submenu container is its sibling.
@@ -88,5 +88,22 @@ describe('collapsed MenuGroup row', () => {
     expect(groupRow?.tagName).toBe('DIV');
     const hrefs = Array.from(container.querySelectorAll('a')).map((a) => a.getAttribute('href'));
     expect(hrefs).toEqual(['/log/explorer']);
+  });
+
+  // A bare <a> takes the global link color, which on the theme-color sidebar is the same
+  // purple as the background - the collapsed icon then renders invisible against it.
+  it('spells out the sidebar text color on the collapsed link row', () => {
+    const item = {
+      key: 'explorer',
+      label: 'menu.explorer',
+      children: [{ key: '/log/explorer', label: 'menu.logs_explorer' }],
+    } satisfies IMenuItem;
+
+    const onCustomBg = renderGroup(item, true, { isCustomBg: true }).groupRow;
+    expect(onCustomBg?.tagName).toBe('A');
+    expect(onCustomBg).toHaveClass('text-[#e6e6e8]');
+
+    const onLightBg = renderGroup(item, true, { isLight: true }).groupRow;
+    expect(onLightBg).toHaveClass('text-[var(--fc-sidemenu-item-text)]');
   });
 });

--- a/src/components/SideMenu/MenuList.tsx
+++ b/src/components/SideMenu/MenuList.tsx
@@ -91,6 +91,16 @@ function getMenuGroupIconColorClass(opts: {
 }
 
 /**
+ * The sidebar's base text color. A row rendered as an anchor has to carry it
+ * explicitly: a bare <a> takes the global link color instead of inheriting, and
+ * on the theme-color sidebar that link color is the very same purple as the
+ * background, so the row's icon turns invisible.
+ */
+function getSideMenuRowTextClass(opts: { isLight: boolean; isCustomBg: boolean }): string {
+  return opts.isLight ? 'text-[var(--fc-sidemenu-item-text)]' : opts.isCustomBg ? 'text-[#e6e6e8]' : 'text-main';
+}
+
+/**
  * Collapsed top-level rows show an icon only, so the label has to come from a tooltip.
  * Sub rows live inside the hover panel, which already renders their labels.
  */
@@ -186,6 +196,7 @@ export function MenuGroup(props: { item: IMenuItem } & IMenuProps) {
 
   const rowClassName = cn(
     'group flex h-8 cursor-pointer items-center justify-between rounded-md px-3 transition-colors duration-75',
+    getSideMenuRowTextClass({ isLight: Boolean(isLight), isCustomBg: props.isCustomBg }),
     rowHover,
     collapsed && isActive ? collapsedActiveBg : '',
   );
@@ -573,7 +584,7 @@ export default function MenuList(
 
   return (
     <>
-      <div className={cn('h-full pl-2 pr-4 pb-2.5', isLight ? 'text-[var(--fc-sidemenu-item-text)]' : props.isCustomBg ? 'text-[#e6e6e8]' : 'text-main')}>
+      <div className={cn('h-full pl-2 pr-4 pb-2.5', getSideMenuRowTextClass({ isLight, isCustomBg: props.isCustomBg }))}>
         {IS_ENT ? (
           <Link
             to='/landing'
@@ -581,7 +592,7 @@ export default function MenuList(
               'group relative flex min-w-0 cursor-pointer items-center transition-colors transition-spacing duration-75',
               'h-8 rounded-md',
               'px-3',
-              isLight ? 'text-[var(--fc-sidemenu-item-text)]' : props.isCustomBg ? 'text-[#e6e6e8]' : 'text-main',
+              getSideMenuRowTextClass({ isLight, isCustomBg: props.isCustomBg }),
               isLight ? 'hover:bg-[var(--fc-sidemenu-item-hover-bg)]' : props.isCustomBg ? 'hover:bg-[rgba(204,204,220,0.12)]' : 'hover:bg-fc-200',
             )}
           >
@@ -603,7 +614,7 @@ export default function MenuList(
               'group relative flex min-w-0 cursor-pointer items-center transition-colors transition-spacing duration-75',
               'h-8 rounded-md',
               'px-3',
-              isLight ? 'text-[var(--fc-sidemenu-item-text)]' : props.isCustomBg ? 'text-[#e6e6e8]' : 'text-main',
+              getSideMenuRowTextClass({ isLight, isCustomBg: props.isCustomBg }),
               isLight ? 'hover:bg-[var(--fc-sidemenu-item-hover-bg)]' : props.isCustomBg ? 'hover:bg-[rgba(204,204,220,0.12)]' : 'hover:bg-fc-200',
             )}
           >


### PR DESCRIPTION
## Problem

On the collapsed side menu, every top-level group icon is invisible when the
sidebar uses the theme color, and renders purple instead of grey when the
sidebar uses the dark color. Only the light color scheme is affected.

The collapsed rail renders a group row as a link so that clicking the icon
opens the group's first child. `MenuGroup` never set a text color on that row
— it relied on inheriting the sidebar's. A bare `<a>` takes the global link
color instead of inheriting, and that link color is the exact same purple the
theme-color sidebar paints as its background, so the icon disappears into it.

## Fix

Give the group row the sidebar's base text color, the way the leaf rows and the
landing links already do, and pull the repeated expression into
`getSideMenuRowTextClass` so the next anchor added here picks up the guard.

## Tests

`MenuGroup.test.tsx` gains a case asserting the collapsed link row spells out a
sidebar text color, for both the colored and the light sidebar. It fails
without this change and passes with it.
