### PR TITLE
fix(ai-chat): send the page's own params where the chat reads them

### DIFF
--- a/src/components/AiChatNG/FlashAiButton.test.ts
+++ b/src/components/AiChatNG/FlashAiButton.test.ts
@@ -1,6 +1,14 @@
 import fs from 'fs';
 import path from 'path';
 
+/**
+ * Asserted against the source text rather than by rendering.
+ *
+ * The ENT branch is chosen by `IS_ENT`, which reads `import.meta.env` — not
+ * something this project's jest transform can evaluate — so rendering the
+ * button here would only ever exercise the CE path. What is worth guarding is
+ * the shape handed to the chat, and that is legible in the source.
+ */
 const source = fs.readFileSync(path.join(__dirname, 'FlashAiButton.tsx'), 'utf8');
 
 function extractUseAiEntClickHandler(code: string): string {
@@ -22,17 +30,32 @@ function extractUseAiEntClickHandler(code: string): string {
 
 describe('useAiEntClickHandler', () => {
   const handler = extractUseAiEntClickHandler(source);
+  const customBlock = handler.slice(handler.indexOf('custom:'));
 
   it('forces a drawer overlay so ConfigHost pages on /flashai* can still open chat', () => {
     expect(handler).toMatch(/forceDrawer:\s*true/);
   });
 
-  it('keeps forceDrawer after queryAction spread so call sites cannot wipe it', () => {
-    const customStart = handler.indexOf('custom:');
-    const customBlock = handler.slice(customStart);
-    const spreadAt = customBlock.indexOf('...queryAction');
+  it('spreads the page params themselves, not the wrapper around them', () => {
+    // The chat sends whatever is left in `custom` as page_from.param, a flat bag
+    // beside workspace_id and the firemap keys. Spreading `queryPageFrom` whole
+    // buried the page's own params one level deeper, where nothing reads them —
+    // which is how the metric explorer's data source stopped reaching the model.
+    expect(customBlock).toMatch(/\.\.\.\(queryPageFrom\?\.param \?\? \{\}\)/);
+    expect(customBlock).not.toMatch(/\.\.\.queryPageFrom\s*,/);
+  });
+
+  it('puts the action in the field the chat reads', () => {
+    // Spread flat it arrived as a stray `key`, and its `param` overwrote the
+    // page's own params.
+    expect(customBlock).toMatch(/\.\.\.\(queryAction \? \{ action: queryAction \} : \{\}\)/);
+    expect(customBlock).not.toMatch(/\.\.\.queryAction\s*,/);
+  });
+
+  it('keeps forceDrawer after the spreads so call sites cannot wipe it', () => {
+    const lastSpreadAt = customBlock.lastIndexOf('...(');
     const forceAt = customBlock.search(/forceDrawer:\s*true/);
-    expect(spreadAt).toBeGreaterThanOrEqual(0);
-    expect(forceAt).toBeGreaterThan(spreadAt);
+    expect(lastSpreadAt).toBeGreaterThanOrEqual(0);
+    expect(forceAt).toBeGreaterThan(lastSpreadAt);
   });
 });

--- a/src/components/AiChatNG/FlashAiButton.tsx
+++ b/src/components/AiChatNG/FlashAiButton.tsx
@@ -52,8 +52,17 @@ function useAiEntClickHandler(options?: {
         // content: ' ', // 预填充一个空格，表示新建会话，不然 FlashAI Chat 会报错导致页面崩溃
         prefillOnly: true, // 禁止自动发送消息
         createNew: true,
-        ...queryPageFrom,
-        ...queryAction,
+        // Spread the page's own params, not the wrapper around them. The chat
+        // strips the fields it uses itself and sends everything left over as
+        // page_from.param, alongside workspace_id and the firemap keys — a flat
+        // bag. Passing `queryPageFrom` whole nested that bag one level deeper,
+        // where nothing reads it, so the page's data source never reached the
+        // model. `url` is dropped on purpose: the chat reads the address bar,
+        // which is the same page and stays right across a navigation.
+        ...(queryPageFrom?.param ?? {}),
+        // The action goes in the field the chat actually looks at. Spread flat
+        // it landed as a stray `key`, and its `param` overwrote the page's.
+        ...(queryAction ? { action: queryAction } : {}),
         // After spreads: ConfigHost pages live on /flashai*, where AiChat stays
         // in page mode unless forceDrawer is set (knowledge / scheduled-task).
         forceDrawer: true,

--- a/src/pages/explorer/Prometheus/index.tsx
+++ b/src/pages/explorer/Prometheus/index.tsx
@@ -175,9 +175,12 @@ export default function Prometheus(props: IProps) {
                 param: {
                   datasource_type: 'prometheus',
                   datasource_id: datasourceValue,
-                  // Says which panel the conversation belongs to. Metric.tsx
-                  // already closes the chat when that panel is removed, but
-                  // nothing ever wrote the key it compares against.
+                  // Says which panel the conversation belongs to, so Metric.tsx
+                  // can close the chat when that panel is removed — it has
+                  // always compared this key, but nothing ever wrote it. Only
+                  // reaches that comparison in the open-source build: the
+                  // commercial one replaces App.tsx and never mounts the
+                  // provider the comparison reads from.
                   panelKey,
                 },
               })}

--- a/src/pages/explorer/Prometheus/index.tsx
+++ b/src/pages/explorer/Prometheus/index.tsx
@@ -175,6 +175,10 @@ export default function Prometheus(props: IProps) {
                 param: {
                   datasource_type: 'prometheus',
                   datasource_id: datasourceValue,
+                  // Says which panel the conversation belongs to. Metric.tsx
+                  // already closes the chat when that panel is removed, but
+                  // nothing ever wrote the key it compares against.
+                  panelKey,
                 },
               })}
               queryAction={{


### PR DESCRIPTION
## Why

In the commercial build the chat is srm-fe's, and a page hands it context through `setParamsAiAction`. That side (`srm-fe` `ChatContent/index.tsx`, `formatPageInfo`) strips the fields it uses itself and sends **everything left in `custom`** as `page_from.param` — a flat bag, beside `workspace_id`, `business_id` and the firemap keys.

We were spreading the wrappers instead of their contents:

- `...queryPageFrom` put `{url, param}` in whole, so the page's own params landed a level deeper at `page_from.param.param`, where nothing looks.
- `...queryAction` did the same, so its `param` **overwrote** the page's, and its `key` arrived as a stray field rather than under `action` — which is the field srm-fe actually destructures and re-adds.

The visible consequence: the metric explorer told the model nothing about which data source the user had selected, so it answered from what metric names usually look like. Measured on 106, asking for a host CPU query returned four candidate expressions and this handed back to the user:

> 常见的 label 分组字段可能是 `instance` 或 `hostname`，取决于采集器配置，建议先用下方语句确认。

That data source has no `hostname` label — its host identity label is `ident`.

## What changes

Spread `queryPageFrom.param`, and nest the action under `action`.

`url` is deliberately not carried: the chat sets it from the address bar, which names the same page and stays right across a navigation. Checked every `AiButton` / `CustomAiButtonWrap` call site — all build `queryPageFrom` through `buildPageFrom({param})`, so no caller relied on any top-level field surviving the spread.

Also sends `panelKey`. `Metric.tsx` has always compared it to decide whether removing a panel should close the chat, but nothing ever wrote it, so that comparison could never hold. It reaches that comparison in the open-source build only — the commercial one replaces `App.tsx` and never mounts the provider `Metric.tsx` reads from; the comment says so.

## Testing

`FlashAiButton.test.ts` now pins both halves of the shape. It asserts against source text rather than rendering, because `IS_ENT` reads `import.meta.env` and cannot be evaluated under this project's jest transform — so a rendered test would only ever exercise the CE branch. The file's header says this.

`jest src/components/AiChatNG src/pages/explorer` — 32 passing. `tsc --noEmit` matches `origin/main` exactly (52 pre-existing errors, none in these files).

## Related

The backend half is `flashcatcloud/fc-model-server#210`, which reads these params and delivers the verified query as a card. Neither is useful without the other, but they land independently.

Supersedes `#2305`, which took a different approach (registering an ai-kit page action) that cannot work in the commercial build — the action would register in n9e/fe's runtime while srm-fe's chat reads its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AI chat context handling so page parameters and actions are passed correctly.
  - Preserved drawer behavior when opening AI chat interactions.
  - Prometheus conversations now retain the associated panel context, helping chats identify the panel they belong to.

- **Tests**
  - Updated coverage to verify corrected parameter and action handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->