### PR TITLE
fix(busi-group): cast busi_group_id to number when removing a team

### DIFF
--- a/src/pages/user/business.tsx
+++ b/src/pages/user/business.tsx
@@ -312,7 +312,7 @@ const Resource: React.FC = () => {
                         const params = [
                           {
                             user_group_id: record['user_group'].id,
-                            busi_group_id: teamId,
+                            busi_group_id: _.toNumber(teamId),
                           },
                         ];
                         confirm({


### PR DESCRIPTION
## Problem

Removing a team from a business group fails with a 400 from the backend:

```
json body invalid: json: cannot unmarshal string into Go struct field BusiGroupMember.busi_group_id of type int64
```

Reported in ccfos/nightingale#3373.

## Root cause

On the business group page, `teamId` is initialized from the `?id=` query string, so it is a **string** on that entry path:

```ts
const id = urlQuery.get('id');
const [teamId, setTeamId] = useState<string>(id || '');
```

The remove-team handler put that raw value straight into the request body:

```ts
const params = [{ user_group_id: record['user_group'].id, busi_group_id: teamId }];
```

The backend field `BusiGroupMember.BusiGroupId` is `int64`, and Go's `encoding/json` refuses a quoted number, so the request is rejected before it reaches any business logic.

## Why it does not always reproduce

`teamId` only holds a string when it comes from the URL. Every other assignment carries a number:

- opening `/busi-groups` directly falls back to `data.dat[0].id`
- clicking an item in the flat list uses `item.id`
- selecting a tree node uses `e.node.id`, and `listToTree` preserves the numeric id

So the bug shows up when the page is opened as `/busi-groups?id=N` (the business group tag in the user list opens exactly that URL in a new tab) or when such a URL is refreshed. Calling the API directly with a numeric id works fine, which matches what the reporter observed.

This is not a regression: the same line exists in v8.5.1, v9.0.0 and v9.1.1.

## Fix

Coerce the id with `_.toNumber` before sending it, consistent with the sibling call sites that already do this (`createModal` and `EditBusinessDrawer` both use `parseInt(teamId)`). Only the remove path was missing it, which is why adding a team worked while removing one did not.

## Verification

- `/busi-groups?id=<id>` then remove a team: request body now carries `"busi_group_id": <number>` and the removal succeeds.
- Entering the page without `?id=` and removing a team is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed business-team member deletion requests to correctly process the team identifier, improving request reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->