### PR TITLE
Fix PageError branded icons ignored by antd Result

### DIFF
--- a/src/components/PageError/index.less
+++ b/src/components/PageError/index.less
@@ -1,0 +1,13 @@
+.page-error {
+  // Default antd Result icon sits 24px above the title; our taller 3D art needs less air.
+  .ant-result-icon {
+    margin-bottom: 0;
+  }
+
+  .page-error-illustration {
+    display: block;
+    width: 240px;
+    height: auto;
+    margin: 0 auto;
+  }
+}

--- a/src/components/PageError/index.tsx
+++ b/src/components/PageError/index.tsx
@@ -22,14 +22,6 @@ interface IProps {
   onRetry?: () => void;
 }
 
-/** antd Result 只认这几种，其余状态统一按 error 画 */
-function toResultStatus(status: number) {
-  if (status === 403) return '403' as const;
-  if (status === 404) return '404' as const;
-  if (status >= 500 && status < 600) return '500' as const;
-  return 'error' as const;
-}
-
 /** 自定义插画：明暗共用透明底 WebP；未知/其它 5xx 统一走 500 */
 function illustrationSrc(status: number) {
   if (status === 403) return '/image/page-error/403.webp';
@@ -147,8 +139,8 @@ export default function PageError(props: IProps) {
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+      {/* antd Result ignores custom icon when status is 403/404/500 — omit status so our art shows */}
       <Result
-        status={toResultStatus(status)}
         icon={<PageErrorIllustration status={status} />}
         title={t(`${status}.title`, { defaultValue: `${status}` })}
         subTitle={

--- a/src/components/PageError/index.tsx
+++ b/src/components/PageError/index.tsx
@@ -11,6 +11,7 @@ import { canGoBackInApp } from '@/utils/pageError';
 
 import { getAdminList } from './services';
 import './locale';
+import './index.less';
 
 export type PageErrorStatus = 403 | 404 | 500;
 
@@ -30,16 +31,7 @@ function illustrationSrc(status: number) {
 }
 
 function PageErrorIllustration({ status }: { status: number }) {
-  return (
-    <img
-      src={illustrationSrc(status)}
-      alt=''
-      width={240}
-      draggable={false}
-      // block + no margin would ignore ant-result-icon's text-align:center
-      style={{ width: 240, height: 'auto', display: 'block', margin: '0 auto' }}
-    />
-  );
+  return <img className='page-error-illustration' src={illustrationSrc(status)} alt='' width={240} draggable={false} />;
 }
 
 /** 「找谁要权限」最多列这么多人：真实环境里管理员可能有几十个，全列出来既没法用，也等于把用户名单摊在错误页上 */
@@ -139,7 +131,7 @@ export default function PageError(props: IProps) {
   ]);
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+    <div className='page-error' style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
       {/* antd Result ignores custom icon when status is 403/404/500 — omit status so our art shows */}
       <Result
         icon={<PageErrorIllustration status={status} />}

--- a/src/components/PageError/index.tsx
+++ b/src/components/PageError/index.tsx
@@ -36,7 +36,8 @@ function PageErrorIllustration({ status }: { status: number }) {
       alt=''
       width={240}
       draggable={false}
-      style={{ width: 240, height: 'auto', display: 'block' }}
+      // block + no margin would ignore ant-result-icon's text-align:center
+      style={{ width: 240, height: 'auto', display: 'block', margin: '0 auto' }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Our bundled antd `Result` ignores the custom `icon` prop when `status` is `403` / `404` / `500` and always renders the built-in SVG
- Omit that exception `status` so the branded WebP illustrations from #2323 actually show

## Test plan
- [ ] `/404` shows the magnifying-glass illustration (not the antd person+box SVG)
- [ ] 403 PageError shows the lock illustration
- [ ] 5xx / OutOfService shows the server illustration
- [ ] `npx jest src/components/PageError/index.test.tsx` passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed error pages so the custom error illustration displays consistently across different error statuses.
  - Improved the visual consistency, sizing, and centering of illustrations on 403, 404, 500, and other error pages.
  - Removed inconsistent spacing around error illustrations for a cleaner page layout.
  - Ensured custom illustrations render uniformly regardless of the error status shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->