### PR TITLE
Center PageError illustrations horizontally

### DIFF
--- a/src/components/PageError/index.less
+++ b/src/components/PageError/index.less
@@ -1,0 +1,13 @@
+.page-error {
+  // Default antd Result icon sits 24px above the title; our taller 3D art needs less air.
+  .ant-result-icon {
+    margin-bottom: 0;
+  }
+
+  .page-error-illustration {
+    display: block;
+    width: 240px;
+    height: auto;
+    margin: 0 auto;
+  }
+}

--- a/src/components/PageError/index.tsx
+++ b/src/components/PageError/index.tsx
@@ -11,6 +11,7 @@ import { canGoBackInApp } from '@/utils/pageError';
 
 import { getAdminList } from './services';
 import './locale';
+import './index.less';
 
 export type PageErrorStatus = 403 | 404 | 500;
 
@@ -30,16 +31,7 @@ function illustrationSrc(status: number) {
 }
 
 function PageErrorIllustration({ status }: { status: number }) {
-  return (
-    <img
-      src={illustrationSrc(status)}
-      alt=''
-      width={240}
-      draggable={false}
-      // block + no margin would ignore ant-result-icon's text-align:center
-      style={{ width: 240, height: 'auto', display: 'block', margin: '0 auto' }}
-    />
-  );
+  return <img className='page-error-illustration' src={illustrationSrc(status)} alt='' width={240} draggable={false} />;
 }
 
 /** 「找谁要权限」最多列这么多人：真实环境里管理员可能有几十个，全列出来既没法用，也等于把用户名单摊在错误页上 */
@@ -139,7 +131,7 @@ export default function PageError(props: IProps) {
   ]);
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+    <div className='page-error' style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
       {/* antd Result ignores custom icon when status is 403/404/500 — omit status so our art shows */}
       <Result
         icon={<PageErrorIllustration status={status} />}

--- a/src/components/PageError/index.tsx
+++ b/src/components/PageError/index.tsx
@@ -30,7 +30,16 @@ function illustrationSrc(status: number) {
 }
 
 function PageErrorIllustration({ status }: { status: number }) {
-  return <img src={illustrationSrc(status)} alt='' width={240} draggable={false} style={{ width: 240, height: 'auto', display: 'block' }} />;
+  return (
+    <img
+      src={illustrationSrc(status)}
+      alt=''
+      width={240}
+      draggable={false}
+      // block + no margin would ignore ant-result-icon's text-align:center
+      style={{ width: 240, height: 'auto', display: 'block', margin: '0 auto' }}
+    />
+  );
 }
 
 /** 「找谁要权限」最多列这么多人：真实环境里管理员可能有几十个，全列出来既没法用，也等于把用户名单摊在错误页上 */


### PR DESCRIPTION
## Summary
- PageError art uses `display:block`, so antd Result's `text-align:center` on `.ant-result-icon` does not center it
- Add `margin: 0 auto` so the illustration aligns with the title and actions

## Test plan
- [ ] `/404` illustration is horizontally centered under the title
- [ ] 403 / 5xx pages likewise look centered


Made with [Cursor](https://cursor.com)