### PR TITLE
feat(alert-cur-events): add fullscreen live view

### DIFF
--- a/src/components/TimeRangePicker/AutoRefresh/index.tsx
+++ b/src/components/TimeRangePicker/AutoRefresh/index.tsx
@@ -35,7 +35,7 @@ interface IProps {
 
 function Refresh(props: IProps, ref) {
   const intervalSecondsCache = props.localKey ? _.toNumber(window.localStorage.getItem(props.localKey)) : 0;
-  const [intervalSeconds, setIntervalSeconds] = useState(props.intervalSeconds || intervalSecondsCache);
+  const [intervalSeconds, setIntervalSeconds] = useState(props.intervalSeconds ?? intervalSecondsCache);
   const [visible, setVisible] = useState(false);
   const intervalRef = useRef<ReturnType<typeof setTimeout> | undefined>();
   const removeRef = useRef(false);
@@ -86,7 +86,7 @@ function Refresh(props: IProps, ref) {
   }, []);
 
   useEffect(() => {
-    setIntervalSeconds(props.intervalSeconds || intervalSecondsCache);
+    setIntervalSeconds(props.intervalSeconds ?? intervalSecondsCache);
   }, [props.intervalSeconds]);
 
   useImperativeHandle(ref, () => ({

--- a/src/pages/alertCurEvent/pages/List/AlertTable.tsx
+++ b/src/pages/alertCurEvent/pages/List/AlertTable.tsx
@@ -33,6 +33,7 @@ interface IProps {
   setRefreshFlag: (refreshFlag: string) => void;
   tagDisplayMode: AlertEventTagsDisplayMode;
   alertEscalationEnable: boolean;
+  isFullscreen: boolean;
 }
 
 function formatDuration(ms: number) {
@@ -59,7 +60,7 @@ function formatDuration(ms: number) {
 }
 
 export default function AlertTable(props: IProps) {
-  const { filter, setFilter, selectedRowKeys, setSelectedRowKeys, params, setRefreshFlag, tagDisplayMode, alertEscalationEnable } = props;
+  const { filter, setFilter, selectedRowKeys, setSelectedRowKeys, params, setRefreshFlag, tagDisplayMode, alertEscalationEnable, isFullscreen } = props;
   const history = useHistory();
   const { t } = useTranslation(NS);
   const { datasourceList } = useContext(CommonStateContext);
@@ -73,6 +74,18 @@ export default function AlertTable(props: IProps) {
   const lastInitiatedViewIdRef = useRef<number | null>(null);
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const [tableHeaderHeight, setTableHeaderHeight] = useState<number>();
+  const [newFullscreenEventKeys, setNewFullscreenEventKeys] = useState<Set<string>>(new Set());
+  const previousFullscreenPageRef = useRef<{ queryKey: string; eventKeys: Set<string> }>();
+  // TimeRangePicker 会在刷新时向 range 写入 refreshFlag；它不参与接口筛选，不能让它重置新增事件的对比基准。
+  const fullscreenQueryKey = JSON.stringify({
+    ...params,
+    range: params.range ? _.omit(params.range, ['refreshFlag']) : params.range,
+  });
+
+  useEffect(() => {
+    previousFullscreenPageRef.current = undefined;
+    setNewFullscreenEventKeys(new Set());
+  }, [fullscreenQueryKey, isFullscreen]);
 
   useEffect(() => {
     const parsed = queryString.parse(location.search);
@@ -236,9 +249,13 @@ export default function AlertTable(props: IProps) {
     } as any);
   }
 
+  const getEventIdentity = (event: { hash: string }) => event.hash;
+
   const fetchData = ({ current, pageSize }) => {
+    const requestQueryKey = fullscreenQueryKey;
+    const isFullscreenRequest = isFullscreen;
     const requestParams: any = {
-      p: current,
+      p: isFullscreen ? 1 : current,
       limit: pageSize,
       my_groups: String(params.my_groups) === 'true',
       ..._.omit(params, ['range', 'my_groups']),
@@ -250,16 +267,29 @@ export default function AlertTable(props: IProps) {
       requestParams.etime = moment(parsedRange.end).unix();
     }
     return getEvents(requestParams).then((res) => {
+      const list = res.dat.list ?? [];
       return {
         total: res.dat.total,
-        list: res.dat.list,
+        list,
+        requestQueryKey,
+        isFullscreenRequest,
       };
     });
   };
   const { tableProps } = useAntdTable(fetchData, {
-    refreshDeps: [JSON.stringify(params), props.refreshFlag],
+    refreshDeps: [fullscreenQueryKey, props.refreshFlag, isFullscreen],
     defaultPageSize: 30,
     debounceWait: 500,
+    onSuccess: (data: { list: Array<{ hash: string }>; requestQueryKey: string; isFullscreenRequest: boolean }) => {
+      if (!data.isFullscreenRequest) return;
+
+      const eventKeys = new Set(data.list.map(getEventIdentity));
+      const previousPage = previousFullscreenPageRef.current;
+      const nextNewEventKeys = previousPage?.queryKey === data.requestQueryKey ? new Set([...eventKeys].filter((key) => !previousPage.eventKeys.has(key))) : new Set<string>();
+
+      previousFullscreenPageRef.current = { queryKey: data.requestQueryKey, eventKeys };
+      setNewFullscreenEventKeys(nextNewEventKeys);
+    },
   });
 
   const pagination = usePagination({ PAGESIZE_KEY: EVENTS_TABLE_PAGESIZE_CACHE_KEY });
@@ -293,71 +323,86 @@ export default function AlertTable(props: IProps) {
         rowKey={(record) => record.id}
         columns={columns}
         {...tableProps}
-        rowClassName={(record: { severity: number; is_recovered: number }) => {
-          return SEVERITY_COLORS[record.is_recovered ? 3 : record.severity - 1] + '-left-border';
+        rowClassName={(record: { hash: string; severity: number; is_recovered: number }) => {
+          const severityClassName = SEVERITY_COLORS[record.is_recovered ? 3 : record.severity - 1] + '-left-border';
+          const shouldHighlight = isFullscreen && newFullscreenEventKeys.has(getEventIdentity(record));
+          // 复用主题 violet-3（--fc-violet-3），明暗模式各自取值，避免硬编码色值。
+          return shouldHighlight ? `${severityClassName} children:!bg-violet-300` : severityClassName;
         }}
-        rowSelection={{
-          selectedRowKeys: selectedRowKeys,
-          onChange(selectedRowKeys: number[]) {
-            setSelectedRowKeys(selectedRowKeys);
-          },
-        }}
-        pagination={{
-          ...pagination,
-          ...tableProps.pagination,
-          pageSizeOptions: ['30', '100', '200', '500'],
-        }}
-        rowActions={(record) => ({
-          inline: _.compact([
-            IS_PLUS && alertEscalationEnable
-              ? {
-                  key: 'ack',
-                  icon: record.status === 0 ? 'claim' : 'unclaim',
-                  text: record.status === 0 ? t('claim') : t('unclaim'),
-                  onClick: () => {
-                    ackEvents([record.id], record.status === 0 ? 'ack' : 'unack').then(() => {
-                      setRefreshFlag(_.uniqueId('refresh_'));
-                    });
+        rowSelection={
+          isFullscreen
+            ? undefined
+            : {
+                selectedRowKeys: selectedRowKeys,
+                onChange(selectedRowKeys: number[]) {
+                  setSelectedRowKeys(selectedRowKeys);
+                },
+              }
+        }
+        pagination={
+          isFullscreen
+            ? false
+            : {
+                ...pagination,
+                ...tableProps.pagination,
+                pageSizeOptions: ['30', '100', '200', '500'],
+              }
+        }
+        rowActions={
+          isFullscreen
+            ? undefined
+            : (record) => ({
+                inline: _.compact([
+                  IS_PLUS && alertEscalationEnable
+                    ? {
+                        key: 'ack',
+                        icon: record.status === 0 ? 'claim' : 'unclaim',
+                        text: record.status === 0 ? t('claim') : t('unclaim'),
+                        onClick: () => {
+                          ackEvents([record.id], record.status === 0 ? 'ack' : 'unack').then(() => {
+                            setRefreshFlag(_.uniqueId('refresh_'));
+                          });
+                        },
+                      }
+                    : undefined,
+                  !_.includes(['firemap', 'northstar'], record?.rule_prod)
+                    ? {
+                        key: 'shield',
+                        icon: 'shield',
+                        text: t('shield'),
+                        onClick: () => {
+                          history.push({
+                            pathname: '/alert-mutes/add',
+                            search: queryString.stringify({
+                              busiGroup: record.group_id,
+                              prod: record.rule_prod,
+                              cate: record.cate,
+                              datasource_ids: [record.datasource_id],
+                              tags: record.tags,
+                            }),
+                          });
+                        },
+                      }
+                    : undefined,
+                  {
+                    key: 'delete',
+                    icon: 'delete',
+                    text: t('common:btn.delete'),
+                    danger: true,
+                    onClick: () =>
+                      deleteAlertEventsModal(
+                        [record.id],
+                        () => {
+                          setSelectedRowKeys(selectedRowKeys.filter((key) => key !== record.id));
+                          setRefreshFlag(_.uniqueId('refresh_'));
+                        },
+                        t,
+                      ),
                   },
-                }
-              : undefined,
-            !_.includes(['firemap', 'northstar'], record?.rule_prod)
-              ? {
-                  key: 'shield',
-                  icon: 'shield',
-                  text: t('shield'),
-                  onClick: () => {
-                    history.push({
-                      pathname: '/alert-mutes/add',
-                      search: queryString.stringify({
-                        busiGroup: record.group_id,
-                        prod: record.rule_prod,
-                        cate: record.cate,
-                        datasource_ids: [record.datasource_id],
-                        tags: record.tags,
-                      }),
-                    });
-                  },
-                }
-              : undefined,
-            {
-              key: 'delete',
-              icon: 'delete',
-              text: t('common:btn.delete'),
-              danger: true,
-              onClick: () =>
-                deleteAlertEventsModal(
-                  [record.id],
-                  () => {
-                    setSelectedRowKeys(selectedRowKeys.filter((key) => key !== record.id));
-                    setRefreshFlag(_.uniqueId('refresh_'));
-                  },
-                  t,
-                ),
-            },
-          ]) as any,
-        })}
-        actionColumn={{ title: t('common:table.operations'), width: 100 }}
+                ]) as any,
+              })
+        }
+        actionColumn={isFullscreen ? undefined : { title: t('common:table.operations'), width: 100 }}
       />
       <EventDetailDrawer
         showAckBtn

--- a/src/pages/alertCurEvent/pages/List/FullscreenList.tsx
+++ b/src/pages/alertCurEvent/pages/List/FullscreenList.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Button, ConfigProvider, Space, Tooltip } from 'antd';
+import { FullscreenExitOutlined } from '@ant-design/icons';
+import { useTranslation } from 'react-i18next';
+
+import { TimeRangePickerWithRefresh } from '@/components/TimeRangePicker';
+import { IRawTimeRange } from '@/components/TimeRangePicker';
+
+import { NS, TIME_RANGE_CACHE_KEY } from '../../constants';
+
+interface IProps {
+  title: string;
+  children: React.ReactNode;
+  range?: IRawTimeRange;
+  onRangeChange: (range?: IRawTimeRange) => void;
+  onRefresh: () => void;
+  onExit: () => void;
+}
+
+export default function FullscreenList({ title, children, range, onRangeChange, onRefresh, onExit }: IProps) {
+  const { t } = useTranslation(NS);
+  const [refreshInterval, setRefreshInterval] = useState(30);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // 退出全屏时把自动刷新缓存置为 Off。该 key 与常规列表的 TimeRangePickerWithRefresh 共享，
+  // 因此离开全屏大屏后常规列表也会停止轮询；AutoRefresh 自身的卸载清理已停掉全屏内的定时器。
+  useEffect(() => {
+    return () => {
+      localStorage.setItem(`${TIME_RANGE_CACHE_KEY}_refresh`, '0');
+    };
+  }, []);
+
+  return (
+    <ConfigProvider getPopupContainer={() => containerRef.current ?? document.body}>
+      <div ref={containerRef} className='flex h-full flex-col bg-fc-100 p-4'>
+        <div className='mb-4 flex shrink-0 items-center justify-between border-0 border-b border-solid border-[var(--fc-border-color)] bg-fc-100 pb-4'>
+          <div className='flex items-center text-title'>
+            <span className='text-[18px] font-semibold leading-7'>{title}</span>
+            <span className='ml-3 inline-flex items-center gap-2 text-[14px] font-medium leading-[22px] text-green-900'>
+              <span className='relative inline-flex h-3.5 w-3.5 items-center justify-center' aria-hidden>
+                <span className='absolute h-2.5 w-2.5 rounded-full border border-green-900 motion-reduce:animate-none animate-[ping_2s_ease-out_infinite]' />
+                <span className='absolute h-2.5 w-2.5 rounded-full border border-green-900 motion-reduce:animate-none animate-[ping_2s_ease-out_infinite] [animation-delay:0.8s]' />
+                <span className='relative z-[1] h-2 w-2 rounded-full bg-green-900' />
+              </span>
+              <span>LIVE</span>
+            </span>
+          </div>
+          <Space>
+            <TimeRangePickerWithRefresh
+              allowClear
+              value={range}
+              onChange={onRangeChange}
+              onRefresh={onRefresh}
+              intervalSeconds={refreshInterval}
+              onIntervalSecondsChange={setRefreshInterval}
+              localKey={TIME_RANGE_CACHE_KEY}
+              dateFormat='YYYY-MM-DD HH:mm:ss'
+            />
+            <Tooltip title={t('dashboard:exit_full_screen')}>
+              <Button icon={<FullscreenExitOutlined />} onClick={onExit} />
+            </Tooltip>
+          </Space>
+        </div>
+        <div className='h-full min-h-0 flex-1'>{children}</div>
+      </div>
+    </ConfigProvider>
+  );
+}

--- a/src/pages/alertCurEvent/pages/List/index.tsx
+++ b/src/pages/alertCurEvent/pages/List/index.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState, useMemo, useEffect, useRef, useCallback } from 'react';
-import { Input, Checkbox, Collapse, Segmented, Button, Space } from 'antd';
-import { AlertOutlined, SearchOutlined } from '@ant-design/icons';
+import { Input, Checkbox, Collapse, Segmented, Button, Space, Tooltip } from 'antd';
+import { AlertOutlined, FullscreenOutlined, SearchOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
 import queryString from 'query-string';
@@ -35,6 +35,7 @@ import DatasourceCheckbox from './DatasourceCheckbox';
 import AggrRuleDropdown from './AggrRuleDropdown';
 import AlertCard, { isEqualEventIds } from './AlertCard';
 import AlertTable from './AlertTable';
+import FullscreenList from './FullscreenList';
 
 const AlertCurEvent: React.FC = () => {
   const { t } = useTranslation(NS);
@@ -127,7 +128,27 @@ const AlertCurEvent: React.FC = () => {
   const [prodFilterExpanded, setProdFilterExpanded] = useState(() => readAlertCurEventSidebarFilterExpanded('prod', true));
   const [severityFilterExpanded, setSeverityFilterExpanded] = useState(() => readAlertCurEventSidebarFilterExpanded('severity', true));
   const [datasourceFilterExpanded, setDatasourceFilterExpanded] = useState(() => readAlertCurEventSidebarFilterExpanded('datasource', false));
+  const fullscreenRef = useRef<HTMLDivElement>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const params = getRequestParamsByFilter(filter);
+
+  useEffect(() => {
+    const syncFullscreenState = () => setIsFullscreen(document.fullscreenElement === fullscreenRef.current);
+    document.addEventListener('fullscreenchange', syncFullscreenState);
+    return () => document.removeEventListener('fullscreenchange', syncFullscreenState);
+  }, []);
+
+  const toggleFullscreen = useCallback(async () => {
+    try {
+      if (document.fullscreenElement === fullscreenRef.current) {
+        await document.exitFullscreen();
+      } else {
+        await fullscreenRef.current?.requestFullscreen();
+      }
+    } catch {
+      // 浏览器可能因权限策略禁止全屏，保持当前页面状态即可。
+    }
+  }, []);
 
   useEffect(() => {
     if (!IS_PLUS || !getBrainLicense) return;
@@ -213,256 +234,279 @@ const AlertCurEvent: React.FC = () => {
 
   return (
     <PageLayout icon={<AlertOutlined />} title={t('title')} doc='https://flashcat.cloud/docs/content/flashcat-monitor/nightingale-v9/usage/alert-notify/events/cur-events/'>
-      <div className={`n9e ${NS}`}>
-        <div className='bg-fc-100 fc-border rounded-lg h-full'>
-          <div className='p-4 h-full'>
-            <div className='flex flex-col h-full'>
-              <div className='flex justify-between items-center mb-2'>
-                <Space>
+      <div ref={fullscreenRef} className={`n9e ${NS} h-full`}>
+        {isFullscreen ? (
+          <FullscreenList
+            title={t('title')}
+            range={filter.range}
+            onRangeChange={(range) => setFilterPatch({ range })}
+            onRefresh={() => setRefreshFlag(_.uniqueId('refresh_'))}
+            onExit={toggleFullscreen}
+          >
+            <AlertTable
+              filter={filter}
+              setFilter={setFilterPatch}
+              refreshFlag={refreshFlag}
+              selectedRowKeys={selectedRowKeys}
+              setSelectedRowKeys={setSelectedRowKeys}
+              params={params}
+              setRefreshFlag={setRefreshFlag}
+              tagDisplayMode={tagDisplayMode}
+              alertEscalationEnable={alertEscalationEnable}
+              isFullscreen
+            />
+          </FullscreenList>
+        ) : (
+          <div className='fc-border h-full rounded-lg bg-fc-100'>
+            <div className='h-full p-4'>
+              <div className='flex flex-col h-full'>
+                <div className='mb-2 flex items-center justify-between'>
                   <Space>
-                    <Segmented
-                      shape='round'
-                      className='whitespace-nowrap min-w-[190px]'
-                      onChange={(value: 'true' | 'false') => {
-                        setFilterPatch({ my_groups: value });
-                        localStorage.setItem(MY_GRPUPS_CACHE_KEY, value);
+                    <Space>
+                      <Segmented
+                        shape='round'
+                        className='whitespace-nowrap min-w-[190px]'
+                        onChange={(value: 'true' | 'false') => {
+                          setFilterPatch({ my_groups: value });
+                          localStorage.setItem(MY_GRPUPS_CACHE_KEY, value);
+                        }}
+                        value={filter.my_groups}
+                        block
+                        options={[
+                          { label: t('my_groups'), value: 'true' },
+                          { label: t('all_groups'), value: 'false' },
+                        ]}
+                      />
+                      <BusinessGroupSelectWithAll
+                        value={filter.bgid}
+                        onChange={(val: number) => {
+                          setFilterPatch({ bgid: val });
+                        }}
+                      />
+                    </Space>
+                    <Input
+                      allowClear
+                      style={{ width: '320px' }}
+                      prefix={<SearchOutlined />}
+                      placeholder={t('search_placeholder')}
+                      value={draftQuery}
+                      onFocus={() => {
+                        queryFocusedRef.current = true;
                       }}
-                      value={filter.my_groups}
-                      block
-                      options={[
-                        { label: t('my_groups'), value: 'true' },
-                        { label: t('all_groups'), value: 'false' },
-                      ]}
-                    />
-                    <BusinessGroupSelectWithAll
-                      value={filter.bgid}
-                      onChange={(val: number) => {
-                        setFilterPatch({ bgid: val });
+                      onBlur={() => {
+                        queryFocusedRef.current = false;
+                        setDraftQuery(filter.query ?? '');
+                      }}
+                      onChange={(e) => {
+                        const next = e.target.value;
+                        setDraftQuery(next);
+                        commitQueryDebounced(next);
                       }}
                     />
                   </Space>
-                  <Input
-                    allowClear
-                    style={{ width: '320px' }}
-                    prefix={<SearchOutlined />}
-                    placeholder={t('search_placeholder')}
-                    value={draftQuery}
-                    onFocus={() => {
-                      queryFocusedRef.current = true;
-                    }}
-                    onBlur={() => {
-                      queryFocusedRef.current = false;
-                      setDraftQuery(filter.query ?? '');
-                    }}
-                    onChange={(e) => {
-                      const next = e.target.value;
-                      setDraftQuery(next);
-                      commitQueryDebounced(next);
-                    }}
-                  />
-                </Space>
-                <Space>
-                  <span className='whitespace-nowrap'>{t('tag_display')}: </span>
-                  <Segmented
-                    value={tagDisplayMode}
-                    options={[
-                      { label: t('tag_display_all'), value: 'all' },
-                      { label: t('tag_display_compact'), value: 'compact' },
-                      { label: t('tag_display_off'), value: 'off' },
-                    ]}
-                    onChange={(value) => {
-                      const next = value as AlertEventTagsDisplayMode;
-                      setTagDisplayMode(next);
-                      writeAlertEventTagsDisplayMode(ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY, next);
-                    }}
-                  />
-                  <TimeRangePickerWithRefresh
-                    allowClear={true}
-                    value={filter.range}
-                    onChange={(val) => {
-                      setFilterPatch({ range: val });
-                    }}
-                    onRefresh={() => {
-                      setRefreshFlag(_.uniqueId('refresh_'));
-                    }}
-                    localKey={TIME_RANGE_CACHE_KEY}
-                    dateFormat='YYYY-MM-DD HH:mm:ss'
-                  />
-                </Space>
-              </div>
-              <div className='h-full min-h-0 flex'>
-                {/* 左侧筛选区 */}
-                <div className='w-[190px] mr-[8px] overflow-hidden h-full shrink-0 flex flex-col gap-2 n9e-antd-collapse-height-full'>
-                  <div className='flex-shrink-0'>
-                    <Collapse
-                      className='w-full'
-                      bordered={false}
-                      expandIconPosition='start'
-                      activeKey={prodFilterExpanded ? ['prod'] : []}
-                      onChange={(keys) => {
-                        const expanded = (Array.isArray(keys) ? keys : [keys]).includes('prod');
-                        setProdFilterExpanded(expanded);
-                        writeAlertCurEventSidebarFilterExpanded('prod', expanded);
+                  <Space>
+                    <span className='whitespace-nowrap'>{t('tag_display')}: </span>
+                    <Segmented
+                      value={tagDisplayMode}
+                      options={[
+                        { label: t('tag_display_all'), value: 'all' },
+                        { label: t('tag_display_compact'), value: 'compact' },
+                        { label: t('tag_display_off'), value: 'off' },
+                      ]}
+                      onChange={(value) => {
+                        const next = value as AlertEventTagsDisplayMode;
+                        setTagDisplayMode(next);
+                        writeAlertEventTagsDisplayMode(ALERT_CUR_EVENT_TAGS_EXPANDED_TABLE_KEY, next);
                       }}
-                    >
-                      <Collapse.Panel header={t('prod')} key='prod'>
-                        <Checkbox.Group
-                          value={filter.rule_prods}
-                          onChange={(val: string[]) => {
-                            setFilterPatch({ rule_prods: val });
-                          }}
-                        >
-                          {_.map(getProdOptions(feats), (item) => (
-                            <div key={item.value}>
-                              <Checkbox className='py-1' value={item.value}>
-                                {item.label}
-                                <br />
-                              </Checkbox>
-                            </div>
-                          ))}
-                        </Checkbox.Group>
-                      </Collapse.Panel>
-                    </Collapse>
-                  </div>
-                  <div className='flex-shrink-0'>
-                    <Collapse
-                      className='w-full'
-                      bordered={false}
-                      expandIconPosition='start'
-                      activeKey={severityFilterExpanded ? ['severity'] : []}
-                      onChange={(keys) => {
-                        const expanded = (Array.isArray(keys) ? keys : [keys]).includes('severity');
-                        setSeverityFilterExpanded(expanded);
-                        writeAlertCurEventSidebarFilterExpanded('severity', expanded);
-                      }}
-                    >
-                      <Collapse.Panel header={t('severity')} key='severity'>
-                        <Checkbox.Group
-                          value={filter.severity}
-                          onChange={(val) => {
-                            setFilterPatch({ severity: _.map(val, _.toNumber) });
-                          }}
-                        >
-                          <Checkbox className='py-1' value={1}>
-                            <div className='inline-block mr-2 w-[4px] h-[12px] rounded-lg event-card-circle red' />
-                            S1（Critical）
-                          </Checkbox>
-                          <br />
-                          <Checkbox className='py-1' value={2}>
-                            <div className='inline-block mr-2 w-[4px] h-[12px] rounded-lg event-card-circle orange' />
-                            S2（Warning）
-                          </Checkbox>
-                          <br />
-                          <Checkbox className='py-1' value={3}>
-                            <div className='inline-block mr-2 w-[4px] h-[12px] rounded-lg event-card-circle yellow' />
-                            S3（Info）
-                          </Checkbox>
-                          <br />
-                        </Checkbox.Group>
-                      </Collapse.Panel>
-                    </Collapse>
-                  </div>
-                  <div className='flex-1 h-full min-h-0'>
-                    <Collapse
-                      className='w-full'
-                      bordered={false}
-                      expandIconPosition='start'
-                      activeKey={datasourceFilterExpanded ? ['datasource'] : []}
-                      onChange={(keys) => {
-                        const expanded = (Array.isArray(keys) ? keys : [keys]).includes('datasource');
-                        setDatasourceFilterExpanded(expanded);
-                        writeAlertCurEventSidebarFilterExpanded('datasource', expanded);
-                      }}
-                    >
-                      <Collapse.Panel header={t('datasources')} key='datasource'>
-                        <DatasourceCheckbox
-                          value={filter.datasource_ids}
-                          onChange={(val: number[]) => {
-                            setFilterPatch({ datasource_ids: val });
-                          }}
-                        />
-                      </Collapse.Panel>
-                    </Collapse>
-                  </div>
-                </div>
-                {/* 右侧内容区 */}
-                <div className='fc-border flex-1 min-w-0 flex flex-col gap-2'>
-                  <div
-                    className='cur-events'
-                    style={{
-                      borderBottom: '1px solid var(--fc-border-color)',
-                    }}
-                  >
-                    <div className='p-2'>
-                      <div className='alert-event-summary-toolbar'>
-                        <AggrRuleDropdown cardList={cardList} filter={filter} setFilter={setFilterPatch} reloadRuleCards={reloadRuleCards} />
-                      </div>
-                      <AlertCard filter={filter} setFilter={setFilterPatch} cardList={cardList} />
-                    </div>
-                  </div>
-                  {selectedRowKeys.length > 0 && (
-                    <div className='flex-shrink-0 flex gap-2 justify-end mr-2'>
-                      <Button
-                        className='ant-dropdown-menu-item'
-                        onClick={() =>
-                          deleteAlertEventsModal(
-                            selectedRowKeys,
-                            () => {
-                              setSelectedRowKeys([]);
-                              setRefreshFlag(_.uniqueId('refresh_'));
-                            },
-                            t,
-                          )
-                        }
-                      >
-                        {t('common:btn.batch_delete')}
-                      </Button>
-                      {IS_PLUS && alertEscalationEnable && (
-                        <>
-                          <Button
-                            className='ant-dropdown-menu-item'
-                            onClick={() => {
-                              ackEvents(selectedRowKeys).then(() => {
-                                setSelectedRowKeys([]);
-                                setRefreshFlag(_.uniqueId('refresh_'));
-                              });
-                            }}
-                          >
-                            {t('batch_claim')}
-                          </Button>
-                          <Button
-                            className='ant-dropdown-menu-item'
-                            onClick={() => {
-                              ackEvents(selectedRowKeys, 'unack').then(() => {
-                                setSelectedRowKeys([]);
-                                setRefreshFlag(_.uniqueId('refresh_'));
-                              });
-                            }}
-                          >
-                            {t('batch_unclaim')}
-                          </Button>
-                        </>
-                      )}
-                    </div>
-                  )}
-                  <div className='px-2 h-full min-h-0'>
-                    <AlertTable
-                      filter={filter}
-                      setFilter={setFilterPatch}
-                      refreshFlag={refreshFlag}
-                      selectedRowKeys={selectedRowKeys}
-                      setSelectedRowKeys={setSelectedRowKeys}
-                      params={params}
-                      setRefreshFlag={setRefreshFlag}
-                      tagDisplayMode={tagDisplayMode}
-                      alertEscalationEnable={alertEscalationEnable}
                     />
+                    <TimeRangePickerWithRefresh
+                      allowClear
+                      value={filter.range}
+                      onChange={(range) => setFilterPatch({ range })}
+                      onRefresh={() => setRefreshFlag(_.uniqueId('refresh_'))}
+                      localKey={TIME_RANGE_CACHE_KEY}
+                      dateFormat='YYYY-MM-DD HH:mm:ss'
+                    />
+                    <Tooltip title={t('dashboard:full_screen')}>
+                      <Button icon={<FullscreenOutlined />} onClick={toggleFullscreen} />
+                    </Tooltip>
+                  </Space>
+                </div>
+                <div className='flex flex-1 min-h-0'>
+                  {/* 左侧筛选区 */}
+                  <div className='mr-2 flex h-full w-[190px] shrink-0 flex-col gap-2 overflow-hidden n9e-antd-collapse-height-full'>
+                    <div className='flex-shrink-0'>
+                      <Collapse
+                        className='w-full'
+                        bordered={false}
+                        expandIconPosition='start'
+                        activeKey={prodFilterExpanded ? ['prod'] : []}
+                        onChange={(keys) => {
+                          const expanded = (Array.isArray(keys) ? keys : [keys]).includes('prod');
+                          setProdFilterExpanded(expanded);
+                          writeAlertCurEventSidebarFilterExpanded('prod', expanded);
+                        }}
+                      >
+                        <Collapse.Panel header={t('prod')} key='prod'>
+                          <Checkbox.Group
+                            value={filter.rule_prods}
+                            onChange={(val: string[]) => {
+                              setFilterPatch({ rule_prods: val });
+                            }}
+                          >
+                            {_.map(getProdOptions(feats), (item) => (
+                              <div key={item.value}>
+                                <Checkbox className='py-1' value={item.value}>
+                                  {item.label}
+                                  <br />
+                                </Checkbox>
+                              </div>
+                            ))}
+                          </Checkbox.Group>
+                        </Collapse.Panel>
+                      </Collapse>
+                    </div>
+                    <div className='flex-shrink-0'>
+                      <Collapse
+                        className='w-full'
+                        bordered={false}
+                        expandIconPosition='start'
+                        activeKey={severityFilterExpanded ? ['severity'] : []}
+                        onChange={(keys) => {
+                          const expanded = (Array.isArray(keys) ? keys : [keys]).includes('severity');
+                          setSeverityFilterExpanded(expanded);
+                          writeAlertCurEventSidebarFilterExpanded('severity', expanded);
+                        }}
+                      >
+                        <Collapse.Panel header={t('severity')} key='severity'>
+                          <Checkbox.Group
+                            value={filter.severity}
+                            onChange={(val) => {
+                              setFilterPatch({ severity: _.map(val, _.toNumber) });
+                            }}
+                          >
+                            <Checkbox className='py-1' value={1}>
+                              <div className='inline-block mr-2 w-[4px] h-[12px] rounded-lg event-card-circle red' />
+                              S1（Critical）
+                            </Checkbox>
+                            <br />
+                            <Checkbox className='py-1' value={2}>
+                              <div className='inline-block mr-2 w-[4px] h-[12px] rounded-lg event-card-circle orange' />
+                              S2（Warning）
+                            </Checkbox>
+                            <br />
+                            <Checkbox className='py-1' value={3}>
+                              <div className='inline-block mr-2 w-[4px] h-[12px] rounded-lg event-card-circle yellow' />
+                              S3（Info）
+                            </Checkbox>
+                            <br />
+                          </Checkbox.Group>
+                        </Collapse.Panel>
+                      </Collapse>
+                    </div>
+                    <div className='flex-1 h-full min-h-0'>
+                      <Collapse
+                        className='w-full'
+                        bordered={false}
+                        expandIconPosition='start'
+                        activeKey={datasourceFilterExpanded ? ['datasource'] : []}
+                        onChange={(keys) => {
+                          const expanded = (Array.isArray(keys) ? keys : [keys]).includes('datasource');
+                          setDatasourceFilterExpanded(expanded);
+                          writeAlertCurEventSidebarFilterExpanded('datasource', expanded);
+                        }}
+                      >
+                        <Collapse.Panel header={t('datasources')} key='datasource'>
+                          <DatasourceCheckbox
+                            value={filter.datasource_ids}
+                            onChange={(val: number[]) => {
+                              setFilterPatch({ datasource_ids: val });
+                            }}
+                          />
+                        </Collapse.Panel>
+                      </Collapse>
+                    </div>
+                  </div>
+                  {/* 右侧内容区 */}
+                  <div className='fc-border flex min-w-0 flex-1 flex-col gap-2'>
+                    <div
+                      className='cur-events'
+                      style={{
+                        borderBottom: '1px solid var(--fc-border-color)',
+                      }}
+                    >
+                      <div className='p-2'>
+                        <div className='alert-event-summary-toolbar'>
+                          <AggrRuleDropdown cardList={cardList} filter={filter} setFilter={setFilterPatch} reloadRuleCards={reloadRuleCards} />
+                        </div>
+                        <AlertCard filter={filter} setFilter={setFilterPatch} cardList={cardList} />
+                      </div>
+                    </div>
+                    {selectedRowKeys.length > 0 && (
+                      <div className='mr-2 flex shrink-0 justify-end gap-2'>
+                        <Button
+                          className='ant-dropdown-menu-item'
+                          onClick={() =>
+                            deleteAlertEventsModal(
+                              selectedRowKeys,
+                              () => {
+                                setSelectedRowKeys([]);
+                                setRefreshFlag(_.uniqueId('refresh_'));
+                              },
+                              t,
+                            )
+                          }
+                        >
+                          {t('common:btn.batch_delete')}
+                        </Button>
+                        {IS_PLUS && alertEscalationEnable && (
+                          <>
+                            <Button
+                              className='ant-dropdown-menu-item'
+                              onClick={() => {
+                                ackEvents(selectedRowKeys).then(() => {
+                                  setSelectedRowKeys([]);
+                                  setRefreshFlag(_.uniqueId('refresh_'));
+                                });
+                              }}
+                            >
+                              {t('batch_claim')}
+                            </Button>
+                            <Button
+                              className='ant-dropdown-menu-item'
+                              onClick={() => {
+                                ackEvents(selectedRowKeys, 'unack').then(() => {
+                                  setSelectedRowKeys([]);
+                                  setRefreshFlag(_.uniqueId('refresh_'));
+                                });
+                              }}
+                            >
+                              {t('batch_unclaim')}
+                            </Button>
+                          </>
+                        )}
+                      </div>
+                    )}
+                    <div className='h-full min-h-0 px-2'>
+                      <AlertTable
+                        filter={filter}
+                        setFilter={setFilterPatch}
+                        refreshFlag={refreshFlag}
+                        selectedRowKeys={selectedRowKeys}
+                        setSelectedRowKeys={setSelectedRowKeys}
+                        params={params}
+                        setRefreshFlag={setRefreshFlag}
+                        tagDisplayMode={tagDisplayMode}
+                        alertEscalationEnable={alertEscalationEnable}
+                        isFullscreen={false}
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
+        )}
       </div>
     </PageLayout>
   );


### PR DESCRIPTION
Add a fullscreen wall mode for the active alert events list, toggled by a fullscreen button. In this mode the table fetches page 1 on a refresh cadence, disables selection/pagination/row actions, and highlights rows whose hash did not appear in the previous fetch.