### PR TITLE
feat(dev): support VITE_DEV_LOCALE=all and default dev locale to en_US

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,27 @@ The back-end api proxy config is https://github.com/n9e/fe/blob/main/vite.config
 Trouble shooting: https://answer.flashcat.cloud/questions/10010000000003759
 
 > **💡 Dev locale switching**  
-> To speed up the dev server, only **Chinese (zh_CN)** locale files are loaded by default in development mode; other languages are replaced with empty objects to reduce unnecessary module requests.  
+> To speed up the dev server, only **English (en_US)** locale files are loaded by default in development mode; other languages are replaced with empty objects to reduce unnecessary module requests.  
 > To switch to another language, create a `.env` file in the project root and set the `VITE_DEV_LOCALE` environment variable:
 >
 > ```bash
 > # .env
-> VITE_DEV_LOCALE=en_US
+> VITE_DEV_LOCALE=zh_CN
 > ```
 >
 > Or specify it inline when starting the dev server:
 >
 > ```bash
-> VITE_DEV_LOCALE=en_US npm run dev
+> VITE_DEV_LOCALE=zh_CN npm run dev
 > ```
 >
-> Supported locales: `zh_CN`, `en_US`, `zh_HK`, `ru_RU`, `ja_JP`.  
+> Supported locales: `zh_CN`, `en_US`, `zh_HK`, `ru_RU`, `ja_JP`, `pt_BR`, `es_ES`, `id_ID`, `ko_KR`, `fr_FR`.  
+> To load **all** locales (so you can switch languages freely in the UI, at the cost of more module requests), set it to `all`:
+>
+> ```bash
+> VITE_DEV_LOCALE=all npm run dev
+> ```
+>
 > This optimization only applies to the `serve` phase; production builds are unaffected.
 
 ## Build

--- a/plugins/vite-plugin-dev-locale.ts
+++ b/plugins/vite-plugin-dev-locale.ts
@@ -1,23 +1,28 @@
 /*
  * 仅「开发（serve）」阶段生效：把各 locale/index.(ts|js) 中「非当前语言」的语言 import
- * 就地替换为空对象，避免 dev 下每个 locale 目录都请求全部 5 种语言文件。
+ * 就地替换为空对象，避免 dev 下每个 locale 目录都请求全部语言文件。
  *
  * 背景：i18n 用 import.meta.glob(eager) 加载全部 locale/index，每个 index 又静态
- * "import xx from './<lang>'" 引入 5 种语言 → 一个目录 6 个请求，全站 700+。dev 实际只用
+ * "import xx from './<lang>'" 引入全部语言 → 一个目录 11 个请求，全站 1000+。dev 实际只用
  * 一种语言，其余是浪费。
  *
- * 转换示例（当前语言 = zh_CN）：
+ * 转换示例（当前语言 = en_US）：
  *   import zh_HK from './zh_HK';  =>  const zh_HK = {};
- *   import zh_CN from './zh_CN';  =>  （保留，真实加载）
+ *   import en_US from './en_US';  =>  （保留，真实加载）
  * resources 对象仍引用这些标识符，结构不变，非当前语言为 {} 不会报错。
  *
- * 当前语言由 VITE_DEV_LOCALE（默认 zh_CN）在启动时决定；prod 不受影响（apply: 'serve'）。
+ * 当前语言由 VITE_DEV_LOCALE（默认 en_US）在启动时决定；prod 不受影响（apply: 'serve'）。
+ *   - VITE_DEV_LOCALE=<lang>：只加载该语言，其余替换为 {}
+ *   - VITE_DEV_LOCALE=all：不做任何裁剪，全部语言真实加载，可在页面上随意切换语言
  * 遇到非标准写法（如深层路径的语言 import）自动跳过，回退为全量加载，无副作用。
  */
