### PR TITLE
feat(iotdb): support table-model RPC settings and per-query databases

### DIFF
--- a/src/pages/datasource/Datasources/iotdb/Detail.tsx
+++ b/src/pages/datasource/Datasources/iotdb/Detail.tsx
@@ -22,6 +22,23 @@ export default function Index(props: Props) {
           </Col>
         </Row>
       </div>
+      <div className='page-title'>RPC / Table Model</div>
+      <div className='flash-cat-block'>
+        <Row gutter={16}>
+          <Col span={8}>RPC address：</Col>
+          <Col span={8}>Default database：</Col>
+          <Col span={8}>Query timeout：</Col>
+          <Col span={8} className='second-color'>
+            {data?.settings?.['iotdb.rpc_addr'] || 'derived from URL:6667'}
+          </Col>
+          <Col span={8} className='second-color'>
+            {data?.settings?.['iotdb.database'] || '-'}
+          </Col>
+          <Col span={8} className='second-color'>
+            {data?.settings?.['iotdb.timeout'] || data?.http?.timeout || 30000} ms
+          </Col>
+        </Row>
+      </div>
       <div className='page-title'>{t('form.auth')}</div>
       <div className='flash-cat-block'>
         <Row gutter={16}>

--- a/src/pages/datasource/Datasources/iotdb/Form.tsx
+++ b/src/pages/datasource/Datasources/iotdb/Form.tsx
@@ -61,7 +61,7 @@ export default function FormCpt({ action, data, onFinish, submitLoading }: any) 
                 { type: 'number', min: 1, message: 'RPC connection timeout must be at least 1 ms' },
               ]}
             >
-              <InputNumber style={{ width: '100%' }} controls={false} />
+              <InputNumber className='w-full' controls={false} />
             </Form.Item>
           </Col>
           <Col flex='1'>
@@ -74,7 +74,7 @@ export default function FormCpt({ action, data, onFinish, submitLoading }: any) 
                 { type: 'number', min: 1, message: 'RPC query timeout must be at least 1 ms' },
               ]}
             >
-              <InputNumber style={{ width: '100%' }} controls={false} />
+              <InputNumber className='w-full' controls={false} />
             </Form.Item>
           </Col>
         </Row>

--- a/src/pages/datasource/Datasources/iotdb/Form.tsx
+++ b/src/pages/datasource/Datasources/iotdb/Form.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { Form, Card } from 'antd';
+import { Form, Card, Input, InputNumber, Row, Col } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { scrollToFirstError } from '@/utils';
 import Name from '../../components/items/Name';
@@ -37,6 +37,31 @@ export default function FormCpt({ action, data, onFinish, submitLoading }: any) 
       <Card title={t(`${action}_title`)}>
         <Name />
         <HTTP placeholder='http://localhost:18080' />
+        <div className='page-title'>RPC / Table Model</div>
+        <Row gutter={16}>
+          <Col flex='1'>
+            <Form.Item label='RPC address' name={['settings', 'iotdb.rpc_addr']}>
+              <Input placeholder='127.0.0.1:6667' />
+            </Form.Item>
+          </Col>
+          <Col flex='1'>
+            <Form.Item label='Default database' name={['settings', 'iotdb.database']}>
+              <Input placeholder='database_name' />
+            </Form.Item>
+          </Col>
+        </Row>
+        <Row gutter={16}>
+          <Col flex='1'>
+            <Form.Item label='RPC connection timeout (ms)' name={['settings', 'iotdb.dial_timeout']} initialValue={10000} rules={[{ type: 'number', min: 1 }]}>
+              <InputNumber style={{ width: '100%' }} controls={false} />
+            </Form.Item>
+          </Col>
+          <Col flex='1'>
+            <Form.Item label='RPC query timeout (ms)' name={['settings', 'iotdb.timeout']} initialValue={30000} rules={[{ type: 'number', min: 1 }]}>
+              <InputNumber style={{ width: '100%' }} controls={false} />
+            </Form.Item>
+          </Col>
+        </Row>
         <BasicAuth />
         <SkipTLSVerify />
         <Headers />

--- a/src/pages/datasource/Datasources/iotdb/Form.tsx
+++ b/src/pages/datasource/Datasources/iotdb/Form.tsx
@@ -52,12 +52,28 @@ export default function FormCpt({ action, data, onFinish, submitLoading }: any) 
         </Row>
         <Row gutter={16}>
           <Col flex='1'>
