### PR TITLE
fix(users): restore last active time column

### DIFF
--- a/src/pages/user/constants.ts
+++ b/src/pages/user/constants.ts
@@ -17,7 +17,7 @@ import i18next from 'i18next';
  * limitations under the License.
  *
  */
-export const LOCAL_STORAGE_KEY = 'users_columns_configs';
+export const LOCAL_STORAGE_KEY = 'users_columns_configs_v2';
 export const defaultColumnsConfigs = [
   {
     name: 'username',
@@ -62,6 +62,11 @@ export const defaultColumnsConfigs = [
   {
     name: 'create_at',
     i18nKey: 'common:table.create_at',
+    visible: true,
+  },
+  {
+    name: 'last_active_time',
+    i18nKey: 'user.last_active_time',
     visible: true,
   },
 ];


### PR DESCRIPTION
## Summary
- Restore `last_active_time` in `/users` `defaultColumnsConfigs` so the column shows again after the TableColumnSelect migration.
- Bump the page column localStorage key so existing browsers pick up the restored default instead of a stale visible set.

## Review
- Conflict branch cut from `origin/pre` with only the fix commit cherry-picked (clean feat branch `fix/users-last-active-time-column` remains for →`main` as #2330).
- Scoped to `src/pages/user/constants.ts`.

## Test plan
- [ ] Open `/users` and confirm **最后活跃时间** is visible by default after reload
- [ ] Confirm the column appears in the column picker


Made with [Cursor](https://cursor.com)