-const LANGS = ['zh_CN', 'en_US', 'zh_HK', 'ru_RU', 'ja_JP'];
+// 需与 src/i18n.ts 中的 languages 保持一致，否则未列出的语言在 dev 下不会被裁剪
+export const LANGS = ['zh_CN', 'en_US', 'zh_HK', 'ru_RU', 'ja_JP', 'pt_BR', 'es_ES', 'id_ID', 'ko_KR', 'fr_FR'];
+export const ALL_LOCALES = 'all';
 
 export default function devSingleLocale(activeLocale: string) {
-  const active = LANGS.includes(activeLocale) ? activeLocale : 'zh_CN';
+  const loadAll = activeLocale === ALL_LOCALES;
+  const active = LANGS.includes(activeLocale) ? activeLocale : 'en_US';
   const importRe = /import\s+(\w+)\s+from\s+'\.\/(\w+)';/g;
 
   return {
@@ -25,6 +30,7 @@ export default function devSingleLocale(activeLocale: string) {
     enforce: 'pre' as const,
     apply: 'serve' as const,
     transform(code: string, id: string) {
+      if (loadAll) return null;
       const clean = id.split('?')[0];
       if (!/\/(locale|locales)\/index\.(ts|js)$/.test(clean)) return null;
       let changed = false;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -52,11 +52,14 @@ let language = detectBrowserLanguage();
 if (localStorageLanguage && _.includes(languages, localStorageLanguage)) {
   language = localStorageLanguage;
 }
-// 开发环境仅加载单一语言（见 plugins/vite-plugin-dev-locale），此处需与之对齐，
-// 否则运行时语言与已加载语言不一致会显示成翻译 key。可用 VITE_DEV_LOCALE 指定，默认 zh_CN。
+// 开发环境默认仅加载单一语言（见 plugins/vite-plugin-dev-locale），此处需与之对齐，
+// 否则运行时语言与已加载语言不一致会显示成翻译 key。可用 VITE_DEV_LOCALE 指定，默认 en_US；
+// 设为 all 时全部语言真实加载，沿用浏览器/localStorage 的语言，不再强制覆盖。
 if (import.meta.env.DEV) {
   const devLocale = import.meta.env.VITE_DEV_LOCALE as string | undefined;
-  language = devLocale && _.includes(languages, devLocale) ? devLocale : 'zh_CN';
+  if (devLocale !== 'all') {
+    language = devLocale && _.includes(languages, devLocale) ? devLocale : 'en_US';
+  }
 }
 
 function getI18nextTranslations() {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,7 +58,7 @@ export default defineConfig(({ mode }) => {
     base: baseName + '/',
     plugins: [
       lazyToEagerOnBuild(),
-      devSingleLocale(env.VITE_DEV_LOCALE || 'zh_CN'),
+      devSingleLocale(env.VITE_DEV_LOCALE || 'en_US'),
       react(),
       svgr({
         svgrOptions: {


### PR DESCRIPTION
## Summary

- Add an `all` mode to the dev-locale Vite plugin (`VITE_DEV_LOCALE=all`): no locale trimming, every language loads for real, so the in-app language switcher works during `npm run dev`.
- Align `src/i18n.ts` with it: in `all` mode the runtime keeps the browser / localStorage language instead of forcing the dev locale.
- Sync the plugin language list with `src/i18n.ts`. `pt_BR`, `es_ES`, `id_ID`, `ko_KR`, `fr_FR` were missing from the plugin, so they were never trimmed in dev.
- Switch the default single dev locale from `zh_CN` to `en_US`.
- Document the new default and the `all` option in README.

## Behavior

| `VITE_DEV_LOCALE` | Loaded | Displayed language |
|---|---|---|
| unset | `en_US` only | English |
| a specific locale, e.g. `zh_CN` | that locale only | that locale |
| `all` | all 10 locales | browser / localStorage, switchable in UI |

Production builds are unaffected (`apply: 'serve'`).

## Test plan

- [x] Started the dev server with `VITE_DEV_LOCALE=all` and fetched a transformed `locale/index.ts`: all 10 language imports are preserved, `import.meta.env.VITE_DEV_LOCALE` is `all`.
- [x] Started the dev server with no env: only `en_US` is imported, the other 9 languages become `{}`.
- [x] Started the dev server with `VITE_DEV_LOCALE=zh_CN` (and `en_US`): only that language is imported, including the 5 previously untrimmed locales.
- [x] `prettier --check` passes on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for 10 development locales, including Portuguese, Spanish, Indonesian, Korean, and French.
  * Added an `all` development locale mode that enables switching freely between supported languages in the UI.

* **Documentation**
  * Updated development locale guidance, including the English default and configuration examples.
  * Documented the trade-off that loading all locales may increase module requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->