### PR TITLE
fix(tables): preserve row position after status changes

### DIFF
--- a/src/components/EnhancedTable/useRowMutation.test.tsx
+++ b/src/components/EnhancedTable/useRowMutation.test.tsx
@@ -1,0 +1,99 @@
+/** @jest-environment jsdom */
+import { act, renderHook } from '@testing-library/react';
+import useRowMutation from './useRowMutation';
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+it.each([
+  [[1], [1]],
+  [[1], [1, 2]],
+  [[1, 2], [2]],
+  [
+    [1, 2],
+    [2, 3],
+  ],
+  [
+    [1, 1],
+    [1, 1],
+  ],
+])('queues overlapping writes %j then %j', async (firstIds, secondIds) => {
+  const { result } = renderHook(useRowMutation);
+  const first = deferred();
+  const second = deferred();
+  const action = jest.fn(() => second.promise);
+  let firstResult!: Promise<void>;
+  let secondResult!: Promise<void>;
+  await act(async () => {
+    firstResult = result.current.run(firstIds, () => first.promise);
+    secondResult = result.current.run(secondIds, action);
+  });
+  expect(action).not.toHaveBeenCalled();
+  expect(result.current.pendingIds).toEqual(new Set([...firstIds, ...secondIds]));
+  await act(async () => {
+    first.resolve();
+    await firstResult;
+  });
+  expect(action).toHaveBeenCalledTimes(1);
+  expect(result.current.pendingIds).toEqual(new Set(secondIds));
+  await act(async () => {
+    second.resolve();
+    await secondResult;
+  });
+  expect(result.current.pendingIds.size).toBe(0);
+});
+
+it('lets disjoint rows finish independently and returns the action value', async () => {
+  const { result } = renderHook(useRowMutation);
+  const first = deferred();
+  let pending!: Promise<void>;
+  await act(async () => {
+    pending = result.current.run([1], () => first.promise);
+    expect(await result.current.run([2], async () => 42)).toBe(42);
+  });
+  expect(result.current.pendingIds).toEqual(new Set([1]));
+  await act(async () => {
+    first.resolve();
+    await pending;
+  });
+});
+
+it('preserves failures and runs queued writes after rejection', async () => {
+  const { result } = renderHook(useRowMutation);
+  const first = deferred();
+  const error = new Error('write failed');
+  let rejected!: Promise<unknown>;
+  let next!: Promise<string>;
+  await act(async () => {
+    rejected = result.current.run([1], () => first.promise).catch((reason) => reason);
+    next = result.current.run([1], async () => 'saved');
+  });
+  await act(async () => {
+    first.reject(error);
+    expect(await rejected).toBe(error);
+    expect(await next).toBe('saved');
+  });
+  expect(result.current.pendingIds.size).toBe(0);
+  await act(async () => {
+    expect(await result.current.run([1], async () => 'again')).toBe('again');
+  });
+});
+
+it('finishes pending writes safely after unmount', async () => {
+  const { result, unmount } = renderHook(useRowMutation);
+  const first = deferred();
+  let pending!: Promise<void>;
+  act(() => {
+    pending = result.current.run([1], () => first.promise);
+  });
+  unmount();
+  first.resolve();
+  await expect(pending).resolves.toBeUndefined();
+});

--- a/src/components/EnhancedTable/useRowMutation.ts
+++ b/src/components/EnhancedTable/useRowMutation.ts
@@ -1,0 +1,22 @@
+import { useRef } from 'react';
+import type { Key } from 'react';
+import { useMemoizedFn, useSafeState } from 'ahooks';
+
+export default function useRowMutation() {
+  const pending = useRef(new Map<Key, Promise<unknown>>());
+  const [pendingIds, setPendingIds] = useSafeState<ReadonlySet<Key>>(new Set());
+  const run = useMemoizedFn(<T>(ids: readonly Key[], action: () => Promise<T>): Promise<T> => {
+    const keys = [...new Set(ids)];
+    const previous = keys.flatMap((key) => (pending.current.has(key) ? [pending.current.get(key)!] : []));
+    const task = Promise.allSettled(previous).then(action);
+    keys.forEach((key) => pending.current.set(key, task));
+    setPendingIds(new Set(pending.current.keys()));
+    return task.finally(() => {
+      keys.forEach((key) => {
+        if (pending.current.get(key) === task) pending.current.delete(key);
+      });
+      setPendingIds(new Set(pending.current.keys()));
+    });
+  });
+  return { run, pendingIds };
+}

--- a/src/pages/alertRules/List/ListNG.tsx
+++ b/src/pages/alertRules/List/ListNG.tsx
@@ -54,6 +54,7 @@ interface Props {
   data: AlertRuleType<any>[];
   loading: boolean;
   setRefreshFlag?: (flag: string) => void;
+  onStatusChange?: (ids: React.Key[], disabled: 0 | 1) => void;
   linkTarget?: string;
   emptyGuide?: React.ReactNode;
   gids?: string;
@@ -98,6 +99,10 @@ export default function AlertRules(props: Props) {
   const [queryValue, setQueryValue] = useState<string | undefined>(defaultFilter.search);
   const [selectRowKeys, setSelectRowKeys] = useState<React.Key[]>([]);
   const [selectedRows, setSelectedRows] = useState<AlertRuleType<any>[]>([]);
+  const updateStatus = (ids: React.Key[], disabled: 0 | 1) => {
+    props.onStatusChange?.(ids, disabled);
+    setSelectedRows((rows) => rows.map((row) => (ids.includes(row.id) ? { ...row, disabled } : row)));
+  };
   const clearSelection = () => {
     setSelectRowKeys([]);
     setSelectedRows([]);
@@ -338,7 +343,7 @@ export default function AlertRules(props: Props) {
                     },
                     record.group_id,
                   ).then(() => {
-                    fetchData();
+                    updateStatus([id], disabled ? 0 : 1);
                   });
                 }}
               />
@@ -494,6 +499,7 @@ export default function AlertRules(props: Props) {
               selectRowKeys,
               selectedRows,
               getList: fetchData,
+              onStatusChange: updateStatus,
               clearSelection,
             })}
           <TableColumnSelect

