### PR TITLE
Historical alerts support querying by hash.

### DIFF
--- a/src/pages/historyEvents/ListNG/index.tsx
+++ b/src/pages/historyEvents/ListNG/index.tsx
@@ -54,6 +54,8 @@ interface Props {
   filterAreaRight?: React.ReactNode;
   refreshFlag?: string;
   rowSelection?: any;
+  // 按事件 hash 精确筛选，仅历史告警页开启：复用本组件的其他页面走各自的接口，后端没接 hash
+  showHashFilter?: boolean;
 }
 
 const Event = (props: Props) => {
@@ -72,8 +74,11 @@ const Event = (props: Props) => {
     filterAreaRight,
     rowSelection,
     showClaimant = false,
+    showHashFilter = false,
   } = props;
   const [refreshFlag, setRefreshFlag] = useState<string>(_.uniqueId('refresh_'));
+  // hash 是精确匹配，输入过程中的半截值查出来必然为空，所以用本地 state 暂存、回车才提交
+  const [hashInput, setHashInput] = useState<string>(filter.hash ?? '');
   const [eventColumnExpanded, setEventColumnExpanded] = useState(() => readAlertEventTagsExpanded(HISTORY_EVENT_TAGS_EXPANDED_TABLE_KEY));
   const [eventDetailDrawerData, setEventDetailDrawerData] = useState<{
     visible: boolean;
@@ -97,6 +102,11 @@ const Event = (props: Props) => {
       });
     }
   }, [location.search]);
