### PR TITLE
feat(hosts): add the host topology view to the host list page

### DIFF
--- a/plugins/PlusPlaceholder.tsx
+++ b/plugins/PlusPlaceholder.tsx
@@ -56,6 +56,7 @@ const HostTopoViewSwitch = PlusePlaceholder;
 const HostTopoGlobalGraph = PlusePlaceholder;
 const HostTopoDrawerTab = PlusePlaceholder;
 const HostTopoCenterSelect = PlusePlaceholder;
+const HostTopoCollectSetup = PlusePlaceholder;
 const readHostTopoViewMode = () => 'list';
 const getNetworkDevices = () => {};
 const getNetworkDevicesList = () => {};
@@ -112,6 +113,7 @@ export {
   HostTopoGlobalGraph,
   HostTopoDrawerTab,
   HostTopoCenterSelect,
+  HostTopoCollectSetup,
   readHostTopoViewMode,
   getNetworkDevices,
   getNetworkDevicesList,

--- a/plugins/PlusPlaceholder.tsx
+++ b/plugins/PlusPlaceholder.tsx
@@ -56,7 +56,6 @@ const HostTopoViewSwitch = PlusePlaceholder;
 const HostTopoGlobalGraph = PlusePlaceholder;
 const HostTopoDrawerTab = PlusePlaceholder;
 const HostTopoCenterSelect = PlusePlaceholder;
-const HostTopoStats = PlusePlaceholder;
 const readHostTopoViewMode = () => 'list';
 const getNetworkDevices = () => {};
 const getNetworkDevicesList = () => {};
@@ -113,7 +112,6 @@ export {
   HostTopoGlobalGraph,
   HostTopoDrawerTab,
   HostTopoCenterSelect,
-  HostTopoStats,
   readHostTopoViewMode,
   getNetworkDevices,
   getNetworkDevicesList,

--- a/plugins/PlusPlaceholder.tsx
+++ b/plugins/PlusPlaceholder.tsx
@@ -55,6 +55,8 @@ const extraColumns = () => {};
 const HostTopoViewSwitch = PlusePlaceholder;
 const HostTopoGlobalGraph = PlusePlaceholder;
 const HostTopoDrawerTab = PlusePlaceholder;
+const HostTopoCenterSelect = PlusePlaceholder;
+const HostTopoStats = PlusePlaceholder;
 const readHostTopoViewMode = () => 'list';
 const getNetworkDevices = () => {};
 const getNetworkDevicesList = () => {};
@@ -110,6 +112,8 @@ export {
   HostTopoViewSwitch,
   HostTopoGlobalGraph,
   HostTopoDrawerTab,
+  HostTopoCenterSelect,
+  HostTopoStats,
   readHostTopoViewMode,
   getNetworkDevices,
   getNetworkDevicesList,

--- a/plugins/PlusPlaceholder.tsx
+++ b/plugins/PlusPlaceholder.tsx
@@ -50,6 +50,12 @@ const getDefaultValuesByCate = () => {};
 const autoDatasourcetype = [];
 const AuthList = [];
 const extraColumns = () => {};
+// 主机拓扑（plus 功能）。命名导入必须在这里有对应物，否则开源构建缺符号。
+// 调用点都由 IS_PLUS 守着，开源构建下这几个不会被真正用到。
+const HostTopoViewSwitch = PlusePlaceholder;
+const HostTopoGlobalGraph = PlusePlaceholder;
+const HostTopoDrawerTab = PlusePlaceholder;
+const readHostTopoViewMode = () => 'list';
 const getNetworkDevices = () => {};
 const getNetworkDevicesList = () => {};
 const getNetworkDevicesTags = () => {};
@@ -101,6 +107,10 @@ export {
   autoDatasourcetype,
   AuthList,
   extraColumns,
+  HostTopoViewSwitch,
+  HostTopoGlobalGraph,
+  HostTopoDrawerTab,
+  readHostTopoViewMode,
   getNetworkDevices,
   getNetworkDevicesList,
   getNetworkDevicesTags,

--- a/src/pages/hosts/locale/en_US.ts
+++ b/src/pages/hosts/locale/en_US.ts
@@ -18,6 +18,7 @@ const en_US = {
   tags_popover_title: '{{count}} items',
   view_collects: 'View related collection configurations',
   host_topology: 'Topology',
+  collects_tab: 'Collection',
   host_no_heartbeat_tip: 'No heartbeat from host',
   expand_busi_and_overview: 'Expand business group and overview',
   collapse_busi_and_overview: 'Collapse business group and overview',

--- a/src/pages/hosts/locale/en_US.ts
+++ b/src/pages/hosts/locale/en_US.ts
@@ -17,6 +17,7 @@ const en_US = {
   cores: 'Cores',
   tags_popover_title: '{{count}} items',
   view_collects: 'View related collection configurations',
+  host_topology: 'Topology',
   host_no_heartbeat_tip: 'No heartbeat from host',
   expand_busi_and_overview: 'Expand business group and overview',
   collapse_busi_and_overview: 'Collapse business group and overview',

--- a/src/pages/hosts/locale/ja_JP.ts
+++ b/src/pages/hosts/locale/ja_JP.ts
@@ -18,6 +18,7 @@ const ja_JP = {
   tags_popover_title: '{{count}} 個',
   view_collects: '関連する収集設定を表示',
   host_topology: 'トポロジー',
+  collects_tab: '収集設定',
   host_no_heartbeat_tip: 'ホストはハートビートなし',
   expand_busi_and_overview: '業務グループと概要を展開',
   collapse_busi_and_overview: '業務グループと概要を折りたたむ',

--- a/src/pages/hosts/locale/ja_JP.ts
+++ b/src/pages/hosts/locale/ja_JP.ts
@@ -17,6 +17,7 @@ const ja_JP = {
   cores: 'Cores',
   tags_popover_title: '{{count}} 個',
   view_collects: '関連する収集設定を表示',
+  host_topology: 'トポロジー',
   host_no_heartbeat_tip: 'ホストはハートビートなし',
   expand_busi_and_overview: '業務グループと概要を展開',
   collapse_busi_and_overview: '業務グループと概要を折りたたむ',

--- a/src/pages/hosts/locale/ru_RU.ts
+++ b/src/pages/hosts/locale/ru_RU.ts
@@ -18,6 +18,7 @@ const ru_RU = {
   tags_popover_title: '{{count}} тегов',
   view_collects: 'Показать связанные конфигурации сбора',
   host_topology: 'Топология',
+  collects_tab: 'Сбор данных',
   host_no_heartbeat_tip: 'Хост без heartbeat',
   expand_busi_and_overview: 'Развернуть бизнес-группы и обзор',
   collapse_busi_and_overview: 'Свернуть бизнес-группы и обзор',

--- a/src/pages/hosts/locale/ru_RU.ts
+++ b/src/pages/hosts/locale/ru_RU.ts
@@ -17,6 +17,7 @@ const ru_RU = {
   cores: 'Cores',
   tags_popover_title: '{{count}} тегов',
   view_collects: 'Показать связанные конфигурации сбора',
+  host_topology: 'Топология',
   host_no_heartbeat_tip: 'Хост без heartbeat',
   expand_busi_and_overview: 'Развернуть бизнес-группы и обзор',
   collapse_busi_and_overview: 'Свернуть бизнес-группы и обзор',

--- a/src/pages/hosts/locale/zh_CN.ts
+++ b/src/pages/hosts/locale/zh_CN.ts
@@ -19,6 +19,7 @@ const zh_CN = {
   tags_popover_title: '{{count}} 个',
   view_collects: '查看关联采集配置',
   host_topology: '拓扑',
+  collects_tab: '采集配置',
   host_no_heartbeat_tip: '机器无心跳',
   expand_busi_and_overview: '展开业务组和概览',
   collapse_busi_and_overview: '收起业务组和概览',

--- a/src/pages/hosts/locale/zh_CN.ts
+++ b/src/pages/hosts/locale/zh_CN.ts
@@ -18,6 +18,7 @@ const zh_CN = {
   cores: 'Cores',
   tags_popover_title: '{{count}} 个',
   view_collects: '查看关联采集配置',
+  host_topology: '拓扑',
   host_no_heartbeat_tip: '机器无心跳',
   expand_busi_and_overview: '展开业务组和概览',
   collapse_busi_and_overview: '收起业务组和概览',

--- a/src/pages/hosts/locale/zh_HK.ts
+++ b/src/pages/hosts/locale/zh_HK.ts
@@ -19,6 +19,7 @@ const zh_HK = {
   tags_popover_title: '{{count}} 個',
   view_collects: '查看關聯採集配置',
   host_topology: '拓撲',
+  collects_tab: '採集配置',
   host_no_heartbeat_tip: '機器無心跳',
   expand_busi_and_overview: '展開業務組和概覽',
   collapse_busi_and_overview: '收起業務組和概覽',

--- a/src/pages/hosts/locale/zh_HK.ts
+++ b/src/pages/hosts/locale/zh_HK.ts
@@ -18,6 +18,7 @@ const zh_HK = {
   cores: 'Cores',
   tags_popover_title: '{{count}} 個',
   view_collects: '查看關聯採集配置',
+  host_topology: '拓撲',
   host_no_heartbeat_tip: '機器無心跳',
   expand_busi_and_overview: '展開業務組和概覽',
   collapse_busi_and_overview: '收起業務組和概覽',

--- a/src/pages/hosts/pages/List/HostFilters.tsx
+++ b/src/pages/hosts/pages/List/HostFilters.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import _ from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { Input, Select } from 'antd';
+import { SearchOutlined } from '@ant-design/icons';
+
+import HostsSelect from '@/pages/targets/components/HostsSelect';
+// @ts-ignore
+import VersionSelect from 'plus:/parcels/Targets/VersionSelect';
+
+import { NS } from '../../constants';
+
+const downtimeOptions = [1, 2, 3, 5, 10, 30];
+
+export interface HostFilterValues {
+  query?: string;
+  hosts?: string;
+  downtime?: number;
+  agent_versions?: string[];
+  /** AI 任务页专用，普通列表不显示这一项 */
+  auth_level?: string;
+}
+
+interface Props {
+  value: HostFilterValues;
+  onChange: (next: HostFilterValues) => void;
+  /** AI 任务页：隐藏机器标识筛选，改显示授权等级 */
+  aiTaskMode?: boolean;
+}
+
+/**
+ * 机器筛选条。列表视图和拓扑视图共用同一份控件与同一份状态——
+ * 两边各写一套的话，同样的条件会因为参数拼法的细微差别选出不同的机器，
+ * 而用户只会把这种差异理解成「拓扑画漏了」。
+ *
+ * 只管筛选，不管刷新/折叠/批量操作那些：那些是表格专属的动作，
+ * 拓扑视图下没有对应语义，混进来只会多出几个点了没反应的按钮。
+ */
+export default function HostFilters({ value, onChange, aiTaskMode }: Props) {
+  const { t } = useTranslation(NS);
+  // 搜索框是「回车/失焦才提交」的，本地留一份草稿；外部换值（比如切业务组）要同步回来
+  const [searchValue, setSearchValue] = useState(value.query ?? '');
+  useEffect(() => {
+    setSearchValue(value.query ?? '');
+  }, [value.query]);
+
+  const patch = (p: Partial<HostFilterValues>) => onChange({ ...value, ...p });
+
+  return (
+    <>
+      <Input
+        // 唯一可伸缩的控件：宽屏顶到 300px，窄屏最多收到 140px，把余量让给筛选控件和右侧动作区
+        className='min-w-[140px] max-w-[300px] flex-1'
+        prefix={<SearchOutlined />}
+        placeholder={t('search_placeholder')}
+        allowClear
+        value={searchValue}
+        onChange={(e) => setSearchValue(e.target.value)}
+        onPressEnter={() => patch({ query: searchValue })}
+        onBlur={() => patch({ query: searchValue })}
+      />
+      {!aiTaskMode && <HostsSelect value={value.hosts} onChange={(newHosts) => patch({ hosts: newHosts })} />}
+      <Select
+        allowClear
+        placeholder={t('filterDowntime')}
+        style={{ minWidth: 120 }}
+        dropdownMatchSelectWidth={false}
+        options={[
+          {
+            label: t('filterDowntimeNegative'),
+            options: _.map(downtimeOptions, (item) => ({ label: t('filterDowntimeNegativeMin', { count: item }), value: -(item * 60) })),
+          },
+          {
+            label: t('filterDowntimePositive'),
+            options: _.map(downtimeOptions, (item) => ({ label: t('filterDowntimePositiveMin', { count: item }), value: item * 60 })),
+          },
+        ]}
+        value={value.downtime}
+        onChange={(val) => patch({ downtime: val })}
+      />
+      <VersionSelect value={value.agent_versions} onChange={(val) => patch({ agent_versions: val })} />
+      {aiTaskMode && (
+        <Select
+          style={{ minWidth: 120 }}
+          allowClear
+          showArrow
+          mode='multiple'
+          placeholder={t('auth_level')}
+          dropdownMatchSelectWidth={false}
+          options={[
+            { label: t('auth_level_1'), value: 1 },
+            { label: t('auth_level_2'), value: 2 },
+            { label: t('auth_level_3'), value: 3 },
+          ]}
+          value={value.auth_level ? value.auth_level.split(',').map(Number) : undefined}
+          onChange={(val: number[]) => patch({ auth_level: val.length > 0 ? val.join(',') : undefined })}
+        />
+      )}
+    </>
+  );
+}

--- a/src/pages/hosts/pages/List/List.tsx
+++ b/src/pages/hosts/pages/List/List.tsx
@@ -25,7 +25,7 @@ import TargetMetaDrawer from '@/pages/targets/TargetMetaDrawer';
 import { timeFormatter } from '@/pages/dashboard/Renderer/utils/valueFormatter';
 
 // @ts-ignore
-import CollectsDrawer from 'plus:/pages/collects/CollectsDrawer';
+import CollectsPanel from 'plus:/pages/collects/CollectsPanel';
 import HostFilters from './HostFilters';
 // @ts-ignore — 主机拓扑页签（plus parcel；开源构建下解析成空组件）
 import { HostTopoDrawerTab } from 'plus:/parcels/Targets';
@@ -148,10 +148,10 @@ export default function List(props: Props) {
   const { allCollapseNode, editable = true, explorable = true, gids, selectedRows, setSelectedRows, refreshFlag, setRefreshFlag, setOperateType, aiTaskMode = false } = props;
   const selectedIdents = _.map(selectedRows, 'ident');
 
-  const [collectsDrawerVisible, setCollectsDrawerVisible] = useState(false);
-  const [collectsDrawerIdent, setCollectsDrawerIdent] = useState('');
   const [metaDrawerOpen, setMetaDrawerOpen] = useState(false);
   const [metaDrawerIdent, setMetaDrawerIdent] = useState('');
+  // 从哪个入口进来就落在哪个页签：整行点击看概览，两个图标各自直达拓扑 / 采集配置
+  const [metaDrawerTab, setMetaDrawerTab] = useState('meta');
   const [upgradeTargetIdent, setUpgradeTargetIdent] = useState<string | null>(null);
   // null 表示后端不支持一键安装（老版本 / 企业版），此时不展示入口，避免死按钮
   const [installMeta, setInstallMeta] = useState<CategrafInstallMeta | null>(null);
@@ -411,6 +411,7 @@ export default function List(props: Props) {
                 return;
               }
               setMetaDrawerIdent(record.ident);
+              setMetaDrawerTab('meta');
               setMetaDrawerOpen(true);
             },
           })}
@@ -531,8 +532,9 @@ export default function List(props: Props) {
                                 size='small'
                                 onClick={(e) => {
                                   e.stopPropagation();
-                                  setCollectsDrawerVisible(true);
-                                  setCollectsDrawerIdent(ident);
+                                  setMetaDrawerIdent(ident);
+                                  setMetaDrawerTab('collects');
+                                  setMetaDrawerOpen(true);
                                 }}
                                 icon={<ApartmentOutlined />}
                               />
@@ -548,6 +550,7 @@ export default function List(props: Props) {
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   setMetaDrawerIdent(ident);
+                                  setMetaDrawerTab('topology');
                                   setMetaDrawerOpen(true);
                                 }}
                                 icon={<ShareAltOutlined />}
@@ -986,13 +989,16 @@ export default function List(props: Props) {
         ident={metaDrawerIdent}
         drawerOnly
         drawerOpen={metaDrawerOpen}
+        defaultActiveTab={metaDrawerTab}
         onDrawerOpenChange={(open) => {
           setMetaDrawerOpen(open);
           if (!open) setMetaDrawerIdent('');
         }}
         extraTabs={
-          // 「这台机器在跟谁说话」——元信息抽屉里最缺的那一半。
-          // 开源构建下 HostTopoDrawerTab 解析成空，这里给空数组，抽屉不套 Tabs
+          // 概览 / 拓扑 / 采集配置：一台机器的三件事各占一个页签。
+          // 「在跟谁说话」和「配了什么采集」过去一个在别的抽屉里、一个是死胡同里的链接，
+          // 现在收在同一个抽屉里，切页签就能来回看。
+          // 开源构建下这两个组件都解析成空，所以那边给空数组，抽屉照旧不套 Tabs
           IS_PLUS && metaDrawerIdent
             ? [
                 {
@@ -1000,28 +1006,15 @@ export default function List(props: Props) {
                   label: t('host_topology'),
                   children: <HostTopoDrawerTab ident={metaDrawerIdent} height='calc(100vh - 220px)' />,
                 },
+                {
+                  key: 'collects',
+                  label: t('collects_tab'),
+                  children: <CollectsPanel ident={metaDrawerIdent} />,
+                },
               ]
             : []
         }
-        extraActions={
-          IS_PLUS && metaDrawerIdent ? (
-            // 元信息抽屉本身是个死胡同，至少让「这台机器配了什么采集 / 要不要配一个」有条出路
-            <Button
-              size='small'
-              type='link'
-              className='p-0'
-              icon={<ApartmentOutlined />}
-              onClick={() => {
-                setCollectsDrawerVisible(true);
-                setCollectsDrawerIdent(metaDrawerIdent);
-              }}
-            >
-              {t('view_collects')}
-            </Button>
-          ) : undefined
-        }
       />
-      <CollectsDrawer visible={collectsDrawerVisible} setVisible={setCollectsDrawerVisible} ident={collectsDrawerIdent} />
       {installVisible && installMeta && (
         <InstallCategraf
           meta={installMeta}

--- a/src/pages/hosts/pages/List/List.tsx
+++ b/src/pages/hosts/pages/List/List.tsx
@@ -2,7 +2,17 @@ import React, { useState, useEffect, useContext } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Button, Input, Space, Select, Dropdown, Menu, Table, Divider, Tooltip, Modal, message } from 'antd';
-import { ReloadOutlined, SearchOutlined, DownOutlined, QuestionCircleOutlined, CopyOutlined, ApartmentOutlined, DownloadOutlined, AppstoreAddOutlined, ShareAltOutlined } from '@ant-design/icons';
+import {
+  ReloadOutlined,
+  SearchOutlined,
+  DownOutlined,
+  QuestionCircleOutlined,
+  CopyOutlined,
+  DownloadOutlined,
+  AppstoreAddOutlined,
+  DeploymentUnitOutlined,
+  SettingOutlined,
+} from '@ant-design/icons';
 import _ from 'lodash';
 import semver from 'semver';
 import { useAntdTable } from 'ahooks';
@@ -522,27 +532,15 @@ export default function List(props: Props) {
                               {ident}
                             </span>
                           </Tooltip>
+                          {/* 两个图标各自直达详情抽屉的一个页签，顺序跟着页签走：
+                              概览 · 拓扑 · 采集配置，所以拓扑在左、采集配置在右。
+                              常驻而不是 hover 才显形：这是「从机器出发看/配采集」的入口，
+                              藏在 hover 里新用户不可能找到。这一列已经在算 identIpWidth 排版，
+                              所以只放开可见性、不加文字，免得把这列撑变形 */}
                           {IS_PLUS && (
-                            // 常驻而不是 hover 才显形：这是「从机器出发看/配采集」的入口，
-                            // 藏在 hover 里新用户不可能找到。这一列已经在算 identIpWidth 排版，
-                            // 所以只放开可见性、不加文字，免得把这列撑变形
-                            <Tooltip title={t('view_collects')}>
-                              <Button
-                                className='ml-2'
-                                size='small'
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  setMetaDrawerIdent(ident);
-                                  setMetaDrawerTab('collects');
-                                  setMetaDrawerOpen(true);
-                                }}
-                                icon={<ApartmentOutlined />}
-                              />
-                            </Tooltip>
-                          )}
-                          {IS_PLUS && (
-                            // 与采集配置那个按钮并排：两个都是「从这台机器出发」的入口。
-                            // 点它直接把元信息抽屉打开并落在拓扑页签上
+                            // 连通图用 DeploymentUnit（中心节点连着几个卫星节点），不用 ShareAlt ——
+                            // 后者在本仓库各处都是「分享」，也不用 Apartment，那是层级树，
+                            // 而且在数据探索里已经是「下钻」的意思
                             <Tooltip title={t('host_topology')}>
                               <Button
                                 className='ml-2'
@@ -553,7 +551,24 @@ export default function List(props: Props) {
                                   setMetaDrawerTab('topology');
                                   setMetaDrawerOpen(true);
                                 }}
-                                icon={<ShareAltOutlined />}
+                                icon={<DeploymentUnitOutlined />}
+                              />
+                            </Tooltip>
+                          )}
+                          {IS_PLUS && (
+                            // 齿轮与「采集规则」页自己的页面图标一致，也与拓扑工具条上那个
+                            // 「配置采集」按钮一致——同一件事在三处用同一个字形
+                            <Tooltip title={t('view_collects')}>
+                              <Button
+                                className='ml-2'
+                                size='small'
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setMetaDrawerIdent(ident);
+                                  setMetaDrawerTab('collects');
+                                  setMetaDrawerOpen(true);
+                                }}
+                                icon={<SettingOutlined />}
                               />
                             </Tooltip>
                           )}

--- a/src/pages/hosts/pages/List/List.tsx
+++ b/src/pages/hosts/pages/List/List.tsx
@@ -26,6 +26,7 @@ import { timeFormatter } from '@/pages/dashboard/Renderer/utils/valueFormatter';
 
 // @ts-ignore
 import CollectsDrawer from 'plus:/pages/collects/CollectsDrawer';
+import HostFilters from './HostFilters';
 // @ts-ignore — 主机拓扑页签（plus parcel；开源构建下解析成空组件）
 import { HostTopoDrawerTab } from 'plus:/parcels/Targets';
 // @ts-ignore
@@ -117,6 +118,9 @@ interface Props {
   editable?: boolean;
   explorable?: boolean;
   gids?: string;
+  /** 筛选条件由外层持有（与拓扑视图共用）。不传则组件自己管。 */
+  filters?: Record<string, any>;
+  setFilters?: (next: Record<string, any>) => void;
   selectedRows: Item[];
   setSelectedRows: (selectedRowKeys: Item[]) => void;
   refreshFlag?: string;
@@ -154,8 +158,7 @@ export default function List(props: Props) {
   const [installVisible, setInstallVisible] = useState(false);
   const [collectVisible, setCollectVisible] = useState(false);
 
-  const [searchValue, setSearchValue] = useState('');
-  const [params, setParams] = useState<{
+  const [innerParams, setInnerParams] = useState<{
     limit: number;
     p: number;
     gids?: string;
@@ -168,6 +171,15 @@ export default function List(props: Props) {
     limit: pagination.pageSize,
     p: 1,
   });
+
+  // 筛选条件可以由外层持有：机器列表和拓扑视图是同一批机器的两种看法，
+  // 切换视图时筛选不该丢。外层不传就自己管，AI 任务页那类复用方不用改。
+  const params = props.filters ? { ...innerParams, ...props.filters } : innerParams;
+  const setParams = (updater: any) => {
+    const next = typeof updater === 'function' ? updater(params) : updater;
+    if (props.setFilters) props.setFilters(_.omit(next, ['limit', 'p']));
+    setInnerParams((prev) => ({ ...prev, ...next }));
+  };
 
   const featchData = ({ current, pageSize }: { current: number; pageSize: number }): Promise<any> => {
     return getList({
@@ -298,84 +310,7 @@ export default function List(props: Props) {
                 setRefreshFlag(_.uniqueId('refreshFlag_'));
               }}
             />
-            <Input
-              // 唯一可伸缩的控件：宽屏顶到 300px，窄屏最多收到 140px，把余量让给筛选控件和右侧动作区
-              className='min-w-[140px] max-w-[300px] flex-1'
-              prefix={<SearchOutlined />}
-              placeholder={t('search_placeholder')}
-              allowClear
-              value={searchValue}
-              onChange={(e) => setSearchValue(e.target.value)}
-              onPressEnter={() => {
-                setParams((p) => ({ ...p, query: searchValue }));
-              }}
-              onBlur={() => {
-                setParams((p) => ({ ...p, query: searchValue }));
-              }}
-            />
-            {!aiTaskMode && (
-              <HostsSelect
-                value={params.hosts}
-                onChange={(newHosts) => {
-                  setParams((p) => ({ ...p, hosts: newHosts }));
-                }}
-              />
-            )}
-            <Select
-              allowClear
-              placeholder={t('filterDowntime')}
-              style={{ minWidth: 120 }}
-              dropdownMatchSelectWidth={false}
-              options={[
-                {
-                  label: t('filterDowntimeNegative'),
-                  options: _.map(downtimeOptions, (item) => {
-                    return {
-                      label: t('filterDowntimeNegativeMin', { count: item }),
-                      value: -(item * 60),
-                    };
-                  }),
-                },
-                {
-                  label: t('filterDowntimePositive'),
-                  options: _.map(downtimeOptions, (item) => {
-                    return {
-                      label: t('filterDowntimePositiveMin', { count: item }),
-                      value: item * 60,
-                    };
-                  }),
-                },
-              ]}
-              value={params.downtime}
-              onChange={(val) => {
-                setParams((p) => ({ ...p, downtime: val }));
-              }}
-            />
-            <VersionSelect
-              value={params.agent_versions}
-              onChange={(val) => {
-                setParams((p) => ({ ...p, agent_versions: val }));
-              }}
-            />
-            {aiTaskMode && (
-              <Select
-                style={{ minWidth: 120 }}
-                allowClear
-                showArrow
-                mode='multiple'
-                placeholder={t('auth_level')}
-                dropdownMatchSelectWidth={false}
-                options={[
-                  { label: t('auth_level_1'), value: 1 },
-                  { label: t('auth_level_2'), value: 2 },
-                  { label: t('auth_level_3'), value: 3 },
-                ]}
-                value={params.auth_level ? params.auth_level.split(',').map(Number) : undefined}
-                onChange={(val: number[]) => {
-                  setParams((p) => ({ ...p, auth_level: val.length > 0 ? val.join(',') : undefined }));
-                }}
-              />
-            )}
+            <HostFilters value={params} onChange={(next) => setParams((p) => ({ ...p, ...next }))} aiTaskMode={aiTaskMode} />
           </div>
           <Space wrap className='ml-auto'>
             {/* 接入类动作与「批量操作」同属操作区，放右侧，左侧留给筛选控件 */}
@@ -798,8 +733,8 @@ export default function List(props: Props) {
                           onTagClick={(tag) => {
                             if (!_.includes(params.query, tag)) {
                               const val = params.query ? `${params.query.trim()} ${tag}` : tag;
+                              // 只改 params：搜索框的显示值由 HostFilters 跟着 value.query 同步
                               setParams((p) => ({ ...p, query: val }));
-                              setSearchValue(val);
                             }
                           }}
                         />
@@ -831,8 +766,8 @@ export default function List(props: Props) {
                           onTagClick={(tag) => {
                             if (!_.includes(params.query, tag)) {
                               const val = params.query ? `${params.query.trim()} ${tag}` : tag;
+                              // 只改 params：搜索框的显示值由 HostFilters 跟着 value.query 同步
                               setParams((p) => ({ ...p, query: val }));
-                              setSearchValue(val);
                             }
                           }}
                         />

--- a/src/pages/hosts/pages/List/List.tsx
+++ b/src/pages/hosts/pages/List/List.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useContext } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Button, Input, Space, Select, Dropdown, Menu, Table, Divider, Tooltip, Modal, message } from 'antd';
-import { ReloadOutlined, SearchOutlined, DownOutlined, QuestionCircleOutlined, CopyOutlined, ApartmentOutlined, DownloadOutlined, AppstoreAddOutlined } from '@ant-design/icons';
+import { ReloadOutlined, SearchOutlined, DownOutlined, QuestionCircleOutlined, CopyOutlined, ApartmentOutlined, DownloadOutlined, AppstoreAddOutlined, ShareAltOutlined } from '@ant-design/icons';
 import _ from 'lodash';
 import semver from 'semver';
 import { useAntdTable } from 'ahooks';
@@ -26,6 +26,8 @@ import { timeFormatter } from '@/pages/dashboard/Renderer/utils/valueFormatter';
 
 // @ts-ignore
 import CollectsDrawer from 'plus:/pages/collects/CollectsDrawer';
+// @ts-ignore — 主机拓扑页签（plus parcel；开源构建下解析成空组件）
+import { HostTopoDrawerTab } from 'plus:/parcels/Targets';
 // @ts-ignore
 import UpgradeAgent from 'plus:/parcels/Targets/UpgradeAgent';
 // @ts-ignore
@@ -601,6 +603,22 @@ export default function List(props: Props) {
                               />
                             </Tooltip>
                           )}
+                          {IS_PLUS && (
+                            // 与采集配置那个按钮并排：两个都是「从这台机器出发」的入口。
+                            // 点它直接把元信息抽屉打开并落在拓扑页签上
+                            <Tooltip title={t('host_topology')}>
+                              <Button
+                                className='ml-2'
+                                size='small'
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setMetaDrawerIdent(ident);
+                                  setMetaDrawerOpen(true);
+                                }}
+                                icon={<ShareAltOutlined />}
+                              />
+                            </Tooltip>
+                          )}
                         </div>
                         <Space size={4} className='flex flex-wrap items-center'>
                           {record.host_ip ? (
@@ -1037,6 +1055,19 @@ export default function List(props: Props) {
           setMetaDrawerOpen(open);
           if (!open) setMetaDrawerIdent('');
         }}
+        extraTabs={
+          // 「这台机器在跟谁说话」——元信息抽屉里最缺的那一半。
+          // 开源构建下 HostTopoDrawerTab 解析成空，这里给空数组，抽屉不套 Tabs
+          IS_PLUS && metaDrawerIdent
+            ? [
+                {
+                  key: 'topology',
+                  label: t('host_topology'),
+                  children: <HostTopoDrawerTab ident={metaDrawerIdent} height='calc(100vh - 220px)' />,
+                },
+              ]
+            : []
+        }
         extraActions={
           IS_PLUS && metaDrawerIdent ? (
             // 元信息抽屉本身是个死胡同，至少让「这台机器配了什么采集 / 要不要配一个」有条出路

--- a/src/pages/hosts/pages/List/index.tsx
+++ b/src/pages/hosts/pages/List/index.tsx
@@ -38,6 +38,12 @@ export default function index() {
 
   const businessGroupRef = React.useRef<{ getCollapse: () => boolean; setCollapse: (collapse: boolean) => void }>(null);
 
+  // 拓扑图的筛选条件。必须 memo：它进了 GlobalGraph 的 effect 依赖，
+  // 写成内联字面量的话每次父组件 render 都是新对象，折叠统计栏这种
+  // 跟图毫无关系的状态变化也会触发一次重新取图。
+  const selectedIdentsKey = _.join(_.map(selectedRows, 'ident'), ',');
+  const hostFilter = React.useMemo(() => ({ idents: selectedIdentsKey ? _.split(selectedIdentsKey, ',') : [] }), [selectedIdentsKey]);
+
   useEffect(() => {
     // 如果 businessGroup 和 stats 都是折叠的则 allCollapsed 也设置成折叠
     if (businessGroupRef.current?.getCollapse() && statsCollapsed) {
@@ -83,7 +89,7 @@ export default function index() {
             )}
             {viewMode === 'topology' && IS_PLUS ? (
               <div className='flex-1 min-h-0'>
-                <HostTopoGlobalGraph gids={gids} hostFilter={{ idents: _.map(selectedRows, 'ident') }} />
+                <HostTopoGlobalGraph gids={gids} hostFilter={hostFilter} />
               </div>
             ) : (
             <List

--- a/src/pages/hosts/pages/List/index.tsx
+++ b/src/pages/hosts/pages/List/index.tsx
@@ -15,7 +15,7 @@ import { IS_ENT, IS_PLUS } from '@/utils/constant';
 import ObsLoopHostEntry from 'plus:/parcels/ObsLoop/HostEntry';
 
 // @ts-ignore — 主机拓扑（plus parcel；开源构建下解析成空组件）
-import { HostTopoViewSwitch, HostTopoGlobalGraph, HostTopoCenterSelect, HostTopoStats, readHostTopoViewMode } from 'plus:/parcels/Targets';
+import { HostTopoViewSwitch, HostTopoGlobalGraph, HostTopoCenterSelect, readHostTopoViewMode } from 'plus:/parcels/Targets';
 
 import { NS, STATS_COLLAPSED_KEY } from '../../constants';
 import { Item, OperateType } from '../../types';
@@ -149,11 +149,6 @@ export default function index() {
                       <HostFilters value={hostFilters} onChange={setHostFilters} />
                       {/* 中心主机紧跟在筛选控件后面：它和前面几项一样都在回答「画哪些机器」 */}
                       <HostTopoCenterSelect gids={gids} />
-                    </div>
-                    {/* 图的统计放筛选条右端：它回答的是「这些条件圈出了多少东西」。
-                        self-center 让它和 32px 高的控件垂直居中 */}
-                    <div className='self-center'>
-                      <HostTopoStats />
                     </div>
                   </div>
                 </div>

--- a/src/pages/hosts/pages/List/index.tsx
+++ b/src/pages/hosts/pages/List/index.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
 import { Button, Tooltip } from 'antd';
+import { ReloadOutlined } from '@ant-design/icons';
 
 import { CommonStateContext } from '@/App';
 import PageLayout from '@/components/pageLayout';
@@ -69,6 +70,24 @@ export default function index() {
     setGids(getTargetsCompatibleGids(businessGroup.ids));
   }, [businessGroup.ids]);
 
+  // 折叠与刷新两个视图都要：折叠是给主区域腾地方——图比表格更吃空间，
+  // 拓扑视图下反而更需要；刷新对一张实时的图更是必需（服务端还有 30 秒缓存，
+  // 所以刷新会带一个随机串把那层缓存也绕过去，见 hostTopoGraph 的缓存键）。
+  const allCollapseNode = (
+    <Tooltip title={allCollapsed ? t('expand_busi_and_overview') : t('collapse_busi_and_overview')}>
+      <Button
+        icon={allCollapsed ? <PanelRightCloseIcon /> : <PanelLeftCloseIcon />}
+        onClick={() => {
+          const newCollapsed = !allCollapsed;
+          setAllCollapsed(newCollapsed);
+          businessGroupRef.current?.setCollapse(newCollapsed);
+          setStatsCollapsed(newCollapsed);
+          window.localStorage.setItem(STATS_COLLAPSED_KEY, newCollapsed.toString());
+        }}
+      />
+    </Tooltip>
+  );
+
   return (
     <PageLayout
       title={t('title')}
@@ -101,32 +120,21 @@ export default function index() {
             )}
             {viewMode === 'topology' && IS_PLUS ? (
               <div className='flex-1 min-h-0 flex flex-col gap-2'>
-                {/* 拓扑视图下 <List/> 整个不渲染，筛选条也跟着没了。
+                {/* 拓扑视图下 <List/> 整个不渲染，它那条工具栏也跟着没了。
                     这里挂同一个 HostFilters、共用同一份状态，切视图筛选不丢。
-                    刷新/折叠/批量操作那几个不搬过来：它们是表格专属动作。 */}
+                    批量操作不搬过来：那是选中表格行之后的动作，图上没有对应语义。 */}
                 <div className='fc-border rounded-lg p-2 flex flex-wrap items-center gap-2'>
+                  {allCollapseNode}
+                  <Button icon={<ReloadOutlined />} onClick={() => setRefreshFlag(_.uniqueId('refreshFlag_'))} />
                   <HostFilters value={hostFilters} onChange={setHostFilters} />
                 </div>
                 <div className='flex-1 min-h-0'>
-                  <HostTopoGlobalGraph gids={gids} hostFilter={hostFilter} />
+                  <HostTopoGlobalGraph gids={gids} hostFilter={hostFilter} refreshFlag={refreshFlag} />
                 </div>
               </div>
             ) : (
             <List
-              allCollapseNode={
-                <Tooltip title={allCollapsed ? t('expand_busi_and_overview') : t('collapse_busi_and_overview')}>
-                  <Button
-                    icon={allCollapsed ? <PanelRightCloseIcon /> : <PanelLeftCloseIcon />}
-                    onClick={() => {
-                      const newCollapsed = !allCollapsed;
-                      setAllCollapsed(newCollapsed);
-                      businessGroupRef.current?.setCollapse(newCollapsed);
-                      setStatsCollapsed(newCollapsed);
-                      window.localStorage.setItem(STATS_COLLAPSED_KEY, newCollapsed.toString());
-                    }}
-                  />
-                </Tooltip>
-              }
+              allCollapseNode={allCollapseNode}
               gids={gids}
               filters={hostFilters}
               setFilters={setHostFilters}

--- a/src/pages/hosts/pages/List/index.tsx
+++ b/src/pages/hosts/pages/List/index.tsx
@@ -15,7 +15,7 @@ import { IS_ENT, IS_PLUS } from '@/utils/constant';
 import ObsLoopHostEntry from 'plus:/parcels/ObsLoop/HostEntry';
 
 // @ts-ignore — 主机拓扑（plus parcel；开源构建下解析成空组件）
-import { HostTopoViewSwitch, HostTopoGlobalGraph, HostTopoCenterSelect, readHostTopoViewMode } from 'plus:/parcels/Targets';
+import { HostTopoViewSwitch, HostTopoGlobalGraph, HostTopoCenterSelect, HostTopoCollectSetup, readHostTopoViewMode } from 'plus:/parcels/Targets';
 
 import { NS, STATS_COLLAPSED_KEY } from '../../constants';
 import { Item, OperateType } from '../../types';
@@ -149,6 +149,11 @@ export default function index() {
                       <HostFilters value={hostFilters} onChange={setHostFilters} />
                       {/* 中心主机紧跟在筛选控件后面：它和前面几项一样都在回答「画哪些机器」 */}
                       <HostTopoCenterSelect gids={gids} />
+                    </div>
+                    {/* 「配置采集」摆在筛选条右端：它不是筛选，是这张图空着时唯一该做的动作。
+                        图上没有连线，最常见的原因就是这批机器还没配 servicemap 采集规则 */}
+                    <div className='self-center'>
+                      <HostTopoCollectSetup gids={gids} />
                     </div>
                   </div>
                 </div>

--- a/src/pages/hosts/pages/List/index.tsx
+++ b/src/pages/hosts/pages/List/index.tsx
@@ -7,10 +7,13 @@ import { CommonStateContext } from '@/App';
 import PageLayout from '@/components/pageLayout';
 import BusinessGroup2, { getCleanBusinessGroupIds } from '@/components/BusinessGroup';
 import { getTargetsCompatibleGids } from '@/components/BusinessGroup/presetFilters';
-import { IS_ENT } from '@/utils/constant';
+import { IS_ENT, IS_PLUS } from '@/utils/constant';
 
 // @ts-ignore — ObsLoop HostEntry（srm-fe parcel；开源/plus 源仓不挂此依赖）
 import ObsLoopHostEntry from 'plus:/parcels/ObsLoop/HostEntry';
+
+// @ts-ignore — 主机拓扑（plus parcel；开源构建下解析成空组件）
+import { HostTopoViewSwitch, HostTopoGlobalGraph, readHostTopoViewMode } from 'plus:/parcels/Targets';
 
 import { NS, STATS_COLLAPSED_KEY } from '../../constants';
 import { Item, OperateType } from '../../types';
@@ -28,6 +31,8 @@ export default function index() {
   const [selectedRows, setSelectedRows] = useState<Item[]>([]);
   const [refreshFlag, setRefreshFlag] = useState<string>();
 
+  // 列表 / 拓扑两种视图。开源构建下 readHostTopoViewMode 解析成空，恒为 list
+  const [viewMode, setViewMode] = useState<'list' | 'topology'>(() => (IS_PLUS ? readHostTopoViewMode() : 'list'));
   const [statsCollapsed, setStatsCollapsed] = useState(window.localStorage.getItem(STATS_COLLAPSED_KEY) === 'true');
   const [allCollapsed, setAllCollapsed] = useState(false);
 
@@ -71,6 +76,16 @@ export default function index() {
           />
           <div className='w-full min-w-0 flex flex-col'>
             <StatsCards gids={gids} collapsed={statsCollapsed} setCollapsed={setStatsCollapsed} refreshFlag={refreshFlag} />
+            {IS_PLUS && (
+              <div className='mb-2'>
+                <HostTopoViewSwitch value={viewMode} onChange={setViewMode} />
+              </div>
+            )}
+            {viewMode === 'topology' && IS_PLUS ? (
+              <div className='flex-1 min-h-0'>
+                <HostTopoGlobalGraph gids={gids} hostFilter={{ idents: _.map(selectedRows, 'ident') }} />
+              </div>
+            ) : (
             <List
               allCollapseNode={
                 <Tooltip title={allCollapsed ? t('expand_busi_and_overview') : t('collapse_busi_and_overview')}>
@@ -93,6 +108,7 @@ export default function index() {
               setRefreshFlag={setRefreshFlag}
               setOperateType={setOperateType}
             />
+            )}
           </div>
         </div>
       </div>

--- a/src/pages/hosts/pages/List/index.tsx
+++ b/src/pages/hosts/pages/List/index.tsx
@@ -19,6 +19,7 @@ import { NS, STATS_COLLAPSED_KEY } from '../../constants';
 import { Item, OperateType } from '../../types';
 import { PanelLeftCloseIcon, PanelRightCloseIcon } from './panelCloseIcon';
 import StatsCards from './StatsCards';
+import HostFilters, { HostFilterValues } from './HostFilters';
 import OperationModal from './OperationModal';
 import List from './List';
 
@@ -30,6 +31,8 @@ export default function index() {
   const [operateType, setOperateType] = useState<OperateType>(OperateType.None);
   const [selectedRows, setSelectedRows] = useState<Item[]>([]);
   const [refreshFlag, setRefreshFlag] = useState<string>();
+  // 筛选条件提到这一层：列表和拓扑是同一批机器的两种看法，切视图时筛选不该丢
+  const [hostFilters, setHostFilters] = useState<HostFilterValues>({});
 
   // 列表 / 拓扑两种视图。开源构建下 readHostTopoViewMode 解析成空，恒为 list
   const [viewMode, setViewMode] = useState<'list' | 'topology'>(() => (IS_PLUS ? readHostTopoViewMode() : 'list'));
@@ -42,7 +45,16 @@ export default function index() {
   // 写成内联字面量的话每次父组件 render 都是新对象，折叠统计栏这种
   // 跟图毫无关系的状态变化也会触发一次重新取图。
   const selectedIdentsKey = _.join(_.map(selectedRows, 'ident'), ',');
-  const hostFilter = React.useMemo(() => ({ idents: selectedIdentsKey ? _.split(selectedIdentsKey, ',') : [] }), [selectedIdentsKey]);
+  const hostFilter = React.useMemo(
+    () => ({
+      idents: selectedIdentsKey ? _.split(selectedIdentsKey, ',') : [],
+      query: hostFilters.query,
+      hosts: hostFilters.hosts,
+      downtime: hostFilters.downtime,
+      agent_versions: hostFilters.agent_versions,
+    }),
+    [selectedIdentsKey, hostFilters.query, hostFilters.hosts, hostFilters.downtime, hostFilters.agent_versions],
+  );
 
   useEffect(() => {
     // 如果 businessGroup 和 stats 都是折叠的则 allCollapsed 也设置成折叠
@@ -88,8 +100,16 @@ export default function index() {
               </div>
             )}
             {viewMode === 'topology' && IS_PLUS ? (
-              <div className='flex-1 min-h-0'>
-                <HostTopoGlobalGraph gids={gids} hostFilter={hostFilter} />
+              <div className='flex-1 min-h-0 flex flex-col gap-2'>
+                {/* 拓扑视图下 <List/> 整个不渲染，筛选条也跟着没了。
+                    这里挂同一个 HostFilters、共用同一份状态，切视图筛选不丢。
+                    刷新/折叠/批量操作那几个不搬过来：它们是表格专属动作。 */}
+                <div className='fc-border rounded-lg p-2 flex flex-wrap items-center gap-2'>
+                  <HostFilters value={hostFilters} onChange={setHostFilters} />
+                </div>
+                <div className='flex-1 min-h-0'>
+                  <HostTopoGlobalGraph gids={gids} hostFilter={hostFilter} />
+                </div>
               </div>
             ) : (
             <List
@@ -108,6 +128,8 @@ export default function index() {
                 </Tooltip>
               }
               gids={gids}
+              filters={hostFilters}
+              setFilters={setHostFilters}
               selectedRows={selectedRows}
               setSelectedRows={setSelectedRows}
               refreshFlag={refreshFlag}

--- a/src/pages/hosts/pages/List/index.tsx
+++ b/src/pages/hosts/pages/List/index.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useHistory, useLocation } from 'react-router-dom';
 import _ from 'lodash';
 import { Button, Tooltip } from 'antd';
 import { ReloadOutlined } from '@ant-design/icons';
@@ -14,7 +15,7 @@ import { IS_ENT, IS_PLUS } from '@/utils/constant';
 import ObsLoopHostEntry from 'plus:/parcels/ObsLoop/HostEntry';
 
 // @ts-ignore — 主机拓扑（plus parcel；开源构建下解析成空组件）
-import { HostTopoViewSwitch, HostTopoGlobalGraph, readHostTopoViewMode } from 'plus:/parcels/Targets';
+import { HostTopoViewSwitch, HostTopoGlobalGraph, HostTopoCenterSelect, HostTopoStats, readHostTopoViewMode } from 'plus:/parcels/Targets';
 
 import { NS, STATS_COLLAPSED_KEY } from '../../constants';
 import { Item, OperateType } from '../../types';
@@ -41,6 +42,21 @@ export default function index() {
   const [allCollapsed, setAllCollapsed] = useState(false);
 
   const businessGroupRef = React.useRef<{ getCollapse: () => boolean; setCollapse: (collapse: boolean) => void }>(null);
+
+  // 换视图的唯一入口：视图开关和「保存的视图」都走这里。
+  // 视图写进 URL 好分享，也让刷新之后还停在同一种看法上。
+  const history = useHistory();
+  const location = useLocation();
+  const changeViewMode = React.useCallback(
+    (mode: 'list' | 'topology') => {
+      setViewMode(mode);
+      const sp = new URLSearchParams(location.search);
+      if (mode === 'list') sp.delete('view');
+      else sp.set('view', mode);
+      history.replace({ pathname: location.pathname, search: sp.toString() });
+    },
+    [history, location.pathname, location.search],
+  );
 
   // 拓扑图的筛选条件。必须 memo：它进了 GlobalGraph 的 effect 依赖，
   // 写成内联字面量的话每次父组件 render 都是新对象，折叠统计栏这种
@@ -115,7 +131,7 @@ export default function index() {
             <StatsCards gids={gids} collapsed={statsCollapsed} setCollapsed={setStatsCollapsed} refreshFlag={refreshFlag} />
             {IS_PLUS && (
               <div className='mb-2'>
-                <HostTopoViewSwitch value={viewMode} onChange={setViewMode} />
+                <HostTopoViewSwitch value={viewMode} onChange={changeViewMode} filters={hostFilters} onFiltersChange={setHostFilters} />
               </div>
             )}
             {viewMode === 'topology' && IS_PLUS ? (
@@ -123,27 +139,40 @@ export default function index() {
                 {/* 拓扑视图下 <List/> 整个不渲染，它那条工具栏也跟着没了。
                     这里挂同一个 HostFilters、共用同一份状态，切视图筛选不丢。
                     批量操作不搬过来：那是选中表格行之后的动作，图上没有对应语义。 */}
-                <div className='fc-border rounded-lg p-2 flex flex-wrap items-center gap-2'>
-                  {allCollapseNode}
-                  <Button icon={<ReloadOutlined />} onClick={() => setRefreshFlag(_.uniqueId('refreshFlag_'))} />
-                  <HostFilters value={hostFilters} onChange={setHostFilters} />
+                {/* 容器样式与 List.tsx 的工具栏逐字一致（bg + 边框 + p-4 + 内层 flex 行）：
+                    两个视图的筛选条切换时不该跳动，差一档 padding 就是 16px 的位移 */}
+                <div className='flex-shrink-0 bg-fc-100 fc-border rounded-lg p-4'>
+                  <div className='flex flex-wrap items-start justify-between gap-2'>
+                    <div className='flex min-w-0 flex-1 flex-wrap items-center gap-2'>
+                      {allCollapseNode}
+                      <Button icon={<ReloadOutlined />} onClick={() => setRefreshFlag(_.uniqueId('refreshFlag_'))} />
+                      <HostFilters value={hostFilters} onChange={setHostFilters} />
+                      {/* 中心主机紧跟在筛选控件后面：它和前面几项一样都在回答「画哪些机器」 */}
+                      <HostTopoCenterSelect gids={gids} />
+                    </div>
+                    {/* 图的统计放筛选条右端：它回答的是「这些条件圈出了多少东西」。
+                        self-center 让它和 32px 高的控件垂直居中 */}
+                    <div className='self-center'>
+                      <HostTopoStats />
+                    </div>
+                  </div>
                 </div>
                 <div className='flex-1 min-h-0'>
                   <HostTopoGlobalGraph gids={gids} hostFilter={hostFilter} refreshFlag={refreshFlag} />
                 </div>
               </div>
             ) : (
-            <List
-              allCollapseNode={allCollapseNode}
-              gids={gids}
-              filters={hostFilters}
-              setFilters={setHostFilters}
-              selectedRows={selectedRows}
-              setSelectedRows={setSelectedRows}
-              refreshFlag={refreshFlag}
-              setRefreshFlag={setRefreshFlag}
-              setOperateType={setOperateType}
-            />
+              <List
+                allCollapseNode={allCollapseNode}
+                gids={gids}
+                filters={hostFilters}
+                setFilters={setHostFilters}
+                selectedRows={selectedRows}
+                setSelectedRows={setSelectedRows}
+                refreshFlag={refreshFlag}
+                setRefreshFlag={setRefreshFlag}
+                setOperateType={setOperateType}
+              />
             )}
           </div>
         </div>

--- a/src/pages/hosts/pages/List/index.tsx
+++ b/src/pages/hosts/pages/List/index.tsx
@@ -43,6 +43,31 @@ export default function index() {
 
   const businessGroupRef = React.useRef<{ getCollapse: () => boolean; setCollapse: (collapse: boolean) => void }>(null);
 
+  /**
+   * 切到拓扑视图时自动收起上面那排统计卡片。
+   *
+   * 那几张图讲的是「这批机器的心跳、内存、CPU 分布」，是列表的注解；图上用不到，
+   * 而它们占掉的两百来像素正是画布最缺的。回到列表时还原用户自己的选择 ——
+   * 用 ref 记住进拓扑之前的值，而不是一律展开。
+   *
+   * 这里只改 state 不写 localStorage：那份持久化的是用户在列表视图下的偏好，
+   * 由 StatsCards 上那个把手负责，自动折叠不该把它覆盖掉。
+   */
+  const statsCollapsedBeforeTopoRef = React.useRef<boolean | null>(null);
+  useEffect(() => {
+    if (viewMode === 'topology') {
+      if (statsCollapsedBeforeTopoRef.current === null) {
+        statsCollapsedBeforeTopoRef.current = statsCollapsed;
+        setStatsCollapsed(true);
+      }
+    } else if (statsCollapsedBeforeTopoRef.current !== null) {
+      setStatsCollapsed(statsCollapsedBeforeTopoRef.current);
+      statsCollapsedBeforeTopoRef.current = null;
+    }
+    // 只跟着视图变，statsCollapsed 不进依赖：用户在拓扑里手动展开时不该被立刻收回去
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewMode]);
+
   // 换视图的唯一入口：视图开关和「保存的视图」都走这里。
   // 视图写进 URL 好分享，也让刷新之后还停在同一种看法上。
   const history = useHistory();
@@ -128,12 +153,14 @@ export default function index() {
             }}
           />
           <div className='w-full min-w-0 flex flex-col'>
-            <StatsCards gids={gids} collapsed={statsCollapsed} setCollapsed={setStatsCollapsed} refreshFlag={refreshFlag} />
+            {/* 视图开关摆在统计卡片上面：它决定下面整块内容是什么，
+                夹在卡片和筛选条中间的话，用户得先看完一屏图表才找得到「换一种看法」 */}
             {IS_PLUS && (
               <div className='mb-2'>
                 <HostTopoViewSwitch value={viewMode} onChange={changeViewMode} filters={hostFilters} onFiltersChange={setHostFilters} />
               </div>
             )}
+            <StatsCards gids={gids} collapsed={statsCollapsed} setCollapsed={setStatsCollapsed} refreshFlag={refreshFlag} />
             {viewMode === 'topology' && IS_PLUS ? (
               <div className='flex-1 min-h-0 flex flex-col gap-2'>
                 {/* 拓扑视图下 <List/> 整个不渲染，它那条工具栏也跟着没了。

--- a/src/pages/targets/TargetMetaDrawer/index.tsx
+++ b/src/pages/targets/TargetMetaDrawer/index.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { Drawer, Tag } from 'antd';
+import { Drawer, Tabs, Tag } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { Tooltip, Space } from 'antd';
 import { DownOutlined, RightOutlined, CopyOutlined } from '@ant-design/icons';
@@ -22,6 +22,14 @@ interface IProps {
    * 采集配置」，是因为那个抽屉在 plus 里，本组件不该知道它的存在。
    */
   extraActions?: React.ReactNode;
+  /**
+   * 额外的页签。不传时抽屉与过去渲染得一模一样（不套 Tabs），
+   * 传了才把现有的元信息收成「概览」页签、其余接在后面。
+   *
+   * 与 extraActions 同一个道理：具体有哪些页签由调用方决定。机器列表能给
+   * 「这台机器的拓扑」，是因为那个视图在 plus 里，本组件不该知道它的存在。
+   */
+  extraTabs?: { key: string; label: React.ReactNode; children: React.ReactNode }[];
 }
 
 function bytesToSize(bytes, precision) {
@@ -181,7 +189,7 @@ function Group({ name, data }) {
 
 export default function TargetMetaDrawer(props: IProps) {
   const { t } = useTranslation('targets');
-  const { ident, targetNode, drawerOnly, drawerOpen, onDrawerOpenChange, extraActions } = props;
+  const { ident, targetNode, drawerOnly, drawerOpen, onDrawerOpenChange, extraActions, extraTabs } = props;
   const [visible, setVisible] = useState(false);
   const groupsName = ['platform', 'cpu', 'memory', 'network', 'filesystem'];
   const [information, setInformation] = useState({});
@@ -210,6 +218,10 @@ export default function TargetMetaDrawer(props: IProps) {
     });
   };
 
+  // 元信息本体。抽成变量是为了让它既能直接渲染（没有额外页签时），
+  // 又能作为「概览」页签的内容，两条路径共用同一段。
+  const meta = _.map(groupsName, (groupName) => <Group key={groupName} name={groupName} data={information[groupName]} />);
+
   return (
     <>
       {!drawerOnly && (
@@ -219,9 +231,24 @@ export default function TargetMetaDrawer(props: IProps) {
       )}
       <Drawer destroyOnClose title={t('meta_title')} width={800} placement='right' onClose={handleClose} visible={drawerVisible} className='n9e-antd-drawer'>
         {extraActions && <div className='mb-3 flex flex-wrap items-center gap-3'>{extraActions}</div>}
-        {_.map(groupsName, (groupName) => {
-          return <Group key={groupName} name={groupName} data={information[groupName]} />;
-        })}
+        {/* 没有额外页签时不套 Tabs：抽屉要和过去长得一模一样，开源构建下
+            plus 的页签解析成空，走的就是这条分支。
+            用 TabPane 子元素而不是 items：本仓库的 antd 版本还不支持 items，
+            网设详情抽屉也是这个写法 */}
+        {_.isEmpty(extraTabs) ? (
+          meta
+        ) : (
+          <Tabs destroyInactiveTabPane>
+            <Tabs.TabPane key='meta' tab={t('meta_tab_overview')}>
+              {meta}
+            </Tabs.TabPane>
+            {_.map(extraTabs, (tab) => (
+              <Tabs.TabPane key={tab.key} tab={tab.label}>
+                {tab.children}
+              </Tabs.TabPane>
+            ))}
+          </Tabs>
+        )}
       </Drawer>
     </>
   );

--- a/src/pages/targets/TargetMetaDrawer/index.tsx
+++ b/src/pages/targets/TargetMetaDrawer/index.tsx
@@ -30,6 +30,12 @@ interface IProps {
    * 「这台机器的拓扑」，是因为那个视图在 plus 里，本组件不该知道它的存在。
    */
   extraTabs?: { key: string; label: React.ReactNode; children: React.ReactNode }[];
+  /**
+   * 打开时落在哪个页签上（'meta' 是概览，其余取 extraTabs 的 key）。
+   * 机器列表那几个图标各自对应一个页签：点「拓扑」图标该直接看到拓扑，
+   * 而不是打开抽屉后再找一次。给的 key 不存在时回落到概览，不留白屏。
+   */
+  defaultActiveTab?: string;
 }
 
 function bytesToSize(bytes, precision) {
@@ -189,12 +195,21 @@ function Group({ name, data }) {
 
 export default function TargetMetaDrawer(props: IProps) {
   const { t } = useTranslation('targets');
-  const { ident, targetNode, drawerOnly, drawerOpen, onDrawerOpenChange, extraActions, extraTabs } = props;
+  const { ident, targetNode, drawerOnly, drawerOpen, onDrawerOpenChange, extraActions, extraTabs, defaultActiveTab } = props;
   const [visible, setVisible] = useState(false);
   const groupsName = ['platform', 'cpu', 'memory', 'network', 'filesystem'];
   const [information, setInformation] = useState({});
+  const [activeTab, setActiveTab] = useState('meta');
 
   const drawerVisible = drawerOnly ? !!drawerOpen : visible;
+  // 页签是受控的：每次打开都回到调用方指定的那个，用户在抽屉里手动切过的不算数。
+  // 不靠 defaultActiveKey + destroyOnClose，那是把正确性押在别处的一个属性上
+  const tabKeys = ['meta', ..._.map(extraTabs, 'key')];
+  const currentTab = _.includes(tabKeys, activeTab) ? activeTab : 'meta';
+
+  useEffect(() => {
+    if (drawerVisible) setActiveTab(defaultActiveTab || 'meta');
+  }, [drawerVisible, defaultActiveTab]);
 
   useEffect(() => {
     if (!drawerOnly || !drawerOpen || !ident) return;
@@ -238,7 +253,7 @@ export default function TargetMetaDrawer(props: IProps) {
         {_.isEmpty(extraTabs) ? (
           meta
         ) : (
-          <Tabs destroyInactiveTabPane>
+          <Tabs destroyInactiveTabPane activeKey={currentTab} onChange={setActiveTab}>
             <Tabs.TabPane key='meta' tab={t('meta_tab_overview')}>
               {meta}
             </Tabs.TabPane>

--- a/src/pages/targets/locale/en_US.ts
+++ b/src/pages/targets/locale/en_US.ts
@@ -89,6 +89,7 @@ const en_US = {
   },
   meta_tip: 'View meta info',
   meta_title: 'Information',
+  meta_tab_overview: 'Overview',
   meta_desc_key: 'Key',
   meta_desc_value: 'Value',
   meta_value_click_to_copy: 'Click to copy',

--- a/src/pages/targets/locale/ja_JP.ts
+++ b/src/pages/targets/locale/ja_JP.ts
@@ -85,6 +85,7 @@ const ja_JP = {
   },
   meta_tip: 'メタ情報を見る',
   meta_title: 'メタ情報',
+  meta_tab_overview: '概要',
   meta_desc_key: 'メタ情報名',
   meta_desc_value: 'メタ情報値',
   meta_value_click_to_copy: 'クリックしてコピー',

--- a/src/pages/targets/locale/ru_RU.ts
+++ b/src/pages/targets/locale/ru_RU.ts
@@ -85,6 +85,7 @@ const ru_RU = {
   },
   meta_tip: 'Просмотр метаинформации',
   meta_title: 'Метаинформация',
+  meta_tab_overview: 'Обзор',
   meta_desc_key: 'Ключ метаинформации',
   meta_desc_value: 'Значение метаинформации',
   meta_value_click_to_copy: 'Нажмите, чтобы скопировать',

--- a/src/pages/targets/locale/zh_CN.ts
+++ b/src/pages/targets/locale/zh_CN.ts
@@ -89,6 +89,7 @@ const zh_CN = {
   },
   meta_tip: '查看元信息',
   meta_title: '元信息',
+  meta_tab_overview: '概览',
   meta_desc_key: '元信息名称',
   meta_desc_value: '元信息值',
   meta_value_click_to_copy: '点击复制',

--- a/src/pages/targets/locale/zh_HK.ts
+++ b/src/pages/targets/locale/zh_HK.ts
@@ -89,6 +89,7 @@ const zh_HK = {
   },
   meta_tip: '查看元信息',
   meta_title: '元信息',
+  meta_tab_overview: '概覽',
   meta_desc_key: '元信息名稱',
   meta_desc_value: '元信息值',
   meta_value_click_to_copy: '點擊複製',


### PR DESCRIPTION
Mounts the host topology view inside the host list page (open-source side only; the graph itself lives in `src/plus`).

### ⚠️ Merge order

This PR **must not merge before flashcatcloud/n9e-plus-fe#1029**. It imports `HostTopoViewSwitch`, `HostTopoGlobalGraph`, `HostTopoCenterSelect`, `HostTopoCollectSetup`, `readHostTopoViewMode` and `HostTopoDrawerTab` from `plus:/parcels/Targets`, and none of them exist on the plus repo's `pre` branch yet — #1029 is what puts them there. Merging this first breaks the advanced (PRO) build.

The backend counterpart is flashcatcloud/n9e-plus#1261.

### What this adds

- A **Topology** view next to the existing list view, sharing one filter bar with it — business group, search text and tag filters carry over when you switch, so switching views does not reset what you were looking at.
- A **Topology** tab in the host drawer, so a host you opened from the list can be seen in context without leaving the page.
- The topology view gets its own toolbar row with the collapse and refresh controls, and the view switch sits above the stats.

### Notes for review

- The filter object handed to the graph is memoized; without it any unrelated state change in the page refetched the graph.
- `revert(hosts): drop the topology stats slot from the filter card` is an intentional revert of an earlier commit in this same branch — the stats ended up in the toolbar row instead, next to the controls they describe.

### Verification

`tsc --noEmit` clean (with the plus branch from #1029 in `src/plus`). The graph behaviour itself was exercised end to end against a test instance fed with synthetic data.

This branch merges into `pre` without conflicts.
