### PR TITLE
fix(side-menu): invert dark-mode menu icon colors

### DIFF
--- a/src/components/SideMenu/MenuGroup.test.tsx
+++ b/src/components/SideMenu/MenuGroup.test.tsx
@@ -130,9 +130,9 @@ describe('side menu icon colors', () => {
     isBgBlack: false,
   };
 
-  it('uses the theme link color for inactive dark-mode icons and white for active icons', () => {
-    expect(getSideMenuIconColorClass({ ...baseColorOptions, isDarkMode: true })).toBe('text-link');
-    expect(getSideMenuIconColorClass({ ...baseColorOptions, isDarkMode: true, isActive: true })).toBe('text-[#fff]');
+  it('uses white for inactive dark-mode icons and the theme link color for active icons', () => {
+    expect(getSideMenuIconColorClass({ ...baseColorOptions, isDarkMode: true })).toBe('text-[#fff]');
+    expect(getSideMenuIconColorClass({ ...baseColorOptions, isDarkMode: true, isActive: true })).toBe('text-link');
   });
 
   it('preserves the existing colors for light, blue, and custom side menu themes', () => {
@@ -172,7 +172,7 @@ describe('side menu icon colors', () => {
     );
 
     for (const type of ['house', 'icon-ic_search_light', 'flashai', 'dashboard-group']) {
-      expect(container.querySelector(`[data-icon-type='${type}']`)?.parentElement).toHaveClass('text-link');
+      expect(container.querySelector(`[data-icon-type='${type}']`)?.parentElement).toHaveClass('text-[#fff]');
     }
   });
 
@@ -180,7 +180,7 @@ describe('side menu icon colors', () => {
     ['/landing', 'house'],
     ['/flashai', 'flashai'],
     ['/dashboards', 'dashboard-group'],
-  ])('uses white for the active %s icon', (selectedKey, iconType) => {
+  ])('uses the theme link color for the active %s icon', (selectedKey, iconType) => {
     localStorage.removeItem('n9e-dark-mode');
     const list: IMenuItem[] = [
       {
@@ -210,6 +210,6 @@ describe('side menu icon colors', () => {
       </MemoryRouter>,
     );
 
-    expect(container.querySelector(`[data-icon-type='${iconType}']`)?.parentElement).toHaveClass('text-[#fff]');
+    expect(container.querySelector(`[data-icon-type='${iconType}']`)?.parentElement).toHaveClass('text-link');
   });
 });

--- a/src/components/SideMenu/MenuList.tsx
+++ b/src/components/SideMenu/MenuList.tsx
@@ -75,7 +75,7 @@ export function getSideMenuIconColorClass(opts: {
     return isActive ? 'text-[var(--fc-sidemenu-item-active-text)]' : lightInactive;
   }
   if (isDarkMode) {
-    return isActive ? 'text-[#fff]' : 'text-link';
+    return isActive ? 'text-link' : 'text-[#fff]';
   }
   if (isActive) {
     if (isBlueTheme) {


### PR DESCRIPTION
## Summary
- Invert dark-mode sidebar icon colors: inactive white, selected theme link (purple)
- Update SideMenu icon color unit tests to match

## Review
- `/cmt strict` + `/cr`-style review performed; no blockers

## Verification
- `npx jest --testPathPattern='components/SideMenu/MenuGroup.test' --testPathIgnorePatterns='.worktrees' --no-coverage` → 12/12 passed

## Notes/Risks
- Base is `pre` because the `isDarkMode` icon color path exists on `pre` only, not yet on `main`
- `pre` merge step skipped (shipBase ≠ main); this PR targets `pre` directly

Made with [Cursor](https://cursor.com)