+
+  // filter.hash 来自 URL，直达链接和浏览器前进后退都要回填到输入框
+  useEffect(() => {
+    setHashInput(filter.hash ?? '');
+  }, [filter.hash]);
 
   let columns = [
     {
@@ -231,6 +241,7 @@ const Event = (props: Props) => {
     filter.datasource_ids?.length ? { datasource_ids: _.join(filter.datasource_ids, ',') } : {},
     filter.severity !== undefined ? { severity: filter.severity } : {},
     filter.query ? { query: filter.query } : {},
+    filter.hash ? { hash: filter.hash } : {},
     filter.is_recovered !== undefined ? { is_recovered: filter.is_recovered } : {},
     { bgid: filter.bgid },
     filter.rule_prods?.length ? { rule_prods: _.join(filter.rule_prods, ',') } : {},
@@ -361,6 +372,30 @@ const Event = (props: Props) => {
                 setRefreshFlag(_.uniqueId('refresh_'));
               }}
             />
+            {showHashFilter && (
+              <Input
+                className='min-w-[220px]'
+                allowClear
+                placeholder={t('hash_placeholder')}
+                value={hashInput}
+                onChange={(e) => {
+                  setHashInput(e.target.value);
+                  // allowClear 的清空按钮只触发 onChange，不触发 onPressEnter，这里直接提交
+                  if (!e.target.value) {
+                    setFilter({
+                      ...filter,
+                      hash: undefined,
+                    });
+                  }
+                }}
+                onPressEnter={() => {
+                  setFilter({
+                    ...filter,
+                    hash: hashInput.trim() || undefined,
+                  });
+                }}
+              />
+            )}
             {!hideExportButton && (
               <Button
                 loading={exportBtnLoadding}

--- a/src/pages/historyEvents/hashFilter.test.ts
+++ b/src/pages/historyEvents/hashFilter.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+// hash 筛选是纯 UI 接线，没有可单独调用的纯函数，沿用本仓库既有的源码断言方式守住关键约定
+describe('历史告警 hash 筛选', () => {
+  const root = path.resolve(__dirname, '../../..');
+
+  it('hash 输入框由 showHashFilter 控制，回车才提交且提交前 trim', () => {
+    const source = readFileSync(path.join(root, 'src/pages/historyEvents/ListNG/index.tsx'), 'utf8');
+
+    expect(source).toContain('showHashFilter = false');
+    expect(source).toContain('{showHashFilter && (');
+    expect(source).toContain("placeholder={t('hash_placeholder')}");
+    expect(source).toContain('hash: hashInput.trim() || undefined');
+    // 清空时写 undefined，URL 上不会残留空的 hash= 参数
+    expect(source).toContain('hash: undefined');
+    // 输入过程中不能直接 setFilter，否则半截 hash 会不断触发必然为空的查询
+    expect(source).not.toContain('hash: e.target.value');
+  });
+
+  it('hash 进入统一的 filterObj，列表与导出共用同一份筛选条件', () => {
+    const source = readFileSync(path.join(root, 'src/pages/historyEvents/ListNG/index.tsx'), 'utf8');
+
+    expect(source).toContain('filter.hash ? { hash: filter.hash } : {}');
+  });
+
+  it('历史告警页开启该筛选项并与 URL 双向同步', () => {
+    const source = readFileSync(path.join(root, 'src/pages/historyEvents/index.tsx'), 'utf8');
+
+    expect(source).toContain('hash: query.hash');
+    expect(source).toContain('showHashFilter');
+  });
+
+  it('多语言文案齐全', () => {
+    const localeDir = path.join(root, 'src/pages/historyEvents/locale');
+    const langs = ['zh_CN', 'zh_HK', 'en_US', 'ja_JP', 'ko_KR', 'ru_RU', 'fr_FR', 'es_ES', 'pt_BR', 'id_ID'];
+
+    langs.forEach((lang) => {
+      const source = readFileSync(path.join(localeDir, `${lang}.ts`), 'utf8');
+      expect(source).toContain('hash_placeholder');
+    });
+  });
+});

--- a/src/pages/historyEvents/index.tsx
+++ b/src/pages/historyEvents/index.tsx
@@ -35,6 +35,7 @@ const getFilter = (query) => {
     bgid: query.bgid ? Number(query.bgid) : undefined,
     severity: query.severity ? Number(query.severity) : undefined,
     query: query.query,
+    hash: query.hash,
     is_recovered: query.is_recovered ? Number(query.is_recovered) : undefined,
     rule_prods: query.rule_prods ? _.split(query.rule_prods, ',') : [],
   };
@@ -79,6 +80,7 @@ export default function List() {
       <div className='event-content'>
         <div className='table-area fc-border rounded-lg'>
           <ListNG
+            showHashFilter
             filter={filter}
             setFilter={setFilter}
             fetchData={({ current, pageSize }, filterObj) => {

--- a/src/pages/historyEvents/locale/en_US.ts
+++ b/src/pages/historyEvents/locale/en_US.ts
@@ -2,6 +2,7 @@ const en_US = {
   title: 'Historical events',
   event_name: 'Event',
   search_placeholder: 'Multiple keywords separated by spaces',
+  hash_placeholder: 'Exact search by event hash',
   first_trigger_time: 'First triggered',
   trigger_time: 'Triggered',
   last_eval_time: 'Last evaluated',

--- a/src/pages/historyEvents/locale/es_ES.ts
+++ b/src/pages/historyEvents/locale/es_ES.ts
@@ -2,6 +2,7 @@ const es_ES = {
   "title": "Alertas históricas",
   "event_name": "Evento",
   "search_placeholder": "Búsqueda aproximada en reglas y etiquetas (separa las palabras clave con espacios)",
+  "hash_placeholder": "Búsqueda exacta por hash del evento",
   "first_trigger_time": "Primer disparo",
   "trigger_time": "Hora del disparo",
   "last_eval_time": "Momento de la comprobación",

--- a/src/pages/historyEvents/locale/fr_FR.ts
+++ b/src/pages/historyEvents/locale/fr_FR.ts
@@ -2,6 +2,7 @@ const fr_FR = {
   "title": "Alertes passées",
   "event_name": "Événement",
   "search_placeholder": "Recherche approchée sur les règles et les étiquettes (séparez les mots-clés par des espaces)",
+  "hash_placeholder": "Recherche exacte par hash d'événement",
   "first_trigger_time": "Premier déclenchement",
   "trigger_time": "Déclenché le",
   "last_eval_time": "Heure de vérification",

--- a/src/pages/historyEvents/locale/id_ID.ts
+++ b/src/pages/historyEvents/locale/id_ID.ts
@@ -2,6 +2,7 @@ const id_ID = {
   "title": "Riwayat alert",
   "event_name": "Event",
   "search_placeholder": "Cari aturan dan label secara longgar (pisahkan beberapa kata kunci dengan spasi)",
+  "hash_placeholder": "Pencarian tepat berdasarkan hash peristiwa",
   "first_trigger_time": "Pertama kali terpicu",
   "trigger_time": "Waktu terpicu",
   "last_eval_time": "Waktu pemeriksaan",

--- a/src/pages/historyEvents/locale/ja_JP.ts
+++ b/src/pages/historyEvents/locale/ja_JP.ts
@@ -2,6 +2,7 @@ const ja_JP = {
   title: '履歴アラート',
   event_name: 'イベント',
   search_placeholder: 'ルールとラベルを模糊検索（複数のキーワードはスペースで区切ってください）',
+  hash_placeholder: 'イベント Hash で完全一致検索',
   first_trigger_time: '初回トリガ時間',
   trigger_time: 'トリガ時間',
   last_eval_time: '検出時間',

--- a/src/pages/historyEvents/locale/ko_KR.ts
+++ b/src/pages/historyEvents/locale/ko_KR.ts
@@ -2,6 +2,7 @@ const ko_KR = {
   "title": "지난 알림",
   "event_name": "이벤트",
   "search_placeholder": "규칙과 레이블을 부분 일치로 검색합니다 (키워드가 여러 개면 공백으로 구분)",
+  "hash_placeholder": "이벤트 Hash 정확히 일치 검색",
   "first_trigger_time": "최초 발생 시각",
   "trigger_time": "발생 시각",
   "last_eval_time": "점검 시각",

--- a/src/pages/historyEvents/locale/pt_BR.ts
+++ b/src/pages/historyEvents/locale/pt_BR.ts
@@ -2,6 +2,7 @@ const pt_BR = {
   "title": "Alertas históricos",
   "event_name": "Evento",
   "search_placeholder": "Busca aproximada em regras e rótulos (separe as palavras-chave com espaços)",
+  "hash_placeholder": "Busca exata pelo hash do evento",
   "first_trigger_time": "Primeiro disparo",
   "trigger_time": "Horário do disparo",
   "last_eval_time": "Momento da verificação",

--- a/src/pages/historyEvents/locale/ru_RU.ts
+++ b/src/pages/historyEvents/locale/ru_RU.ts
@@ -2,6 +2,7 @@ const ru_RU = {
   title: 'История оповещений',
   event_name: 'Событие',
   search_placeholder: 'Поиск по правилам и меткам (разделяйте ключевые слова пробелами)',
+  hash_placeholder: 'Точный поиск по хешу события',
   first_trigger_time: 'Время первого срабатывания',
   trigger_time: 'Время срабатывания',
   last_eval_time: 'Время проверки',

--- a/src/pages/historyEvents/locale/zh_CN.ts
+++ b/src/pages/historyEvents/locale/zh_CN.ts
@@ -2,6 +2,7 @@ const zh_CN = {
   title: '历史告警',
   event_name: '事件',
   search_placeholder: '模糊搜索规则和标签(多个关键词请用空格分隔)',
+  hash_placeholder: '按事件 Hash 精确查询',
   first_trigger_time: '首次触发时间',
   trigger_time: '触发时间',
   last_eval_time: '检测时间',

--- a/src/pages/historyEvents/locale/zh_HK.ts
+++ b/src/pages/historyEvents/locale/zh_HK.ts
@@ -2,6 +2,7 @@ const zh_HK = {
   title: '歷史告警',
   event_name: '事件',
   search_placeholder: '模糊搜尋規則和標籤 (多個關鍵詞請用空格分隔)',
+  hash_placeholder: '按事件 Hash 精確查詢',
   first_trigger_time: '首次觸發時間',
   trigger_time: '觸發時間',
   last_eval_time: '檢測時間',


### PR DESCRIPTION
## 一句话目标

在「历史告警」列表页新增按事件 hash 查询的能力，用户输入某个 hash 即可查出该 hash 对应的所有历史告警事件。

## 功能点

1. 历史告警列表页筛选区新增一个独立的 hash 输入框（与现有的『模糊搜索规则和标签』搜索框分开），输入 hash 后回车即可筛选
2. hash 采用**精确匹配**（等值查询），不是模糊搜索，也不并入现有关键词搜索框的模糊逻辑，避免改变现有搜索行为
3. hash 筛选与其他筛选条件（业务组、监控类型、数据源、级别、事件类别、关键词、时间范围）正常叠加生效
4. hash 输入框的值同步到 URL，支持直接用形如 `?hash=xxx` 的链接打开页面即为已筛选状态（用户通常是从告警通知/日志里拿到 hash 再来查）
5. 导出 CSV 时遵循当前的 hash 筛选条件
6. 输入框加占位提示文案，并补齐多语言（历史告警页现有 12 种语言文件）
7. 【假设项】为了让用户能拿到 hash，在告警事件详情里展示 hash 并支持一键复制；若用户的 hash 来源本来就是通知消息/日志，这一条可以去掉

## 涉及的 repo / 页面

- `nightingale`：历史告警列表接口 `center/router/router_alert_his_event.go`、查询构造 `models/alert_his_event.go`
- `n9e/fe`：历史告警页 `src/pages/historyEvents/`（`index.tsx` 筛选与 URL 同步、`ListNG/index.tsx` 筛选区与列表、`exportEvents.ts` 导出、`locale/` 多语言）

## 验收标准

1. 在历史告警页输入一个真实存在的 hash，列表只返回该 hash 的事件；输入不存在的 hash 返回空列表且无报错
2. hash 为空时页面行为与改动前完全一致（现有关键词模糊搜索的结果不受影响）
3. 按 hash 筛选后，总条数与分页正确，不会复用上一次查询缓存的总数；翻页结果正确
4. 带 `?hash=xxx` 的 URL 直接打开，输入框已回填且列表已按该 hash 筛选；刷新页面筛选条件不丢失
5. 导出 CSV 的内容与当前 hash 筛选结果一致
6. hash 查询在大数据量下响应正常（hash 字段本身已有索引，不应退化成全表扫描）

## 现状与既有约定

- 列表接口为 `GET /api/n9e/alert-his-events/list`，现有 `query` 参数是对 `rule_name` 和 `tags` 的模糊匹配（多个关键词空格分隔），hash 不在其中
- `alert_his_event` 表已有 `hash` 字段且建有索引，等值查询代价低
- 后端已有按 hash 取单条最新事件的能力（`models/alert_his_event.go` 中的 `AlertHisEventGetByHash`），但列表接口没有 hash 过滤条件
- 列表接口对总条数做了 120 秒缓存，缓存 key 由各筛选条件拼成——新增筛选条件需要一并纳入，否则翻页会拿到错误总数
- 页面筛选条件通过 URL query 参数双向同步（`historyEvents/index.tsx` 的 getFilter/setFilter）
- 列表组件 `historyEvents/ListNG` 被复用于「通知规则详情-事件」页和商业版「聚合告警」页，且已有 `hideExportButton` 这类开关 prop 的约定

## 假设与待确认

1. hash 输入框做成独立筛选项而非并入现有搜索框（理由：hash 是精确值，混进模糊搜索会拖慢查询并改变现有搜索语义）
2. 时间范围继续生效：页面默认最近 6 小时，同一 hash 的事件可能更早，用户可能需要手动放宽时间范围才能查到——是否在 hash 非空时自动放宽/忽略默认时间范围，待确认
3. 本次只要求历史告警页；复用同一列表组件的「通知规则详情-事件」和「聚合告警」页是否也要出现该筛选项，待确认（默认不出现）
4. 「当前告警」列表页同样有 hash 字段，本轮不改，如需一并支持请说明
5. 功能点 7（详情页展示并复制 hash）是为了闭环 hash 的来源而加的假设项，不需要可去掉

---
Created by Ironship task b53d8d34beefe031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added exact event-hash filtering to the event history page.
  - Hash filters can be applied by pressing Enter or cleared when needed.
  - Hash values remain synchronized with URL query parameters and history list filtering.
- **Localization**
  - Added translated hash-search placeholder text across supported languages.
- **Tests**
  - Added coverage for hash filtering, URL synchronization, shared filtering, and localized labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->