-            <Form.Item label='RPC connection timeout (ms)' name={['settings', 'iotdb.dial_timeout']} initialValue={10000} rules={[{ type: 'number', min: 1 }]}>
+            <Form.Item
+              label='RPC connection timeout (ms)'
+              name={['settings', 'iotdb.dial_timeout']}
+              initialValue={10000}
+              rules={[
+                { required: true, message: 'Please enter the RPC connection timeout' },
+                { type: 'number', min: 1, message: 'RPC connection timeout must be at least 1 ms' },
+              ]}
+            >
               <InputNumber style={{ width: '100%' }} controls={false} />
             </Form.Item>
           </Col>
           <Col flex='1'>
-            <Form.Item label='RPC query timeout (ms)' name={['settings', 'iotdb.timeout']} initialValue={30000} rules={[{ type: 'number', min: 1 }]}>
+            <Form.Item
+              label='RPC query timeout (ms)'
+              name={['settings', 'iotdb.timeout']}
+              initialValue={30000}
+              rules={[
+                { required: true, message: 'Please enter the RPC query timeout' },
+                { type: 'number', min: 1, message: 'RPC query timeout must be at least 1 ms' },
+              ]}
+            >
               <InputNumber style={{ width: '100%' }} controls={false} />
             </Form.Item>
           </Col>

