### PR TITLE
fix(users): restore last active time column

### DIFF
--- a/src/pages/user/constants.ts
+++ b/src/pages/user/constants.ts
@@ -17,7 +17,7 @@ import i18next from 'i18next';
  * limitations under the License.
  *
  */
-export const LOCAL_STORAGE_KEY = 'users_columns_configs';
+export const LOCAL_STORAGE_KEY = 'users_columns_configs_v2';
 export const defaultColumnsConfigs = [
   {
     name: 'username',
@@ -62,6 +62,11 @@ export const defaultColumnsConfigs = [
   {
     name: 'create_at',
     i18nKey: 'common:table.create_at',
+    visible: true,
+  },
+  {
+    name: 'last_active_time',
+    i18nKey: 'user.last_active_time',
     visible: true,
   },
 ];


### PR DESCRIPTION
## Summary
- Restore `last_active_time` in `/users` `defaultColumnsConfigs` so the column shows again after the TableColumnSelect migration.
- Bump the page column localStorage key so existing browsers pick up the restored default instead of a stale visible set.

## Review
- Code-reviewed against `main`: scoped to `src/pages/user/constants.ts`; column definition and i18n keys already exist in `users.tsx` / locales.
- Root cause: `ajustColumns` treated unconfigured columns as visible; the new filter requires an explicit config entry.

## Test plan
- [ ] Open `/users` with a cleared or new column preference and confirm **最后活跃时间** is visible by default
- [ ] Confirm the column appears in the column picker and can be toggled
- [ ] Confirm existing custom prefs reset once due to the storage key bump


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible “Last active time” column to user listings.

* **Bug Fixes**
  * Updated saved user-column preferences to use the current configuration format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->