--- a/src/pages/alertRules/List/ListNG.tsx
+++ b/src/pages/alertRules/List/ListNG.tsx
@@ -601,12 +601,10 @@ export default function AlertRules(props: Props) {
                         Modal.confirm({
                           title: t('common:confirm.delete'),
                           onOk: () => {
-                            return runMutation([record.id], () =>
-                              deleteStrategy([record.id], record.group_id).then(() => {
-                                message.success(t('common:success.delete'));
-                                fetchData();
-                              }),
-                            );
+                            deleteStrategy([record.id], record.group_id).then(() => {
+                              message.success(t('common:success.delete'));
+                              fetchData();
+                            });
                           },
                           onCancel() {},
                         });

--- a/src/pages/alertRules/List/ListNG.tsx
+++ b/src/pages/alertRules/List/ListNG.tsx
@@ -8,6 +8,7 @@ import { useDebounceFn } from 'ahooks';
 import _ from 'lodash';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 
+import useRowMutation from '@/components/EnhancedTable/useRowMutation';
 import { CommonStateContext } from '@/App';
 import { updateAlertRules, deleteStrategy } from '@/services/warning';
 import { allCates, getCateDisplayLabel } from '@/components/AdvancedWrap/utils';
@@ -65,6 +66,7 @@ export default function AlertRules(props: Props) {
   const { t, i18n } = useTranslation('alertRules');
   const { busiGroups, datasourceList, feats } = useContext(CommonStateContext);
   const { hideBusinessGroupColumn, showRowSelection, readonly, headerExtra, data, loading, setRefreshFlag, linkTarget, emptyGuide, gids, groupSwitchCount } = props;
+  const { run: runMutation, pendingIds } = useRowMutation();
   const history = useHistory();
   const location = useLocation();
   let defaultFilter = {} as Filter;
@@ -330,21 +332,24 @@ export default function AlertRules(props: Props) {
             width: 80,
             render: (disabled, record) => (
               <Switch
+                loading={pendingIds.has(record.id)}
                 checked={disabled === AlertRuleStatus.Enable}
                 size='small'
                 onChange={() => {
                   const { id, disabled } = record;
-                  updateAlertRules(
-                    {
-                      ids: [id],
-                      fields: {
-                        disabled: !disabled ? 1 : 0,
+                  runMutation([id], () =>
+                    updateAlertRules(
+                      {
+                        ids: [id],
+                        fields: {
+                          disabled: !disabled ? 1 : 0,
+                        },
                       },
-                    },
-                    record.group_id,
-                  ).then(() => {
-                    updateStatus([id], disabled ? 0 : 1);
-                  });
+                      record.group_id,
+                    ).then(() => {
+                      updateStatus([id], disabled ? 0 : 1);
+                    }),
+                  );
                 }}
               />
             ),
@@ -498,6 +503,8 @@ export default function AlertRules(props: Props) {
             React.cloneElement(headerExtra, {
               selectRowKeys,
               selectedRows,
+              runMutation,
+              pendingIds,
               getList: fetchData,
               onStatusChange: updateStatus,
               clearSelection,
@@ -594,10 +601,12 @@ export default function AlertRules(props: Props) {
                         Modal.confirm({
                           title: t('common:confirm.delete'),
                           onOk: () => {
-                            deleteStrategy([record.id], record.group_id).then(() => {
-                              message.success(t('common:success.delete'));
-                              fetchData();
-                            });
+                            return runMutation([record.id], () =>
+                              deleteStrategy([record.id], record.group_id).then(() => {
+                                message.success(t('common:success.delete'));
+                                fetchData();
+                              }),
+                            );
                           },
                           onCancel() {},
                         });

--- a/src/pages/alertRules/List/MoreOperations.tsx
+++ b/src/pages/alertRules/List/MoreOperations.tsx
@@ -107,13 +107,11 @@ export default function MoreOperations(props: MoreOperationsProps) {
                     Modal.confirm({
                       title: t('batch.delete_confirm'),
                       onOk: () => {
-                        return runMutation(selectRowKeys as number[], () =>
-                          deleteStrategy(selectRowKeys as number[], bgid!).then(() => {
-                            message.success(t('batch.delete_success'));
-                            clearSelection?.();
-                            getAlertRules();
-                          }),
-                        );
+                        deleteStrategy(selectRowKeys as number[], bgid!).then(() => {
+                          message.success(t('batch.delete_success'));
+                          clearSelection?.();
+                          getAlertRules();
+                        });
                       },
                     });
                   } else {

--- a/src/pages/alertRules/List/MoreOperations.tsx
+++ b/src/pages/alertRules/List/MoreOperations.tsx
@@ -35,6 +35,7 @@ interface MoreOperationsProps {
   selectRowKeys: React.Key[];
   selectedRows: any[];
   getAlertRules: () => void;
+  onStatusChange?: (ids: React.Key[], disabled: 0 | 1) => void;
   clearSelection?: () => void;
 }
 
@@ -256,7 +257,11 @@ export default function MoreOperations(props: MoreOperationsProps) {
               if (!res.err) {
                 message.success(t('common:success.modify'));
                 clearSelection?.();
-                getAlertRules();
+                if (Object.keys(fieldsData).length === 1 && (fieldsData.disabled === 0 || fieldsData.disabled === 1)) {
+                  props.onStatusChange?.(selectRowKeys, fieldsData.disabled);
+                } else {
+                  getAlertRules();
+                }
                 setisModalVisible(false);
               } else {
                 message.error(res.err);

--- a/src/pages/alertRules/List/MoreOperations.tsx
+++ b/src/pages/alertRules/List/MoreOperations.tsx
@@ -21,6 +21,7 @@ import { Dropdown, Button, Modal, message } from 'antd';
 import { DownOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { json2csv } from 'json-2-csv';
+import useRowMutation from '@/components/EnhancedTable/useRowMutation';
 import { deleteStrategy, updateAlertRules, updateServiceCal, updateNotifyChannels } from '@/services/warning';
 import { CommonStateContext } from '@/App';
 import Export from './Export';
@@ -30,6 +31,8 @@ import CloneToBgids from './CloneToBgids';
 import { downloadFile } from './utils';
 
 interface MoreOperationsProps {
+  runMutation: ReturnType<typeof useRowMutation>['run'];
+  pendingIds: ReadonlySet<React.Key>;
   bgid?: number; // 如果 isLeaf 为 true，则 bgid 必须存在
   isLeaf: boolean;
   selectRowKeys: React.Key[];
@@ -70,6 +73,7 @@ const ignoreFields = [
 export default function MoreOperations(props: MoreOperationsProps) {
   const { t } = useTranslation('alertRules');
   const { bgid, isLeaf, selectRowKeys, selectedRows, getAlertRules, clearSelection } = props;
+  const { runMutation, pendingIds } = props;
   const [isModalVisible, setisModalVisible] = useState<boolean>(false);
   const { isPlus, busiGroups } = useContext(CommonStateContext);
 
@@ -103,11 +107,13 @@ export default function MoreOperations(props: MoreOperationsProps) {
                     Modal.confirm({
                       title: t('batch.delete_confirm'),
                       onOk: () => {
-                        deleteStrategy(selectRowKeys as number[], bgid!).then(() => {
-                          message.success(t('batch.delete_success'));
-                          clearSelection?.();
-                          getAlertRules();
-                        });
+                        return runMutation(selectRowKeys as number[], () =>
+                          deleteStrategy(selectRowKeys as number[], bgid!).then(() => {
+                            message.success(t('batch.delete_success'));
+                            clearSelection?.();
+                            getAlertRules();
+                          }),
+                        );
                       },
                     });
                   } else {
@@ -197,7 +203,7 @@ export default function MoreOperations(props: MoreOperationsProps) {
         }
         trigger={['click']}
       >
-        <Button onClick={(e) => e.stopPropagation()}>
+        <Button disabled={selectRowKeys.some((id) => pendingIds.has(id))} onClick={(e) => e.stopPropagation()}>
           {t('common:btn.more')}
           <DownOutlined
             style={{
@@ -210,63 +216,65 @@ export default function MoreOperations(props: MoreOperationsProps) {
         isModalVisible={isModalVisible}
         editModalFinish={async (isOk, fieldsData) => {
           if (isOk && bgid) {
-            if (isPlus && fieldsData?.service_cal_configs) {
-              const res = await updateServiceCal(
-                {
-                  ids: selectRowKeys,
-                  service_cal_configs: fieldsData?.service_cal_configs || [],
-                },
-                bgid,
-              );
-              if (!res.err) {
-                message.success(t('common:success.modify'));
-                clearSelection?.();
-                getAlertRules();
-                setisModalVisible(false);
-              } else {
-                message.error(res.err);
-              }
-            } else if (isPlus && fieldsData?.notify_channels) {
-              const res = await updateNotifyChannels(
-                {
-                  ids: selectRowKeys,
-                  notify_channels: _.split(fieldsData?.notify_channels, ' ') || [],
-                  custom_notify_tpl: fieldsData?.custom_notify_tpl || {},
-                },
-                bgid,
-              );
-              if (!res.err) {
-                message.success(t('common:success.modify'));
-                clearSelection?.();
-                getAlertRules();
-                setisModalVisible(false);
-              } else {
-                message.error(res.err);
-              }
-            } else {
-              const action = fieldsData.action;
-              delete fieldsData.action;
-              const res = await updateAlertRules(
-                {
-                  ids: selectRowKeys,
-                  fields: fieldsData,
-                  action,
-                },
-                bgid,
-              );
-              if (!res.err) {
-                message.success(t('common:success.modify'));
-                clearSelection?.();
-                if (Object.keys(fieldsData).length === 1 && (fieldsData.disabled === 0 || fieldsData.disabled === 1)) {
-                  props.onStatusChange?.(selectRowKeys, fieldsData.disabled);
-                } else {
+            return runMutation(selectRowKeys, async () => {
+              if (isPlus && fieldsData?.service_cal_configs) {
+                const res = await updateServiceCal(
+                  {
+                    ids: selectRowKeys,
+                    service_cal_configs: fieldsData?.service_cal_configs || [],
+                  },
+                  bgid,
+                );
+                if (!res.err) {
+                  message.success(t('common:success.modify'));
+                  clearSelection?.();
                   getAlertRules();
+                  setisModalVisible(false);
+                } else {
+                  message.error(res.err);
                 }
-                setisModalVisible(false);
+              } else if (isPlus && fieldsData?.notify_channels) {
+                const res = await updateNotifyChannels(
+                  {
+                    ids: selectRowKeys,
+                    notify_channels: _.split(fieldsData?.notify_channels, ' ') || [],
+                    custom_notify_tpl: fieldsData?.custom_notify_tpl || {},
+                  },
+                  bgid,
+                );
+                if (!res.err) {
+                  message.success(t('common:success.modify'));
+                  clearSelection?.();
+                  getAlertRules();
+                  setisModalVisible(false);
+                } else {
+                  message.error(res.err);
+                }
               } else {
-                message.error(res.err);
+                const action = fieldsData.action;
+                delete fieldsData.action;
+                const res = await updateAlertRules(
+                  {
+                    ids: selectRowKeys,
+                    fields: fieldsData,
+                    action,
+                  },
+                  bgid,
+                );
+                if (!res.err) {
+                  message.success(t('common:success.modify'));
+                  clearSelection?.();
+                  if (Object.keys(fieldsData).length === 1 && (fieldsData.disabled === 0 || fieldsData.disabled === 1)) {
+                    props.onStatusChange?.(selectRowKeys, fieldsData.disabled);
+                  } else {
+                    getAlertRules();
+                  }
+                  setisModalVisible(false);
+                } else {
+                  message.error(res.err);
+                }
               }
-            }
+            });
           } else {
             setisModalVisible(false);
           }

--- a/src/pages/alertRules/List/index.tsx
+++ b/src/pages/alertRules/List/index.tsx
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import { Space, Button } from 'antd';
 import { useMemoizedFn, useRequest } from 'ahooks';
 
+import useRowMutation from '@/components/EnhancedTable/useRowMutation';
 import { CommonStateContext } from '@/App';
 import { getBusiGroupsAlertRules } from '@/services/warning';
 import EmptyGuide from '@/components/EmptyGuide';
@@ -23,6 +24,8 @@ interface ListProps {
 function HeaderExtra(
   props: ListProps & {
     selectRowKeys?: React.Key[];
+    runMutation?: ReturnType<typeof useRowMutation>['run'];
+    pendingIds?: ReadonlySet<React.Key>;
     selectedRows?: AlertRuleType<any>[];
     getList?: () => void;
     onStatusChange?: (ids: React.Key[], disabled: 0 | 1) => void;
@@ -66,6 +69,8 @@ function HeaderExtra(
       )}
       {getList && (
         <MoreOperations
+          runMutation={props.runMutation!}
+          pendingIds={props.pendingIds!}
           bgid={businessGroup.id}
           isLeaf={!!(businessGroup.isLeaf && businessGroup.id && gids !== '-2')}
           selectRowKeys={selectRowKeys}

--- a/src/pages/alertRules/List/index.tsx
+++ b/src/pages/alertRules/List/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import _ from 'lodash';
 import { Space, Button } from 'antd';
+import { useMemoizedFn, useRequest } from 'ahooks';
 
 import { CommonStateContext } from '@/App';
 import { getBusiGroupsAlertRules } from '@/services/warning';
@@ -84,19 +85,26 @@ export default function List(props: ListProps) {
   const history = useHistory();
   const { gids, groupSwitchCount } = props;
   const [refreshFlag, setRefreshFlag] = useState<string>(_.uniqueId('refresh_'));
-  const [data, setData] = useState<AlertRuleType<any>[]>([]);
-  const [loading, setLoading] = useState(false);
-  const fetchData = () => {
-    setLoading(true);
-    const ids = gids === '-2' ? undefined : gids;
-    getBusiGroupsAlertRules(ids)
-      .then((res) => {
-        setData(res.dat || []);
-      })
-      .finally(() => {
-        setLoading(false);
-      });
-  };
+  const {
+    data = [],
+    loading,
+    run: fetchData,
+    cancel,
+    mutate,
+  } = useRequest(
+    async () => {
+      const ids = gids === '-2' ? undefined : gids;
+      const res = await getBusiGroupsAlertRules(ids);
+      return res.dat || [];
+    },
+    { manual: true },
+  );
+  const updateStatus = useMemoizedFn((ids: React.Key[], disabled: 0 | 1) => {
+    cancel();
+    mutate((rows) => rows?.map((row) => (ids.includes(row.id) ? { ...row, disabled } : row)));
+    // A pending refresh or group change still needs its latest server result.
+    if (loading) fetchData();
+  });
 
   useEffect(() => {
     fetchData();
@@ -118,9 +126,7 @@ export default function List(props: ListProps) {
         data={data}
         loading={loading}
         setRefreshFlag={setRefreshFlag}
-        onStatusChange={(ids, disabled) => {
-          setData((rows) => rows.map((row) => (ids.includes(row.id) ? { ...row, disabled } : row)));
-        }}
+        onStatusChange={updateStatus}
         emptyGuide={
           <EmptyGuide
             title={t('empty_guide.title')}

--- a/src/pages/alertRules/List/index.tsx
+++ b/src/pages/alertRules/List/index.tsx
@@ -24,6 +24,7 @@ function HeaderExtra(
     selectRowKeys?: React.Key[];
     selectedRows?: AlertRuleType<any>[];
     getList?: () => void;
+    onStatusChange?: (ids: React.Key[], disabled: 0 | 1) => void;
     clearSelection?: () => void;
   },
 ) {
@@ -69,6 +70,7 @@ function HeaderExtra(
           selectRowKeys={selectRowKeys}
           selectedRows={selectedRows}
           getAlertRules={getList}
+          onStatusChange={props.onStatusChange}
           clearSelection={clearSelection}
         />
       )}
@@ -116,6 +118,9 @@ export default function List(props: ListProps) {
         data={data}
         loading={loading}
         setRefreshFlag={setRefreshFlag}
+        onStatusChange={(ids, disabled) => {
+          setData((rows) => rows.map((row) => (ids.includes(row.id) ? { ...row, disabled } : row)));
+        }}
         emptyGuide={
           <EmptyGuide
             title={t('empty_guide.title')}

--- a/src/pages/alertRules/List/statusMutationOrder.test.tsx
+++ b/src/pages/alertRules/List/statusMutationOrder.test.tsx
@@ -1,0 +1,74 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { readFileSync } from 'fs';
+import path from 'path';
+import ts from 'typescript';
+import useRowMutation from '@/components/EnhancedTable/useRowMutation';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+it('serializes repeated row callbacks before applying the next status', async () => {
+  const file = ts.createSourceFile('ListNG.tsx', readFileSync(path.join(__dirname, 'ListNG.tsx'), 'utf8'), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  let callback = '';
+  function visit(node: ts.Node) {
+    if (ts.isJsxAttribute(node) && node.name.text === 'onChange' && node.getText(file).includes('updateAlertRules(')) {
+      callback = (node.initializer as ts.JsxExpression).expression!.getText(file);
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(file);
+  expect(callback).not.toBe('');
+  const { result } = renderHook(() => useRowMutation());
+  const requests: ReturnType<typeof deferred>[] = [];
+  let serverDisabled = 0;
+  let displayedDisabled = 0;
+  const updateAlertRules = jest.fn((payload: { fields: { disabled: number } }) => {
+    serverDisabled = payload.fields.disabled;
+    const request = deferred();
+    requests.push(request);
+    return request.promise;
+  });
+  const updateStatus = jest.fn((_ids: React.Key[], disabled: number) => {
+    displayedDisabled = disabled;
+  });
+  const code = ts.transpile(`const callback = ${callback};`, { target: ts.ScriptTarget.ES2020 });
+  const createToggle = (disabled: number) =>
+    new Function('record', 'updateAlertRules', 'updateStatus', 'runMutation', `${code}; return callback;`)(
+      { id: 1, disabled, group_id: 1 },
+      updateAlertRules,
+      updateStatus,
+      result.current.run,
+    );
+  const toggle = createToggle(0);
+  await act(async () => {
+    toggle();
+    toggle();
+  });
+  expect(updateAlertRules).toHaveBeenCalledTimes(1);
+  await act(async () => {
+    requests[0].resolve();
+  });
+  expect(updateAlertRules).toHaveBeenCalledTimes(2);
+  expect(displayedDisabled).toBe(1);
+  await act(async () => {
+    createToggle(1)();
+  });
+  expect(updateAlertRules).toHaveBeenCalledTimes(2);
+  await act(async () => {
+    requests[1].resolve();
+  });
+  expect(updateAlertRules).toHaveBeenCalledTimes(3);
+  await act(async () => {
+    requests[2].resolve();
+  });
+  expect(updateStatus).toHaveBeenCalledTimes(3);
+  expect(serverDisabled).toBe(0);
+  expect(displayedDisabled).toBe(serverDisabled);
+});

--- a/src/pages/alertRules/List/statusUpdates.test.tsx
+++ b/src/pages/alertRules/List/statusUpdates.test.tsx
@@ -1,0 +1,93 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import List from './index';
+import { getBusiGroupsAlertRules } from '@/services/warning';
+
+jest.mock('@/App', () => ({ CommonStateContext: require('react').createContext({ businessGroup: {} }) }));
+jest.mock('@/services/warning', () => ({ getBusiGroupsAlertRules: jest.fn() }));
+jest.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+jest.mock('react-router-dom', () => ({ useHistory: () => ({ push: jest.fn() }) }));
+jest.mock('@/components/EmptyGuide', () => () => null);
+jest.mock('@/pages/datasource/components/GuideLandingBanner', () => () => null);
+jest.mock('./MoreOperations', () => () => null);
+jest.mock('./Import', () => () => null);
+jest.mock(
+  './ListNG',
+  () => (props: { data: { id: number; disabled: number }[]; loading: boolean; setRefreshFlag: (flag: string) => void; onStatusChange: (ids: number[], disabled: 0 | 1) => void }) =>
+    (
+      <>
+        <button onClick={() => props.setRefreshFlag(String(Math.random()))}>Refresh</button>
+        <button onClick={() => props.onStatusChange([1], 1)}>Confirm disable</button>
+        <output>{JSON.stringify(props.data)}</output>
+        <span>{props.loading ? 'Loading' : 'Ready'}</span>
+      </>
+    ),
+);
+
+const getRules = jest.mocked(getBusiGroupsAlertRules);
+const enabled = { id: 1, disabled: 0 } as const;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+it('keeps a confirmed status when a refresh started earlier finishes later', async () => {
+  getRules.mockResolvedValueOnce({ dat: [enabled] });
+  render(<List gids='1' />);
+  await screen.findByText('Ready');
+  const request = deferred<{ dat: (typeof enabled)[] }>();
+  getRules.mockReturnValueOnce(request.promise);
+  fireEvent.click(screen.getByText('Refresh'));
+  getRules.mockResolvedValueOnce({ dat: [{ ...enabled, disabled: 1 }] });
+  fireEvent.click(screen.getByText('Confirm disable'));
+  await act(async () => {
+    request.resolve({ dat: [enabled] });
+  });
+  expect(screen.getByRole('status')).toHaveTextContent('"disabled":1');
+  expect(screen.getByText('Ready')).toBeInTheDocument();
+});
+
+it('does not restore the previous group when its response arrives last', async () => {
+  const old = deferred<{ dat: { id: number; disabled: number }[] }>();
+  getRules.mockReturnValueOnce(old.promise);
+  const { rerender } = render(<List gids='1' />);
+  getRules.mockResolvedValueOnce({ dat: [{ id: 2, disabled: 0 }] });
+  rerender(<List gids='2' />);
+  await screen.findByText('Ready');
+  await act(async () => {
+    old.resolve({ dat: [enabled] });
+  });
+  expect(screen.getByRole('status')).toHaveTextContent('"id":2');
+  expect(screen.getByRole('status')).not.toHaveTextContent('"id":1');
+});
+
+it('does not reload a settled list after an ordinary status update', async () => {
+  getRules.mockResolvedValueOnce({ dat: [enabled] });
+  render(<List gids='1' />);
+  await screen.findByText('Ready');
+  fireEvent.click(screen.getByText('Confirm disable'));
+  expect(screen.getByRole('status')).toHaveTextContent('"disabled":1');
+  expect(getRules).toHaveBeenCalledTimes(1);
+});
+
+it('restarts a pending group query after a status update without restoring the old group', async () => {
+  getRules.mockResolvedValueOnce({ dat: [enabled] });
+  const { rerender } = render(<List gids='1' />);
+  await screen.findByText('Ready');
+  const old = deferred<{ dat: { id: number; disabled: number }[] }>();
+  getRules.mockReturnValueOnce(old.promise);
+  rerender(<List gids='2' />);
+  getRules.mockResolvedValueOnce({ dat: [{ id: 2, disabled: 0 }] });
+  fireEvent.click(screen.getByText('Confirm disable'));
+  await screen.findByText('Ready');
+  await act(async () => {
+    old.resolve({ dat: [enabled] });
+  });
+  expect(getRules).toHaveBeenLastCalledWith('2');
+  expect(screen.getByRole('status')).toHaveTextContent('"id":2');
+});

--- a/src/pages/embeddedProduct/pages/List/index.tsx
+++ b/src/pages/embeddedProduct/pages/List/index.tsx
@@ -99,7 +99,6 @@ export default function Index() {
                 try {
                   await putEmbeddedProductHide(String(record.id), { hide: nextHide });
                   message.success(t('common:success.save'));
-                  fetchData();
                   eventBus.emit(EVENT_KEYS.EMBEDDED_PRODUCT_UPDATED);
                 } catch (e) {
                   setData((prev) => prev.map((item) => (item.id === record.id ? { ...item, hide: prevHide } : item)));

--- a/src/pages/embeddedProduct/pages/List/index.tsx
+++ b/src/pages/embeddedProduct/pages/List/index.tsx
@@ -66,7 +66,7 @@ export default function Index() {
         width: 40,
         className: 'embedded-product-sort-col',
         render: () => {
-          return <DragHandle disabled={saving || pendingIds.size > 0} />;
+          return <DragHandle disabled={saving} />;
         },
       },
       {
@@ -202,13 +202,11 @@ export default function Index() {
                   Modal.confirm({
                     title: t('common:confirm.delete'),
                     onOk: () => {
-                      return runMutation([record.id], () =>
-                        deleteEmbeddedProducts(String(record.id)).then(() => {
-                          message.success(t('common:success.delete'));
-                          fetchData();
-                          eventBus.emit(EVENT_KEYS.EMBEDDED_PRODUCT_UPDATED);
-                        }),
-                      );
+                      return deleteEmbeddedProducts(String(record.id)).then(() => {
+                        message.success(t('common:success.delete'));
+                        fetchData();
+                        eventBus.emit(EVENT_KEYS.EMBEDDED_PRODUCT_UPDATED);
+                      });
                     },
                   });
                 },
@@ -234,21 +232,17 @@ export default function Index() {
                     helperClass='n9e-embedded-products-row-dragging'
                     hideSortableGhost
                     onSortEnd={async ({ oldIndex, newIndex }) => {
-                      if (saving || pendingIds.size > 0 || oldIndex === newIndex) return;
+                      if (saving || oldIndex === newIndex) return;
                       const oldData = data;
                       const newData = arrayMoveImmutable(oldData, oldIndex, newIndex);
                       setData(newData);
                       setSaving(true);
                       try {
-                        await runMutation(
-                          newData.map((item) => item.id),
-                          () =>
-                            putEmbeddedProductsWeights(
-                              newData.map((item, idx) => ({
-                                id: item.id,
-                                weight: idx,
-                              })),
-                            ),
+                        await putEmbeddedProductsWeights(
+                          newData.map((item, idx) => ({
+                            id: item.id,
+                            weight: idx,
+                          })),
                         );
                         message.success(t('common:success.save'));
                         fetchData();

--- a/src/pages/embeddedProduct/pages/List/index.tsx
+++ b/src/pages/embeddedProduct/pages/List/index.tsx
@@ -9,6 +9,7 @@ import { Link } from 'react-router-dom';
 import { SortableContainer, SortableElement, SortableHandle } from 'react-sortable-hoc';
 import { arrayMoveImmutable } from 'array-move';
 
+import useRowMutation from '@/components/EnhancedTable/useRowMutation';
 import { getTeamInfoList } from '@/services/manage';
 import PageLayout from '@/components/pageLayout';
 import EnhancedTable from '@/components/EnhancedTable';
@@ -38,7 +39,7 @@ export default function Index() {
   const [currentRecord, setCurrentRecord] = useState<EmbeddedProductResponse | null>(null);
   const [userGroups, setUserGroups] = useState<{ id: number; name: string }[]>([]);
   const [saving, setSaving] = useState(false);
-  const [hideSavingId, setHideSavingId] = useState<number | null>(null);
+  const { run: runMutation, pendingIds } = useRowMutation();
   const pagination = usePagination({ PAGESIZE_KEY: NS });
 
   const {
@@ -51,7 +52,7 @@ export default function Index() {
       if (res) setData(_.orderBy(res, ['weight', 'id'], ['asc', 'asc']));
     },
   });
-  const confirmHide = useMemoizedFn((id: number, hide: boolean) => {
+  const updateHide = useMemoizedFn((id: number, hide: boolean) => {
     cancel();
     setData((rows) => rows.map((row) => (row.id === id ? { ...row, hide } : row)));
     if (loading) fetchData();
@@ -65,7 +66,7 @@ export default function Index() {
         width: 40,
         className: 'embedded-product-sort-col',
         render: () => {
-          return <DragHandle disabled={saving} />;
+          return <DragHandle disabled={saving || pendingIds.size > 0} />;
         },
       },
       {
@@ -96,28 +97,24 @@ export default function Index() {
         render: (_val, record: EmbeddedProductResponse) => {
           const hide = record.hide ?? true;
           const checked = !hide;
-          const disabled = saving || hideSavingId === record.id;
+          const disabled = saving || pendingIds.has(record.id);
           return (
             <Switch
               size='small'
               checked={checked}
               disabled={disabled}
+              loading={pendingIds.has(record.id)}
               onChange={async (nextChecked) => {
-                if (disabled) return;
-                const prevHide = record.hide ?? true;
                 const nextHide = !nextChecked;
-                setHideSavingId(record.id);
-                setData((prev) => prev.map((item) => (item.id === record.id ? { ...item, hide: nextHide } : item)));
                 try {
-                  await putEmbeddedProductHide(String(record.id), { hide: nextHide });
-                  confirmHide(record.id, nextHide);
-                  message.success(t('common:success.save'));
-                  eventBus.emit(EVENT_KEYS.EMBEDDED_PRODUCT_UPDATED);
+                  await runMutation([record.id], async () => {
+                    await putEmbeddedProductHide(String(record.id), { hide: nextHide });
+                    updateHide(record.id, nextHide);
+                    message.success(t('common:success.save'));
+                    eventBus.emit(EVENT_KEYS.EMBEDDED_PRODUCT_UPDATED);
+                  });
                 } catch (e) {
-                  setData((prev) => prev.map((item) => (item.id === record.id ? { ...item, hide: prevHide } : item)));
                   message.error(t('common:error.save'));
-                } finally {
-                  setHideSavingId(null);
                 }
               }}
             />
@@ -127,7 +124,7 @@ export default function Index() {
       dateColumn({ title: t('common:table.update_at'), dataIndex: 'update_at', unix: true, sortable: true, defaultSortOrder: 'descend' }) as any,
       updateByColumn({ title: t('common:table.update_by'), dataIndex: 'update_by', nickname: 'update_by_nickname' }) as any,
     ];
-  }, [t, userGroups, saving, hideSavingId]);
+  }, [t, userGroups, saving, pendingIds]);
 
   useEffect(() => {
     fetchData();
@@ -139,7 +136,7 @@ export default function Index() {
   const handleModalOk = async (values: EmbeddedProductParams) => {
     try {
       if (currentRecord) {
-        await updateEmbeddedProducts(currentRecord.id.toString(), values);
+        await runMutation([currentRecord.id], () => updateEmbeddedProducts(currentRecord.id.toString(), values));
         message.success(t('common:success.edit'));
       } else {
         await addEmbeddedProducts([values]);
@@ -205,11 +202,13 @@ export default function Index() {
                   Modal.confirm({
                     title: t('common:confirm.delete'),
                     onOk: () => {
-                      return deleteEmbeddedProducts(String(record.id)).then(() => {
-                        message.success(t('common:success.delete'));
-                        fetchData();
-                        eventBus.emit(EVENT_KEYS.EMBEDDED_PRODUCT_UPDATED);
-                      });
+                      return runMutation([record.id], () =>
+                        deleteEmbeddedProducts(String(record.id)).then(() => {
+                          message.success(t('common:success.delete'));
+                          fetchData();
+                          eventBus.emit(EVENT_KEYS.EMBEDDED_PRODUCT_UPDATED);
+                        }),
+                      );
                     },
                   });
                 },
@@ -235,17 +234,21 @@ export default function Index() {
                     helperClass='n9e-embedded-products-row-dragging'
                     hideSortableGhost
                     onSortEnd={async ({ oldIndex, newIndex }) => {
-                      if (saving || oldIndex === newIndex) return;
+                      if (saving || pendingIds.size > 0 || oldIndex === newIndex) return;
                       const oldData = data;
                       const newData = arrayMoveImmutable(oldData, oldIndex, newIndex);
                       setData(newData);
                       setSaving(true);
                       try {
-                        await putEmbeddedProductsWeights(
-                          newData.map((item, idx) => ({
-                            id: item.id,
-                            weight: idx,
-                          })),
+                        await runMutation(
+                          newData.map((item) => item.id),
+                          () =>
+                            putEmbeddedProductsWeights(
+                              newData.map((item, idx) => ({
+                                id: item.id,
+                                weight: idx,
+                              })),
+                            ),
                         );
                         message.success(t('common:success.save'));
                         fetchData();

--- a/src/pages/embeddedProduct/pages/List/index.tsx
+++ b/src/pages/embeddedProduct/pages/List/index.tsx
@@ -1,3 +1,4 @@
+import { useMemoizedFn, useRequest } from 'ahooks';
 import React, { useEffect, useMemo, useState } from 'react';
 import _ from 'lodash';
 import { Button, Modal, message, Switch } from 'antd';
@@ -40,10 +41,21 @@ export default function Index() {
   const [hideSavingId, setHideSavingId] = useState<number | null>(null);
   const pagination = usePagination({ PAGESIZE_KEY: NS });
 
-  const fetchData = async (): Promise<any> => {
-    const res = await getEmbeddedProducts();
-    if (res) setData(_.orderBy(res, ['weight', 'id'], ['asc', 'asc']));
-  };
+  const {
+    run: fetchData,
+    cancel,
+    loading,
+  } = useRequest(getEmbeddedProducts, {
+    manual: true,
+    onSuccess: (res) => {
+      if (res) setData(_.orderBy(res, ['weight', 'id'], ['asc', 'asc']));
+    },
+  });
+  const confirmHide = useMemoizedFn((id: number, hide: boolean) => {
+    cancel();
+    setData((rows) => rows.map((row) => (row.id === id ? { ...row, hide } : row)));
+    if (loading) fetchData();
+  });
 
   const columns: ColumnType<EmbeddedProductResponse>[] = useMemo(() => {
     return [
@@ -98,6 +110,7 @@ export default function Index() {
                 setData((prev) => prev.map((item) => (item.id === record.id ? { ...item, hide: nextHide } : item)));
                 try {
                   await putEmbeddedProductHide(String(record.id), { hide: nextHide });
+                  confirmHide(record.id, nextHide);
                   message.success(t('common:success.save'));
                   eventBus.emit(EVENT_KEYS.EMBEDDED_PRODUCT_UPDATED);
                 } catch (e) {

--- a/src/pages/eventPipeline/pages/Edit.tsx
+++ b/src/pages/eventPipeline/pages/Edit.tsx
@@ -3,20 +3,25 @@ import { useTranslation } from 'react-i18next';
 import { Spin, message } from 'antd';
 import _ from 'lodash';
 
+import useRowMutation from '@/components/EnhancedTable/useRowMutation';
+
 import { NS } from '../constants';
 import { Item, getItem, putItem } from '../services';
 import Form from './Form';
 import { normalizeFormValues, normalizeInitialValues, omitDerivedFields } from '../utils/normalizeValues';
 
 interface Props {
+  runMutation?: ReturnType<typeof useRowMutation>['run'];
   id: number;
   onOk?: () => void;
   onCancel?: () => void;
   onDirtyChange?: (dirty: boolean) => void;
 }
 
-export default function Edit({ id, onOk, onCancel, onDirtyChange }: Props) {
+export default function Edit({ id, onOk, onCancel, onDirtyChange, runMutation }: Props) {
   const { t } = useTranslation(NS);
+  const localMutation = useRowMutation();
+  const run = runMutation ?? localMutation.run;
   const [data, setData] = useState<Item>();
 
   useEffect(() => {
@@ -37,12 +42,14 @@ export default function Edit({ id, onOk, onCancel, onDirtyChange }: Props) {
             // 后端 PUT 为全字段覆盖，而表单只回传已注册字段。这里以拉取到的完整对象为底，
             // 用表单值覆盖，避免 group_id / use_case / trigger_mode / inputs 等表单未托管的字段被清零；
             // nodes / connections 是后端派生的，必须剔除，否则会覆盖执行时真正生效的配置。
-            putItem({ ...omitDerivedFields(data), ...normalizeFormValues(values) }).then(() => {
-              message.success(t('common:success.edit'));
-              // 已落库，关闭时不该再提示「有未保存的修改」
-              onDirtyChange?.(false);
-              onOk?.();
-            });
+            return run([id], () =>
+              putItem({ ...omitDerivedFields(data), ...normalizeFormValues(values) }).then(() => {
+                message.success(t('common:success.edit'));
+                // The saved form no longer needs an unsaved-changes prompt.
+                onDirtyChange?.(false);
+                onOk?.();
+              }),
+            );
           }}
           onCancel={onCancel}
         />

--- a/src/pages/eventPipeline/pages/List/MoreOperations.tsx
+++ b/src/pages/eventPipeline/pages/List/MoreOperations.tsx
@@ -11,7 +11,8 @@ import { Item, deleteItems, putItemsDisabled } from '../../services';
 
 interface MoreOperationsProps {
   selectedRows: Item[];
-  /** 批量操作完成后刷新列表并清空选择 */
+  onStatusChange: (ids: number[], disabled: boolean) => void;
+  /** Refresh the list and clear selection after deletion. */
   onFinished?: () => void;
 }
 
@@ -52,7 +53,7 @@ export default function MoreOperations(props: MoreOperationsProps) {
         putItemsDisabled(_.map(targets, 'id'), disabled)
           .then(() => {
             message.success(t('common:success.modify'));
-            onFinished?.();
+            props.onStatusChange(_.map(targets, 'id'), disabled);
           })
           .catch((err) => {
             console.error(err);

--- a/src/pages/eventPipeline/pages/List/MoreOperations.tsx
+++ b/src/pages/eventPipeline/pages/List/MoreOperations.tsx
@@ -89,7 +89,7 @@ export default function MoreOperations(props: MoreOperationsProps) {
     Modal.confirm({
       title: enabled.length ? t('batch.delete_enabled_confirm', { count: enabled.length }) : t('batch.delete_confirm', { count: selectedRows.length }),
       okButtonProps: { danger: true },
-      onOk: () => props.runMutation(ids, () => (enabled.length ? putItemsDisabled(_.map(enabled, 'id'), true).then(doDelete) : doDelete())),
+      onOk: () => (enabled.length ? putItemsDisabled(_.map(enabled, 'id'), true).then(doDelete) : doDelete()),
     });
   };
 

--- a/src/pages/eventPipeline/pages/List/MoreOperations.tsx
+++ b/src/pages/eventPipeline/pages/List/MoreOperations.tsx
@@ -4,12 +4,15 @@ import { Dropdown, Menu, Button, Modal, message } from 'antd';
 import { DownOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 
+import useRowMutation from '@/components/EnhancedTable/useRowMutation';
 import { Export } from '@/components/ExportImport';
 
 import { NS } from '../../constants';
 import { Item, deleteItems, putItemsDisabled } from '../../services';
 
 interface MoreOperationsProps {
+  runMutation: ReturnType<typeof useRowMutation>['run'];
+  pendingIds: ReadonlySet<React.Key>;
   selectedRows: Item[];
   onStatusChange: (ids: number[], disabled: boolean) => void;
   /** Refresh the list and clear selection after deletion. */
@@ -50,11 +53,13 @@ export default function MoreOperations(props: MoreOperationsProps) {
     Modal.confirm({
       title: t(disabled ? 'batch.disable_confirm' : 'batch.enable_confirm', { count: targets.length }),
       onOk: () =>
-        putItemsDisabled(_.map(targets, 'id'), disabled)
-          .then(() => {
-            message.success(t('common:success.modify'));
-            props.onStatusChange(_.map(targets, 'id'), disabled);
-          })
+        props
+          .runMutation(_.map(targets, 'id'), () =>
+            putItemsDisabled(_.map(targets, 'id'), disabled).then(() => {
+              message.success(t('common:success.modify'));
+              props.onStatusChange(_.map(targets, 'id'), disabled);
+            }),
+          )
           .catch((err) => {
             console.error(err);
           }),
@@ -84,7 +89,7 @@ export default function MoreOperations(props: MoreOperationsProps) {
     Modal.confirm({
       title: enabled.length ? t('batch.delete_enabled_confirm', { count: enabled.length }) : t('batch.delete_confirm', { count: selectedRows.length }),
       okButtonProps: { danger: true },
-      onOk: () => (enabled.length ? putItemsDisabled(_.map(enabled, 'id'), true).then(doDelete) : doDelete()),
+      onOk: () => props.runMutation(ids, () => (enabled.length ? putItemsDisabled(_.map(enabled, 'id'), true).then(doDelete) : doDelete())),
     });
   };
 
@@ -109,7 +114,7 @@ export default function MoreOperations(props: MoreOperationsProps) {
 
   return (
     <Dropdown overlay={overlay} trigger={['click']}>
-      <Button onClick={(e) => e.stopPropagation()}>
+      <Button disabled={selectedRows.some((row) => props.pendingIds.has(row.id))} onClick={(e) => e.stopPropagation()}>
         {t('common:btn.more')} <DownOutlined />
       </Button>
     </Dropdown>

--- a/src/pages/eventPipeline/pages/List/index.tsx
+++ b/src/pages/eventPipeline/pages/List/index.tsx
@@ -156,14 +156,20 @@ export default function List({ embedded = false }: ListProps) {
   // 行内切换启用/停用：走只写 disabled 的窄接口，不再「先 GET 详情再整条 PUT 回去」。
   // 整条回写会用页面加载时的旧快照覆盖别人并发改过的 processors / 过滤条件；
   // 先 GET 只是把窗口缩小，并没有根治，窄接口才是。
+  const updateStatus = (ids: number[], disabled: boolean) => {
+    setData((prev) => ({
+      ...prev,
+      list: prev.list.map((row) => (ids.includes(row.id) ? { ...row, disabled } : row)),
+    }));
+  };
+
   const toggleDisabled = (record: Item, checked: boolean) => {
     if (_.includes(togglingIds, record.id)) return;
     setTogglingIds((prev) => [...prev, record.id]);
     putItemsDisabled([record.id], !checked)
       .then(() => {
         message.success(t('common:success.modify'));
-        // 重新拉列表而不是本地打补丁：还要刷新「更新时间 / 更新人」两列
-        featchData();
+        updateStatus([record.id], !checked);
       })
       .catch((err) => {
         console.error(err);
@@ -222,6 +228,10 @@ export default function List({ embedded = false }: ListProps) {
           </Button>
           <MoreOperations
             selectedRows={selectedRows}
+            onStatusChange={(ids, disabled) => {
+              updateStatus(ids, disabled);
+              setSelectedRowKeys([]);
+            }}
             onFinished={() => {
               setSelectedRowKeys([]);
               featchData();

--- a/src/pages/eventPipeline/pages/List/index.tsx
+++ b/src/pages/eventPipeline/pages/List/index.tsx
@@ -7,6 +7,7 @@ import { SearchOutlined } from '@ant-design/icons';
 import { Info } from 'lucide-react';
 import _ from 'lodash';
 
+import useRowMutation from '@/components/EnhancedTable/useRowMutation';
 import { CommonStateContext } from '@/App';
 import usePagination from '@/components/usePagination';
 import Tags from '@/components/TableTags/Tags';
@@ -57,8 +58,7 @@ export default function List({ embedded = false }: ListProps) {
   // 存 record 引用的话，行内启停或列表刷新后拿到的仍是勾选那一刻的旧对象，
   // 批量删除的「启用中不可删」校验会读到过期的 disabled 值而被绕过。
   const [selectedRowKeys, setSelectedRowKeys] = useState<number[]>([]);
-  // 切换中的行：请求返回前必须挡住重复点击，否则两次请求的落库顺序不保证
-  const [togglingIds, setTogglingIds] = useState<number[]>([]);
+  const { run: runMutation, pendingIds } = useRowMutation();
 
   const pagination = usePagination({ PAGESIZE_KEY: 'event-pipelines-pagesize' });
 
@@ -154,19 +154,14 @@ export default function List({ embedded = false }: ListProps) {
   });
 
   const toggleDisabled = (record: Item, checked: boolean) => {
-    if (_.includes(togglingIds, record.id)) return;
-    setTogglingIds((prev) => [...prev, record.id]);
-    putItemsDisabled([record.id], !checked)
-      .then(() => {
+    runMutation([record.id], () =>
+      putItemsDisabled([record.id], !checked).then(() => {
         message.success(t('common:success.modify'));
         updateStatus([record.id], !checked);
-      })
-      .catch((err) => {
-        console.error(err);
-      })
-      .finally(() => {
-        setTogglingIds((prev) => _.without(prev, record.id));
-      });
+      }),
+    ).catch((err) => {
+      console.error(err);
+    });
   };
 
   const openDoc = () => {
@@ -217,6 +212,8 @@ export default function List({ embedded = false }: ListProps) {
             {t('common:btn.add')}
           </Button>
           <MoreOperations
+            runMutation={runMutation}
+            pendingIds={pendingIds}
             selectedRows={selectedRows}
             onStatusChange={(ids, disabled) => {
               updateStatus(ids, disabled);
@@ -322,7 +319,7 @@ export default function List({ embedded = false }: ListProps) {
             key: 'disabled',
             width: 90,
             render: (value, record: Item) => (
-              <Switch size='small' checked={value === false} loading={_.includes(togglingIds, record.id)} onChange={(checked) => toggleDisabled(record, checked)} />
+              <Switch size='small' checked={value === false} loading={pendingIds.has(record.id)} onChange={(checked) => toggleDisabled(record, checked)} />
             ),
           },
         ]}
@@ -383,9 +380,11 @@ export default function List({ embedded = false }: ListProps) {
                 Modal.confirm({
                   title: t('common:confirm.delete'),
                   onOk: () => {
-                    deleteItems([item.id]).then(() => {
-                      featchData();
-                    });
+                    return runMutation([item.id], () =>
+                      deleteItems([item.id]).then(() => {
+                        featchData();
+                      }),
+                    );
                   },
                 });
               },
@@ -417,6 +416,7 @@ export default function List({ embedded = false }: ListProps) {
         )}
         {eventPipelineDrawerState.action === 'edit' && eventPipelineDrawerState?.id && (
           <Edit
+            runMutation={runMutation}
             id={eventPipelineDrawerState.id}
             onDirtyChange={(dirty) => (formDirtyRef.current = dirty)}
             onOk={() => {

--- a/src/pages/eventPipeline/pages/List/index.tsx
+++ b/src/pages/eventPipeline/pages/List/index.tsx
@@ -1,3 +1,4 @@
+import { useMemoizedFn, useRequest } from 'ahooks';
 import React, { useState, useEffect, useContext, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
@@ -51,17 +52,7 @@ export default function List({ embedded = false }: ListProps) {
   const history = useHistory();
   const { darkMode } = useContext(CommonStateContext);
   const [filter, setFilter] = useState<Filter>(readFilter);
-  const [data, setData] = useState<{
-    list: Item[];
-    loading: boolean;
-    // 首次请求成功返回过才算「加载完成」：只有这时列表为空才是真的没有工作流，
-    // 否则（尚未发起 / 请求失败）会把首帧和接口故障都误报成空状态引导
-    loaded: boolean;
-  }>({
-    list: [],
-    loading: true,
-    loaded: false,
-  });
+  const [data, setData] = useState<{ list: Item[]; loaded: boolean }>({ list: [], loaded: false });
   // 选择态只存 id，行数据渲染时从最新的 data.list 现查：
   // 存 record 引用的话，行内启停或列表刷新后拿到的仍是勾选那一刻的旧对象，
   // 批量删除的「启用中不可删」校验会读到过期的 disabled 值而被绕过。
@@ -80,17 +71,14 @@ export default function List({ embedded = false }: ListProps) {
     });
   };
 
-  const featchData = () => {
-    setData((prev) => ({ ...prev, loading: true }));
-    getList()
-      .then((res) => {
-        setData({ list: res, loading: false, loaded: true });
-      })
-      .catch((err) => {
-        console.error(err);
-        setData((prev) => ({ ...prev, loading: false }));
-      });
-  };
+  const {
+    loading,
+    run: featchData,
+    cancel,
+  } = useRequest(getList, {
+    manual: true,
+    onSuccess: (list) => setData({ list, loaded: true }),
+  });
 
   const [eventPipelineDrawerState, setEventPipelineDrawerState] = useState<{
     visible: boolean;
@@ -156,12 +144,14 @@ export default function List({ embedded = false }: ListProps) {
   // 行内切换启用/停用：走只写 disabled 的窄接口，不再「先 GET 详情再整条 PUT 回去」。
   // 整条回写会用页面加载时的旧快照覆盖别人并发改过的 processors / 过滤条件；
   // 先 GET 只是把窗口缩小，并没有根治，窄接口才是。
-  const updateStatus = (ids: number[], disabled: boolean) => {
+  const updateStatus = useMemoizedFn((ids: number[], disabled: boolean) => {
+    cancel();
     setData((prev) => ({
       ...prev,
       list: prev.list.map((row) => (ids.includes(row.id) ? { ...row, disabled } : row)),
     }));
-  };
+    if (loading) featchData();
+  });
 
   const toggleDisabled = (record: Item, checked: boolean) => {
     if (_.includes(togglingIds, record.id)) return;
@@ -245,7 +235,7 @@ export default function List({ embedded = false }: ListProps) {
         rowKey='id'
         scroll={{ x: 'max-content' }}
         locale={
-          data.loaded && !data.loading && data.list.length === 0
+          data.loaded && !loading && data.list.length === 0
             ? {
                 emptyText: (
                   <EmptyGuide
@@ -337,7 +327,7 @@ export default function List({ embedded = false }: ListProps) {
           },
         ]}
         dataSource={filteredData}
-        loading={data.loading}
+        loading={loading}
         pagination={pagination}
         rowSelection={{
           selectedRowKeys,

--- a/src/pages/eventPipeline/pages/List/index.tsx
+++ b/src/pages/eventPipeline/pages/List/index.tsx
@@ -380,11 +380,9 @@ export default function List({ embedded = false }: ListProps) {
                 Modal.confirm({
                   title: t('common:confirm.delete'),
                   onOk: () => {
-                    return runMutation([item.id], () =>
-                      deleteItems([item.id]).then(() => {
-                        featchData();
-                      }),
-                    );
+                    deleteItems([item.id]).then(() => {
+                      featchData();
+                    });
                   },
                 });
               },

--- a/src/pages/recordingRules/PageTable.tsx
+++ b/src/pages/recordingRules/PageTable.tsx
@@ -289,13 +289,11 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
                 title: t('common:confirm.delete'),
                 onOk: () => {
                   if (businessGroup.id) {
-                    return runMutation(selectRowKeys as number[], () =>
-                      deleteRecordingRule(selectRowKeys as number[], businessGroup.id).then(() => {
-                        message.success(t('common:success.delete'));
-                        clearSelection();
-                        refreshList();
-                      }),
-                    );
+                    deleteRecordingRule(selectRowKeys as number[], businessGroup.id).then(() => {
+                      message.success(t('common:success.delete'));
+                      clearSelection();
+                      refreshList();
+                    });
                   }
                 },
 
@@ -476,12 +474,10 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
                 confirm({
                   title: t('common:confirm.delete'),
                   onOk: () => {
-                    return runMutation([record.id], () =>
-                      deleteRecordingRule([record.id], record.group_id).then(() => {
-                        message.success(t('common:success.delete'));
-                        refreshList();
-                      }),
-                    );
+                    deleteRecordingRule([record.id], record.group_id).then(() => {
+                      message.success(t('common:success.delete'));
+                      refreshList();
+                    });
                   },
 
                   onCancel() {},

--- a/src/pages/recordingRules/PageTable.tsx
+++ b/src/pages/recordingRules/PageTable.tsx
@@ -1,3 +1,4 @@
+import { useMemoizedFn, useRequest } from 'ahooks';
 import React, { useEffect, useState, useMemo, useContext } from 'react';
 import { Button, Modal, message, Dropdown, Switch, Select, Space } from 'antd';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -69,7 +70,6 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
   const [isModalVisible, setisModalVisible] = useState<boolean>(false);
   const [currentStrategyDataAll, setCurrentStrategyDataAll] = useState<strategyItem[]>([]);
   const [currentStrategyData, setCurrentStrategyData] = useState<strategyItem[]>([]);
-  const [loading, setLoading] = useState(false);
   const [datasourceIds, setDatasourceIds] = useState<number[] | undefined>(defaultFilter.datasourceIds);
   const [filterDisabled, setFilterDisabled] = useState<0 | 1 | undefined>(defaultFilter.disabled);
   const [current, setCurrent] = useState<number>(defaultPage);
@@ -87,18 +87,19 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
     filterData();
   }, [query, datasourceIds, filterDisabled, currentStrategyDataAll]);
 
-  const getRecordingRules = async () => {
-    if (!gids) {
-      return;
-    }
-    setLoading(true);
-    const ids = gids === '-2' ? undefined : gids;
-    const { success, dat } = await getBusiGroupsRecordingRules(ids);
-    if (success) {
-      setCurrentStrategyDataAll(dat.filter((item) => !severity || item.severity === severity) || []);
-      setLoading(false);
-    }
-  };
+  const {
+    loading,
+    run: getRecordingRules,
+    cancel,
+  } = useRequest(
+    async () => {
+      if (!gids) return [];
+      const ids = gids === '-2' ? undefined : gids;
+      const { dat } = await getBusiGroupsRecordingRules(ids);
+      return (dat || []).filter((item) => !severity || item.severity === severity);
+    },
+    { manual: true, onSuccess: setCurrentStrategyDataAll },
+  );
 
   const filterData = () => {
     const data = JSON.parse(JSON.stringify(currentStrategyDataAll));
@@ -141,11 +142,13 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
     }
   }, [groupSwitchCount]);
 
-  const updateStatus = (ids: React.Key[], disabled: 0 | 1) => {
+  const updateStatus = useMemoizedFn((ids: React.Key[], disabled: 0 | 1) => {
+    cancel();
     const patch = (rows: strategyItem[]) => rows.map((row) => (ids.includes(row.id) ? { ...row, disabled } : row));
     setCurrentStrategyDataAll(patch);
     setSelectedRows(patch);
-  };
+    if (loading) getRecordingRules();
+  });
 
   const columns: ColumnType<strategyItem>[] = _.concat([
     {

--- a/src/pages/recordingRules/PageTable.tsx
+++ b/src/pages/recordingRules/PageTable.tsx
@@ -67,8 +67,8 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
   const defaultPage = getPageFromSearch(location.search);
   const [query, setQuery] = useState<string>(defaultFilter.query ?? '');
   const [isModalVisible, setisModalVisible] = useState<boolean>(false);
-  const [currentStrategyDataAll, setCurrentStrategyDataAll] = useState([]);
-  const [currentStrategyData, setCurrentStrategyData] = useState([]);
+  const [currentStrategyDataAll, setCurrentStrategyDataAll] = useState<strategyItem[]>([]);
+  const [currentStrategyData, setCurrentStrategyData] = useState<strategyItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [datasourceIds, setDatasourceIds] = useState<number[] | undefined>(defaultFilter.datasourceIds);
   const [filterDisabled, setFilterDisabled] = useState<0 | 1 | undefined>(defaultFilter.disabled);
@@ -140,6 +140,12 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
       resetPaging();
     }
   }, [groupSwitchCount]);
+
+  const updateStatus = (ids: React.Key[], disabled: 0 | 1) => {
+    const patch = (rows: strategyItem[]) => rows.map((row) => (ids.includes(row.id) ? { ...row, disabled } : row));
+    setCurrentStrategyDataAll(patch);
+    setSelectedRows(patch);
+  };
 
   const columns: ColumnType<strategyItem>[] = _.concat([
     {
@@ -216,7 +222,7 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
               },
               record.group_id,
             ).then(() => {
-              refreshList();
+              updateStatus([id], disabled ? 0 : 1);
             });
           }}
         />
@@ -320,7 +326,11 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
       if (!res.err) {
         message.success(t('common:success.edit'));
         clearSelection();
-        refreshList();
+        if (Object.keys(fieldsData).length === 1 && (fieldsData.disabled === 0 || fieldsData.disabled === 1)) {
+          updateStatus(selectRowKeys, fieldsData.disabled);
+        } else {
+          refreshList();
+        }
         setisModalVisible(false);
       } else {
         message.error(res.err);

--- a/src/pages/recordingRules/PageTable.tsx
+++ b/src/pages/recordingRules/PageTable.tsx
@@ -5,6 +5,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ColumnType } from 'antd/lib/table';
 import _ from 'lodash';
+import useRowMutation from '@/components/EnhancedTable/useRowMutation';
 import RefreshIcon from '@/components/RefreshIcon';
 import { DownOutlined } from '@ant-design/icons';
 import { getBusiGroupsRecordingRules, updateRecordingRules } from '@/services/recording';
@@ -142,6 +143,7 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
     }
   }, [groupSwitchCount]);
 
+  const { run: runMutation, pendingIds } = useRowMutation();
   const updateStatus = useMemoizedFn((ids: React.Key[], disabled: 0 | 1) => {
     cancel();
     const patch = (rows: strategyItem[]) => rows.map((row) => (ids.includes(row.id) ? { ...row, disabled } : row));
@@ -212,21 +214,24 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
 
       render: (disabled, record) => (
         <Switch
+          loading={pendingIds.has(record.id)}
           checked={disabled === strategyStatus.Enable}
           size='small'
           onChange={() => {
             const { id, disabled } = record;
-            updateRecordingRules(
-              {
-                ids: [id],
-                fields: {
-                  disabled: !disabled ? 1 : 0,
+            runMutation([id], () =>
+              updateRecordingRules(
+                {
+                  ids: [id],
+                  fields: {
+                    disabled: !disabled ? 1 : 0,
+                  },
                 },
-              },
-              record.group_id,
-            ).then(() => {
-              updateStatus([id], disabled ? 0 : 1);
-            });
+                record.group_id,
+              ).then(() => {
+                updateStatus([id], disabled ? 0 : 1);
+              }),
+            );
           }}
         />
       ),
@@ -284,11 +289,13 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
                 title: t('common:confirm.delete'),
                 onOk: () => {
                   if (businessGroup.id) {
-                    deleteRecordingRule(selectRowKeys as number[], businessGroup.id).then(() => {
-                      message.success(t('common:success.delete'));
-                      clearSelection();
-                      refreshList();
-                    });
+                    return runMutation(selectRowKeys as number[], () =>
+                      deleteRecordingRule(selectRowKeys as number[], businessGroup.id).then(() => {
+                        message.success(t('common:success.delete'));
+                        clearSelection();
+                        refreshList();
+                      }),
+                    );
                   }
                 },
 
@@ -319,25 +326,27 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
 
   const editModalFinish = async (isOk, fieldsData?) => {
     if (isOk && businessGroup.id) {
-      const res = await updateRecordingRules(
-        {
-          ids: selectRowKeys,
-          fields: fieldsData,
-        },
-        businessGroup.id,
-      );
-      if (!res.err) {
-        message.success(t('common:success.edit'));
-        clearSelection();
-        if (Object.keys(fieldsData).length === 1 && (fieldsData.disabled === 0 || fieldsData.disabled === 1)) {
-          updateStatus(selectRowKeys, fieldsData.disabled);
+      return runMutation(selectRowKeys, async () => {
+        const res = await updateRecordingRules(
+          {
+            ids: selectRowKeys,
+            fields: fieldsData,
+          },
+          businessGroup.id,
+        );
+        if (!res.err) {
+          message.success(t('common:success.edit'));
+          clearSelection();
+          if (Object.keys(fieldsData).length === 1 && (fieldsData.disabled === 0 || fieldsData.disabled === 1)) {
+            updateStatus(selectRowKeys, fieldsData.disabled);
+          } else {
+            refreshList();
+          }
+          setisModalVisible(false);
         } else {
-          refreshList();
+          message.error(res.err);
         }
-        setisModalVisible(false);
-      } else {
-        message.error(res.err);
-      }
+      });
     } else {
       setisModalVisible(false);
     }
@@ -407,7 +416,7 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
               </Button>
               <div className={'table-more-options'}>
                 <Dropdown overlay={menu} trigger={['click']}>
-                  <Button onClick={(e) => e.stopPropagation()}>
+                  <Button disabled={selectRowKeys.some((id) => pendingIds.has(id))} onClick={(e) => e.stopPropagation()}>
                     {t('common:btn.more')}
                     <DownOutlined
                       style={{
@@ -467,10 +476,12 @@ const PageTable: React.FC<Props> = ({ gids, groupSwitchCount = 0 }) => {
                 confirm({
                   title: t('common:confirm.delete'),
                   onOk: () => {
-                    deleteRecordingRule([record.id], record.group_id).then(() => {
-                      message.success(t('common:success.delete'));
-                      refreshList();
-                    });
+                    return runMutation([record.id], () =>
+                      deleteRecordingRule([record.id], record.group_id).then(() => {
+                        message.success(t('common:success.delete'));
+                        refreshList();
+                      }),
+                    );
                   },
 
                   onCancel() {},

--- a/src/pages/warning/shield/components/DeleteMutesModal/index.tsx
+++ b/src/pages/warning/shield/components/DeleteMutesModal/index.tsx
@@ -19,9 +19,12 @@ import { Alert, Form, Modal, Select, message } from 'antd';
 import { useTranslation } from 'react-i18next';
 import moment from 'moment';
 
+import useRowMutation from '@/components/EnhancedTable/useRowMutation';
 import { deleteAlertMutes } from '@/services/shield';
 
 interface Props {
+  runMutation: ReturnType<typeof useRowMutation>['run'];
+  rowIds: readonly React.Key[];
   visible: boolean;
   onCancel: () => void;
   onOk: () => void;
@@ -30,7 +33,7 @@ interface Props {
 
 export default function DeleteMutesModal(props: Props) {
   const { t } = useTranslation('alertMutes');
-  const { visible, onCancel, onOk, gids } = props;
+  const { visible, onCancel, onOk, gids, runMutation, rowIds } = props;
   const [form] = Form.useForm();
 
   return (
@@ -43,17 +46,19 @@ export default function DeleteMutesModal(props: Props) {
         Modal.confirm({
           title: t('delete_mutes.alert_message'),
           onOk() {
-            form.validateFields().then((values) => {
+            return form.validateFields().then((values) => {
               const group_ids = gids && gids !== '-2' ? gids.split(',').map((id) => Number(id)) : undefined;
-              deleteAlertMutes({
-                group_ids,
-                timestamp: moment().subtract(values.month, 'months').unix(),
-              }).then((res) => {
-                if (typeof res.dat === 'string') {
-                  message.success(res.dat);
-                }
-                onOk();
-              });
+              return runMutation(rowIds, () =>
+                deleteAlertMutes({
+                  group_ids,
+                  timestamp: moment().subtract(values.month, 'months').unix(),
+                }).then((res) => {
+                  if (typeof res.dat === 'string') {
+                    message.success(res.dat);
+                  }
+                  onOk();
+                }),
+              );
             });
           },
         });

--- a/src/pages/warning/shield/components/DeleteMutesModal/index.tsx
+++ b/src/pages/warning/shield/components/DeleteMutesModal/index.tsx
@@ -19,12 +19,9 @@ import { Alert, Form, Modal, Select, message } from 'antd';
 import { useTranslation } from 'react-i18next';
 import moment from 'moment';
 
-import useRowMutation from '@/components/EnhancedTable/useRowMutation';
 import { deleteAlertMutes } from '@/services/shield';
 
 interface Props {
-  runMutation: ReturnType<typeof useRowMutation>['run'];
-  rowIds: readonly React.Key[];
   visible: boolean;
   onCancel: () => void;
   onOk: () => void;
@@ -33,7 +30,7 @@ interface Props {
 
 export default function DeleteMutesModal(props: Props) {
   const { t } = useTranslation('alertMutes');
-  const { visible, onCancel, onOk, gids, runMutation, rowIds } = props;
+  const { visible, onCancel, onOk, gids } = props;
   const [form] = Form.useForm();
 
   return (
@@ -46,19 +43,17 @@ export default function DeleteMutesModal(props: Props) {
         Modal.confirm({
           title: t('delete_mutes.alert_message'),
           onOk() {
-            return form.validateFields().then((values) => {
+            form.validateFields().then((values) => {
               const group_ids = gids && gids !== '-2' ? gids.split(',').map((id) => Number(id)) : undefined;
-              return runMutation(rowIds, () =>
-                deleteAlertMutes({
-                  group_ids,
-                  timestamp: moment().subtract(values.month, 'months').unix(),
-                }).then((res) => {
-                  if (typeof res.dat === 'string') {
-                    message.success(res.dat);
-                  }
-                  onOk();
-                }),
-              );
+              deleteAlertMutes({
+                group_ids,
+                timestamp: moment().subtract(values.month, 'months').unix(),
+              }).then((res) => {
+                if (typeof res.dat === 'string') {
+                  message.success(res.dat);
+                }
+                onOk();
+              });
             });
           },
         });

--- a/src/pages/warning/shield/index.tsx
+++ b/src/pages/warning/shield/index.tsx
@@ -493,16 +493,14 @@ const Shield: React.FC = () => {
                       title: t('common:confirm.delete'),
                       icon: <ExclamationCircleOutlined />,
                       onOk: () => {
-                        return runMutation([record.id], () =>
-                          deleteShields({ ids: [record.id] }, record.group_id).then((res) => {
-                            refreshList();
-                            if (res.err) {
-                              message.success(res.err);
-                            } else {
-                              message.success(t('common:success.delete'));
-                            }
-                          }),
-                        );
+                        deleteShields({ ids: [record.id] }, record.group_id).then((res) => {
+                          refreshList();
+                          if (res.err) {
+                            message.success(res.err);
+                          } else {
+                            message.success(t('common:success.delete'));
+                          }
+                        });
                       },
                       onCancel() {},
                     });
@@ -513,8 +511,6 @@ const Shield: React.FC = () => {
             actionColumn={{ title: t('common:table.operations'), width: 80 }}
           />
           <DeleteMutesModal
-            runMutation={runMutation}
-            rowIds={[...new Set([...currentShieldDataAll.map((row) => row.id), ...pendingIds])]}
             visible={deleteMutesModalVisible}
             gids={gids}
             onCancel={() => {

--- a/src/pages/warning/shield/index.tsx
+++ b/src/pages/warning/shield/index.tsx
@@ -24,6 +24,7 @@ import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useHistory, Link, useLocation } from 'react-router-dom';
 
+import useRowMutation from '@/components/EnhancedTable/useRowMutation';
 import Tags from '@/components/TableTags/Tags';
 import EnhancedTable, { getEnabledStatusColumn } from '@/components/EnhancedTable';
 import { dateColumn, updateByColumn } from '@/components/EnhancedTable/columns';
@@ -90,6 +91,7 @@ const Shield: React.FC = () => {
     setCurrent(1);
     history.replace({ pathname: location.pathname, search: removePageFromSearch(location.search) });
   };
+  const { run: runMutation, pendingIds } = useRowMutation();
   const columns: ColumnsType = [
     {
       title: t('note'),
@@ -254,22 +256,25 @@ const Shield: React.FC = () => {
       width: 80,
       render: (disabled, record) => (
         <Switch
+          loading={pendingIds.has(record.id as React.Key)}
           checked={disabled === strategyStatus.Enable}
           size='small'
           onChange={() => {
             // @ts-ignore
             const { id, disabled, group_id } = record;
-            updateShields(
-              {
-                ids: [id],
-                fields: {
-                  disabled: !disabled ? 1 : 0,
+            runMutation([id], () =>
+              updateShields(
+                {
+                  ids: [id],
+                  fields: {
+                    disabled: !disabled ? 1 : 0,
+                  },
                 },
-              },
-              group_id,
-            ).then(() => {
-              updateStatus(id, !disabled ? 1 : 0);
-            });
+                group_id,
+              ).then(() => {
+                updateStatus(id, !disabled ? 1 : 0);
+              }),
+            );
           }}
         />
       ),
@@ -488,14 +493,16 @@ const Shield: React.FC = () => {
                       title: t('common:confirm.delete'),
                       icon: <ExclamationCircleOutlined />,
                       onOk: () => {
-                        deleteShields({ ids: [record.id] }, record.group_id).then((res) => {
-                          refreshList();
-                          if (res.err) {
-                            message.success(res.err);
-                          } else {
-                            message.success(t('common:success.delete'));
-                          }
-                        });
+                        return runMutation([record.id], () =>
+                          deleteShields({ ids: [record.id] }, record.group_id).then((res) => {
+                            refreshList();
+                            if (res.err) {
+                              message.success(res.err);
+                            } else {
+                              message.success(t('common:success.delete'));
+                            }
+                          }),
+                        );
                       },
                       onCancel() {},
                     });
@@ -506,6 +513,8 @@ const Shield: React.FC = () => {
             actionColumn={{ title: t('common:table.operations'), width: 80 }}
           />
           <DeleteMutesModal
+            runMutation={runMutation}
+            rowIds={[...new Set([...currentShieldDataAll.map((row) => row.id), ...pendingIds])]}
             visible={deleteMutesModalVisible}
             gids={gids}
             onCancel={() => {

--- a/src/pages/warning/shield/index.tsx
+++ b/src/pages/warning/shield/index.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+import { useMemoizedFn, useRequest } from 'ahooks';
 import React, { useState, useEffect, useContext } from 'react';
 import { Button, Input, Tooltip, message, Modal, Switch, Space, Tag, Select } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
@@ -75,8 +76,6 @@ const Shield: React.FC = () => {
   const [query, setQuery] = useState<string>(defaultFilter.query ?? '');
   const [currentShieldDataAll, setCurrentShieldDataAll] = useState<Array<shieldItem>>([]);
   const [currentShieldData, setCurrentShieldData] = useState<Array<shieldItem>>([]);
-  // 有业务组时首屏就会拉列表，初始即置为 loading，避免接口返回前闪现空态引导
-  const [loading, setLoading] = useState<boolean>(!!gids);
   const [datasourceIds, setDatasourceIds] = useState<number[] | undefined>(defaultFilter.datasourceIds);
   const [filterDisabled, setFilterDisabled] = useState<0 | 1 | undefined>(defaultFilter.disabled);
   const [deleteMutesModalVisible, setDeleteMutesModalVisible] = useState(false);
@@ -269,7 +268,7 @@ const Shield: React.FC = () => {
               },
               group_id,
             ).then(() => {
-              setCurrentShieldDataAll((items) => items.map((item) => (item.id === id ? { ...item, disabled: !disabled ? 1 : 0 } : item)));
+              updateStatus(id, !disabled ? 1 : 0);
             });
           }}
         />
@@ -277,10 +276,6 @@ const Shield: React.FC = () => {
     },
   ];
   const pagination = usePagination({ pageSizeLocalstorageKey: 'alert-mutes-table-pagesize' });
-
-  useEffect(() => {
-    getList();
-  }, [gids]);
 
   useEffect(() => {
     filterData();
@@ -311,22 +306,24 @@ const Shield: React.FC = () => {
     setCurrentShieldData(res || []);
   };
 
-  const getList = async () => {
-    if (!gids) return;
-    setLoading(true);
-    const ids = gids === '-2' ? undefined : gids;
-    try {
-      const { success, dat } = await getBusiGroupsAlertMutes(ids);
-      if (success) {
-        setCurrentShieldDataAll(dat || []);
-      }
-    } catch (e) {
-      console.error(e);
-    } finally {
-      // 请求失败也要结束 loading，否则表格会一直转圈且空态引导永远不出现
-      setLoading(false);
-    }
-  };
+  const {
+    loading,
+    run: getList,
+    cancel,
+  } = useRequest(
+    async () => {
+      if (!gids) return [];
+      const ids = gids === '-2' ? undefined : gids;
+      const { dat } = await getBusiGroupsAlertMutes(ids);
+      return dat || [];
+    },
+    { ready: !!gids, refreshDeps: [gids], onSuccess: setCurrentShieldDataAll },
+  );
+  const updateStatus = useMemoizedFn((id: number, disabled: 0 | 1) => {
+    cancel();
+    setCurrentShieldDataAll((items) => items.map((item) => (item.id === id ? { ...item, disabled } : item)));
+    if (loading) getList();
+  });
 
   const refreshList = () => {
     getList();

--- a/src/pages/warning/shield/index.tsx
+++ b/src/pages/warning/shield/index.tsx
@@ -269,7 +269,7 @@ const Shield: React.FC = () => {
               },
               group_id,
             ).then(() => {
-              refreshList();
+              setCurrentShieldDataAll((items) => items.map((item) => (item.id === id ? { ...item, disabled: !disabled ? 1 : 0 } : item)));
             });
           }}
         />

--- a/src/pages/warning/subscribe/ListNG.tsx
+++ b/src/pages/warning/subscribe/ListNG.tsx
@@ -509,16 +509,14 @@ const Subscribe = (props: Props) => {
                         title: t('common:confirm.delete'),
                         icon: <ExclamationCircleOutlined />,
                         onOk: () => {
-                          return runMutation([record.id], () =>
-                            deleteSubscribes({ ids: [record.id] }, record.group_id).then((res) => {
-                              refreshList();
-                              if (res.err) {
-                                message.success(res.err);
-                              } else {
-                                message.success(t('common:success.delete'));
-                              }
-                            }),
-                          );
+                          deleteSubscribes({ ids: [record.id] }, record.group_id).then((res) => {
+                            refreshList();
+                            if (res.err) {
+                              message.success(res.err);
+                            } else {
+                              message.success(t('common:success.delete'));
+                            }
+                          });
                         },
                         onCancel() {},
                       });

--- a/src/pages/warning/subscribe/ListNG.tsx
+++ b/src/pages/warning/subscribe/ListNG.tsx
@@ -53,6 +53,7 @@ interface Props {
   data: subscribeItem[];
   loading: boolean;
   setRefreshFlag: (flag: string) => void;
+  onStatusChange?: (ids: React.Key[], disabled: 0 | 1) => void;
   linkTarget?: string;
   gids?: string;
   groupSwitchCount?: number;
@@ -294,7 +295,7 @@ const Subscribe = (props: Props) => {
                     ],
                     record.group_id,
                   ).then(() => {
-                    refreshList();
+                    props.onStatusChange?.([record.id], disabled === 0 ? 1 : 0);
                   });
                 }}
               />

--- a/src/pages/warning/subscribe/ListNG.tsx
+++ b/src/pages/warning/subscribe/ListNG.tsx
@@ -6,6 +6,7 @@ import { Link, useHistory, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
 
+import useRowMutation from '@/components/EnhancedTable/useRowMutation';
 import { deleteSubscribes, editSubscribe } from '@/services/subscribe';
 import { subscribeItem } from '@/store/warningInterface/subscribe';
 import RefreshIcon from '@/components/RefreshIcon';
@@ -93,6 +94,7 @@ const Subscribe = (props: Props) => {
   const [notificationRules, setNotificationRules] = useState<NotificationRuleItem[]>();
   const notificationRulesAuthorized = useIsAuthorized([notificationRulesPerm]);
 
+  const { run: runMutation, pendingIds } = useRowMutation();
   const columns: ColumnsType = _.concat(
     [
       {
@@ -283,20 +285,23 @@ const Subscribe = (props: Props) => {
             width: 80,
             render: (disabled, record: any) => (
               <Switch
+                loading={pendingIds.has(record.id)}
                 checked={disabled === strategyStatus.Enable}
                 size='small'
                 onChange={() => {
-                  editSubscribe(
-                    [
-                      {
-                        ..._.omit(record, ['create_at', 'create_by', 'update_at', 'update_by']),
-                        disabled: disabled === 0 ? 1 : 0,
-                      },
-                    ],
-                    record.group_id,
-                  ).then(() => {
-                    props.onStatusChange?.([record.id], disabled === 0 ? 1 : 0);
-                  });
+                  runMutation([record.id], () =>
+                    editSubscribe(
+                      [
+                        {
+                          ..._.omit(record, ['create_at', 'create_by', 'update_at', 'update_by']),
+                          disabled: disabled === 0 ? 1 : 0,
+                        },
+                      ],
+                      record.group_id,
+                    ).then(() => {
+                      props.onStatusChange?.([record.id], disabled === 0 ? 1 : 0);
+                    }),
+                  );
                 }}
               />
             ),
@@ -504,14 +509,16 @@ const Subscribe = (props: Props) => {
                         title: t('common:confirm.delete'),
                         icon: <ExclamationCircleOutlined />,
                         onOk: () => {
-                          deleteSubscribes({ ids: [record.id] }, record.group_id).then((res) => {
-                            refreshList();
-                            if (res.err) {
-                              message.success(res.err);
-                            } else {
-                              message.success(t('common:success.delete'));
-                            }
-                          });
+                          return runMutation([record.id], () =>
+                            deleteSubscribes({ ids: [record.id] }, record.group_id).then((res) => {
+                              refreshList();
+                              if (res.err) {
+                                message.success(res.err);
+                              } else {
+                                message.success(t('common:success.delete'));
+                              }
+                            }),
+                          );
                         },
                         onCancel() {},
                       });

--- a/src/pages/warning/subscribe/index.tsx
+++ b/src/pages/warning/subscribe/index.tsx
@@ -4,10 +4,10 @@ import { CopyOutlined } from '@ant-design/icons';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
+import { useMemoizedFn, useRequest } from 'ahooks';
 
 import PageLayout from '@/components/pageLayout';
 import { getBusiGroupsAlertSubscribes } from '@/services/subscribe';
-import { subscribeItem } from '@/store/warningInterface/subscribe';
 import BusinessGroupSideBarWithAll, { getDefaultGids } from '@/components/BusinessGroup/BusinessGroupSideBarWithAll';
 import { CommonStateContext } from '@/App';
 
@@ -33,19 +33,26 @@ export default function List() {
     setGroupSwitchCount((count) => count + 1);
   };
   const [refreshFlag, setRefreshFlag] = useState<string>(_.uniqueId('refresh_'));
-  const [data, setData] = useState<Array<subscribeItem>>([]);
-  const [loading, setLoading] = useState<boolean>(false);
-  const getList = async () => {
-    if (gids) {
-      setLoading(true);
+  const {
+    data = [],
+    loading,
+    run: getList,
+    cancel,
+    mutate,
+  } = useRequest(
+    async () => {
+      if (!gids) return [];
       const ids = gids === '-2' ? undefined : gids;
-      const { success, dat } = await getBusiGroupsAlertSubscribes(ids);
-      if (success) {
-        setData(dat || []);
-        setLoading(false);
-      }
-    }
-  };
+      const { dat } = await getBusiGroupsAlertSubscribes(ids);
+      return dat || [];
+    },
+    { manual: true },
+  );
+  const updateStatus = useMemoizedFn((ids: React.Key[], disabled: 0 | 1) => {
+    cancel();
+    mutate((rows) => rows?.map((row) => (ids.includes(row.id) ? { ...row, disabled } : row)));
+    if (loading) getList();
+  });
 
   useEffect(() => {
     getList();
@@ -85,9 +92,7 @@ export default function List() {
             data={data}
             loading={loading}
             setRefreshFlag={setRefreshFlag}
-            onStatusChange={(ids, disabled) => {
-              setData((rows) => rows.map((row) => (ids.includes(row.id) ? { ...row, disabled } : row)));
-            }}
+            onStatusChange={updateStatus}
           />
         </div>
       </div>

--- a/src/pages/warning/subscribe/index.tsx
+++ b/src/pages/warning/subscribe/index.tsx
@@ -85,6 +85,9 @@ export default function List() {
             data={data}
             loading={loading}
             setRefreshFlag={setRefreshFlag}
+            onStatusChange={(ids, disabled) => {
+              setData((rows) => rows.map((row) => (ids.includes(row.id) ? { ...row, disabled } : row)));
+            }}
           />
         </div>
       </div>


### PR DESCRIPTION
Status changes in update-time-sorted tables moved the edited row to another position or page. Update confirmed fields in place for alert, recording and subscription rules, alert mutes, event pipelines and embedded products. Status-only batch edits use the same paths and keep selected rows synchronized.

Use a small per-row mutation queue for status changes and mounted edits that can overwrite status. Overlapping row IDs execute in order; independent rows remain concurrent. Pending switches display loading. Invalidate obsolete list reads and restart the latest query when needed. Embedded visibility changes apply only after successful writes. Delete and drag-order actions retain their existing behavior.

Validation: 36 targeted Jest tests passed before and after scope reduction. Independent review and formatting/diff checks passed. Actual-component browser fixtures verified inline updates, failure preservation, stable ordering, pagination and reload behavior with simulated services. Authenticated backend persistence and a full application build were not verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status and visibility updates across alert rules, event pipelines, recording rules, subscriptions, embedded products, and shields.
  * Prevented overlapping updates from causing stale or incorrect results.
  * Reduced unnecessary list refreshes while keeping displayed data synchronized.
  * Added loading indicators and temporarily disabled affected controls during updates.
  * Improved handling of in-progress requests when switching groups or refreshing lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->