--- a/src/plugins/iotdb/AlertRule/Queries/GraphPreview.tsx
+++ b/src/plugins/iotdb/AlertRule/Queries/GraphPreview.tsx
@@ -49,8 +49,11 @@ export default function GraphPreview({ cate, datasourceValue, query }) {
         query: _.map([query], (q) => {
           return {
             query: q.query,
+            database: q.database,
             keys: {
-              metricKey: _.isArray(q.keys?.metricKey) ? _.join(q.keys?.metricKey, ' ') : q.keys?.metricKey,
+              valueKey: _.isArray(q.keys?.valueKey)
+                ? _.join(q.keys?.valueKey, ' ')
+                : q.keys?.valueKey || (_.isArray(q.keys?.metricKey) ? _.join(q.keys?.metricKey, ' ') : q.keys?.metricKey),
               labelKey: _.isArray(q.keys?.labelKey) ? _.join(q.keys?.labelKey, ' ') : q.keys?.labelKey,
               timeKey: q.keys?.timeKey,
               timeFormat: q.keys?.timeFormat,
@@ -85,7 +88,7 @@ export default function GraphPreview({ cate, datasourceValue, query }) {
     if (visible) {
       fetchData();
     }
-  }, [JSON.stringify(range)]);
+  }, [visible, datasourceValue, cate, query, JSON.stringify(range)]);
 
   return (
     <div ref={divRef}>

--- a/src/plugins/iotdb/AlertRule/Queries/GraphPreview.tsx
+++ b/src/plugins/iotdb/AlertRule/Queries/GraphPreview.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import TimeRangePicker, { IRawTimeRange, parseRange } from '@/components/TimeRangePicker';
 import Timeseries from '@/pages/dashboard/Renderer/Renderer/Timeseries';
 import { getDsQuery } from '../../services';
-import { getSerieName } from '../../utils';
+import { getSerieName, getValueKey } from '../../utils';
 
 export default function GraphPreview({ cate, datasourceValue, query }) {
   const { t } = useTranslation('db_iotdb');
@@ -51,9 +51,7 @@ export default function GraphPreview({ cate, datasourceValue, query }) {
             query: q.query,
             database: q.database,
             keys: {
-              valueKey: _.isArray(q.keys?.valueKey)
-                ? _.join(q.keys?.valueKey, ' ')
-                : q.keys?.valueKey || (_.isArray(q.keys?.metricKey) ? _.join(q.keys?.metricKey, ' ') : q.keys?.metricKey),
+              valueKey: getValueKey(q.keys),
               labelKey: _.isArray(q.keys?.labelKey) ? _.join(q.keys?.labelKey, ' ') : q.keys?.labelKey,
               timeKey: q.keys?.timeKey,
               timeFormat: q.keys?.timeFormat,
@@ -137,7 +135,6 @@ export default function GraphPreview({ cate, datasourceValue, query }) {
           ghost
           onClick={() => {
             if (!visible) {
-              fetchData();
               setVisible(true);
             }
           }}

--- a/src/plugins/iotdb/AlertRule/Queries/index.tsx
+++ b/src/plugins/iotdb/AlertRule/Queries/index.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Form, Space, Row, Col, InputNumber, Select, Tooltip, Button } from 'antd';
+import { Form, Space, Row, Col, Input, InputNumber, Select, Tooltip, Button } from 'antd';
 import { PlusOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import { WandSparkles } from 'lucide-react';
 import _ from 'lodash';
@@ -100,6 +100,13 @@ export default function IotDBAlertRuleQueries({ form, prefixField = {}, fullPref
                               );
                             }}
                           />
+                        </Form.Item>
+                      </InputGroupWithFormItem>
+                    </Col>
+                    <Col flex='180px'>
+                      <InputGroupWithFormItem label='Database'>
+                        <Form.Item {...field} name={[field.name, 'database']}>
+                          <Input placeholder='Optional' disabled={disabled} />
                         </Form.Item>
                       </InputGroupWithFormItem>
                     </Col>

--- a/src/plugins/iotdb/Dashboard/QueryBuilder.tsx
+++ b/src/plugins/iotdb/Dashboard/QueryBuilder.tsx
@@ -69,12 +69,12 @@ export default function IotDBQueryBuilder({ datasourceValue }) {
                         {...restField}
                         name={[field.name, 'query', 'query']}
                         validateTrigger={['onBlur']}
-                          rules={[
-                            {
-                              required: true,
-                              message: t('db_iotdb:query.query_msg'),
-                            },
-                          ]}
+                        rules={[
+                          {
+                            required: true,
+                            message: t('db_iotdb:query.query_msg'),
+                          },
+                        ]}
                         style={{ flex: 1 }}
                       >
                         <Input />
@@ -103,6 +103,13 @@ export default function IotDBQueryBuilder({ datasourceValue }) {
                           }}
                         />
                       </div>
+                    </Col>
+                  </Row>
+                  <Row gutter={10}>
+                    <Col flex='auto'>
+                      <Form.Item label='Database' {...restField} name={[field.name, 'query', 'database']}>
+                        <Input placeholder='Optional; uses datasource default database' />
+                      </Form.Item>
                     </Col>
                   </Row>
                   <Row gutter={10}>

--- a/src/plugins/iotdb/Dashboard/datasource.tsx
+++ b/src/plugins/iotdb/Dashboard/datasource.tsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import { IRawTimeRange, parseRange } from '@/components/TimeRangePicker';
 import { DatasourceCateEnum } from '@/utils/constant';
 import { getDsQuery } from '../services';
+import replaceTemplateVariables from '@/pages/dashboard/Variables/utils/replaceTemplateVariables';
 import replaceExpressionBracket from '@/pages/dashboard/Renderer/utils/replaceExpressionBracket';
 import { getSerieName } from '../utils';
 import { N9E_PATHNAME } from '@/utils/constant';
@@ -24,7 +25,7 @@ interface Result {
 }
 
 export default async function iotdbQuery(options: IOptions): Promise<Result> {
-  const { time, targets, datasourceValue, queryOptionsTime } = options;
+  const { time, targets, datasourceValue, queryOptionsTime, scopedVars } = options;
   if (!time.start) return Promise.resolve({ series: [] });
   const parsedRange = parseRange(time);
   const series: any[] = [];
@@ -41,12 +42,17 @@ export default async function iotdbQuery(options: IOptions): Promise<Result> {
       datasource_id: datasourceValue,
       query: _.map(targets, (target) => {
         const query: any = target.query || {};
+        const queryText = replaceTemplateVariables(query.query, {
+          range: queryOptionsTime ?? time,
+          scopedVars,
+        });
         return {
           from: start,
           to: end,
-          query: query.query,
+          database: query.database,
+          query: queryText,
           keys: {
-            metricKey: _.join(query.keys?.metricKey, ' '),
+            valueKey: _.join(query.keys?.valueKey || query.keys?.metricKey, ' '),
             labelKey: _.join(query.keys?.labelKey, ' '),
             timeKey: query.keys?.timeKey,
             timeFormat: query.keys?.timeFormat,

--- a/src/plugins/iotdb/Dashboard/datasource.tsx
+++ b/src/plugins/iotdb/Dashboard/datasource.tsx
@@ -5,7 +5,7 @@ import { DatasourceCateEnum } from '@/utils/constant';
 import { getDsQuery } from '../services';
 import replaceTemplateVariables from '@/pages/dashboard/Variables/utils/replaceTemplateVariables';
 import replaceExpressionBracket from '@/pages/dashboard/Renderer/utils/replaceExpressionBracket';
-import { getSerieName } from '../utils';
+import { getSerieName, getValueKey } from '../utils';
 import { N9E_PATHNAME } from '@/utils/constant';
 
 interface IOptions {
@@ -52,7 +52,7 @@ export default async function iotdbQuery(options: IOptions): Promise<Result> {
           database: query.database,
           query: queryText,
           keys: {
-            valueKey: _.join(query.keys?.valueKey || query.keys?.metricKey, ' '),
+            valueKey: getValueKey(query.keys),
             labelKey: _.join(query.keys?.labelKey, ' '),
             timeKey: query.keys?.timeKey,
             timeFormat: query.keys?.timeFormat,

--- a/src/plugins/iotdb/Explorer/Graph.tsx
+++ b/src/plugins/iotdb/Explorer/Graph.tsx
@@ -28,6 +28,7 @@ export default function Graph(props: Props) {
   const range = Form.useWatch(['query', 'range'], form);
   const keys = Form.useWatch(['query', 'keys'], form);
   const query = Form.useWatch(['query', 'query'], form);
+  const database = Form.useWatch(['query', 'database'], form);
   const [highLevelConfig, setHighLevelConfig] = useState({
     shared: true,
     sharedSortDirection: 'desc',
@@ -69,8 +70,9 @@ export default function Graph(props: Props) {
             query,
             from: start,
             to: end,
+            database,
             keys: {
-              metricKey: _.join(keys?.metricKey, ' '),
+              valueKey: _.join(keys?.valueKey || keys?.metricKey, ' '),
               labelKey: _.join(keys?.labelKey, ' '),
               timeKey: keys?.timeKey,
               timeFormat: keys?.timeFormat,
@@ -99,7 +101,7 @@ export default function Graph(props: Props) {
           setRefreshFlag();
         });
     }
-  }, [datasourceCate, datasourceValue, JSON.stringify(range), JSON.stringify(keys), query, refreshFlag]);
+  }, [datasourceCate, datasourceValue, JSON.stringify(range), JSON.stringify(keys), query, database, refreshFlag]);
 
   return (
     <div className='explorer-graph-container'>

--- a/src/plugins/iotdb/Explorer/Graph.tsx
+++ b/src/plugins/iotdb/Explorer/Graph.tsx
@@ -9,7 +9,7 @@ import { DatasourceCateEnum } from '@/utils/constant';
 import Timeseries from '@/pages/dashboard/Renderer/Renderer/Timeseries';
 import LineGraphStandardOptions from '@/components/PromGraphCpt/components/GraphStandardOptions';
 import AdvancedSettings from '../components/AdvancedSettings';
-import { getSerieName } from '../utils';
+import { getSerieName, getValueKey } from '../utils';
 import { getDsQuery } from '../services';
 import { cacheDefaultValues } from './index';
 
@@ -72,7 +72,7 @@ export default function Graph(props: Props) {
             to: end,
             database,
             keys: {
-              valueKey: _.join(keys?.valueKey || keys?.metricKey, ' '),
+              valueKey: getValueKey(keys),
               labelKey: _.join(keys?.labelKey, ' '),
               timeKey: keys?.timeKey,
               timeFormat: keys?.timeFormat,

--- a/src/plugins/iotdb/Explorer/QueryBuilder.tsx
+++ b/src/plugins/iotdb/Explorer/QueryBuilder.tsx
@@ -48,6 +48,11 @@ export default function QueryBuilder(props: Props) {
             />
           </Form.Item>
         </InputGroupWithFormItem>
+        <InputGroupWithFormItem label='Database'>
+          <Form.Item name={['query', 'database']}>
+            <Input placeholder='Optional; uses datasource default database' />
+          </Form.Item>
+        </InputGroupWithFormItem>
         <Form.Item name={['query', 'range']} initialValue={{ start: 'now-1h', end: 'now' }}>
           <TimeRangePicker />
         </Form.Item>

--- a/src/plugins/iotdb/Explorer/Table.tsx
+++ b/src/plugins/iotdb/Explorer/Table.tsx
@@ -25,6 +25,7 @@ export default function TableCpt(props: Props) {
   const range = Form.useWatch(['query', 'range'], form);
   const keys = Form.useWatch(['query', 'keys'], form);
   const query = Form.useWatch(['query', 'query'], form);
+  const database = Form.useWatch(['query', 'database'], form);
 
   useEffect(() => {
     if (datasourceCate && datasourceValue && query && range && refreshFlag) {
@@ -38,6 +39,7 @@ export default function TableCpt(props: Props) {
         query: [
           {
             query,
+            database,
             from: start,
             to: end,
             keys: keys || {},
@@ -68,7 +70,7 @@ export default function TableCpt(props: Props) {
           setRefreshFlag();
         });
     }
-  }, [datasourceCate, datasourceValue, JSON.stringify(range), JSON.stringify(keys), query, refreshFlag]);
+  }, [datasourceCate, datasourceValue, JSON.stringify(range), JSON.stringify(keys), query, database, refreshFlag]);
 
   const formatCellValue = (columnName: string, value: any) => {
     if (datasourceCate === DatasourceCateEnum.iotdb && columnName === 'time' && value !== null && value !== undefined) {

--- a/src/plugins/iotdb/services.ts
+++ b/src/plugins/iotdb/services.ts
@@ -53,8 +53,10 @@ export function getDsQuery(
       query: string;
       from: string;
       to: string;
+      database?: string;
       keys: {
-        metricKey: string;
+        valueKey?: string;
+        metricKey?: string;
         labelKey: string;
         timeKey?: string;
         timeFormat: string;
@@ -76,6 +78,7 @@ export function getLogsQuery(
       query: string;
       from: string;
       to: string;
+      database?: string;
       keys: {
         timeFormat: string;
       };

--- a/src/plugins/iotdb/utils.test.ts
+++ b/src/plugins/iotdb/utils.test.ts
@@ -1,0 +1,19 @@
+import { getValueKey } from './utils';
+
+describe('getValueKey', () => {
+  it('falls back to metricKey when valueKey is undefined or empty', () => {
+    expect(getValueKey({ metricKey: ['metric'] })).toBe('metric');
+    expect(getValueKey({ valueKey: [], metricKey: ['metric'] })).toBe('metric');
+    expect(getValueKey({ valueKey: '   ', metricKey: 'metric' })).toBe('metric');
+  });
+
+  it('prefers a non-empty valueKey', () => {
+    expect(getValueKey({ valueKey: 'value', metricKey: 'metric' })).toBe('value');
+    expect(getValueKey({ valueKey: ['value_a', 'value_b'], metricKey: ['metric'] })).toBe('value_a value_b');
+  });
+
+  it('returns an empty string when no key is configured', () => {
+    expect(getValueKey()).toBe('');
+    expect(getValueKey({ valueKey: [], metricKey: [] })).toBe('');
+  });
+});

--- a/src/plugins/iotdb/utils.ts
+++ b/src/plugins/iotdb/utils.ts
@@ -10,3 +10,21 @@ export const getSerieName = (metric: any) => {
 
   return `${metricName}{${_.join(labels, ',')}}`;
 };
+
+type QueryKeys = {
+  valueKey?: string | string[];
+  metricKey?: string | string[];
+};
+
+const normalizeQueryKey = (value?: string | string[]) => {
+  const normalized = Array.isArray(value) ? _.join(value, ' ') : value || '';
+  return normalized.trim();
+};
+
+/**
+ * Returns the configured value key and falls back to the legacy metric key.
+ * Empty arrays and blank strings are treated as missing values.
+ */
+export const getValueKey = (keys?: QueryKeys) => {
+  return normalizeQueryKey(keys?.valueKey) || normalizeQueryKey(keys?.metricKey);
+};


### PR DESCRIPTION
## Summary

This PR updates the Nightingale frontend to support Apache IoTDB 2.x table-model SQL queries with datasource-level and per-query database selection.

It is the frontend part of the migration described in [#3374](https://github.com/ccfos/nightingale/issues/3374), and works together with the backend implementation in [#3375](https://github.com/ccfos/nightingale/pull/3375).

## Changes

- Add IoTDB RPC settings to the datasource form and detail page:
  - RPC address
  - Default database
  - RPC connection timeout
  - RPC query timeout
- Add an optional database field to dashboard, Query Explorer, and alert rule queries.
- Pass the selected database through graph, table, and alert query requests.
- Use the datasource default database when no per-query database is specified.
- Support `valueKey` for IoTDB table-model query results, with fallback to the legacy `metricKey` field for compatibility.
- Expand dashboard template variables before sending IoTDB queries.
- Refresh query results when the selected database or other query parameters change.

## Compatibility

Existing IoTDB dashboards and queries remain compatible. Queries that do not specify a database continue to use the datasource default database, and older payloads using `metricKey` are still accepted.

## Related

- Issue: [#3374](https://github.com/ccfos/nightingale/issues/3374)
- Backend PR: [#3375](https://github.com/ccfos/nightingale/pull/3375)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IoTDB RPC/Table Model settings, including RPC address, default database, and connection/query timeouts.
  * Added optional database selection for IoTDB dashboard queries, alert queries, and Explorer.
  * Added template-variable support for IoTDB queries.
  * Added validation for required query fields and positive timeout values.

* **Bug Fixes**
  * Improved value-key handling when displaying IoTDB query results.
  * Updated graphs and tables to refresh when the selected database changes.
  * Improved graph preview data loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->