### PR TITLE
Alert rule search support PromQL

### DIFF
--- a/src/pages/alertRules/List/ListNG.tsx
+++ b/src/pages/alertRules/List/ListNG.tsx
@@ -25,7 +25,7 @@ import { AlertRuleType, AlertRuleStatus } from '@/pages/alertRules/types';
 import { defaultColumnsConfigs, LOCAL_STORAGE_KEY, FILTER_SESSION_STORAGE_KEY } from '@/pages/alertRules/List/constants';
 import EventsDrawer, { Props as EventsDrawerProps } from '@/pages/alertRules/List/EventsDrawer';
 import EvalRecordsDrawer, { Props as EvalRecordsDrawerProps } from '@/pages/alertRules/List/EvalRecordsDrawer';
-import { matchTriggerType, TRIGGER_TYPE_OPTIONS, TriggerType } from '@/pages/alertRules/List/utils';
+import { matchSearch, matchTriggerType, TRIGGER_TYPE_OPTIONS, TriggerType } from '@/pages/alertRules/List/utils';
 import { getPageFromSearch, setPageInSearch, removePageFromSearch } from '@/utils/urlPage';
 import { getAlertSeverityName } from '@/utils/alertSeverity';
 
@@ -364,11 +364,10 @@ export default function AlertRules(props: Props) {
     return _.filter(data, (item) => {
       const { datasourceIds, search, prod, severities, triggerType } = filter;
       const datasourceIdsWithoutHost = _.filter(datasourceIds, (id) => id !== -999);
-      const lowerCaseQuery = search?.toLowerCase() || '';
       return (
         // 列表数据排除 prod 为 firemap(灭火图)、northstar(北极星) 的记录
         !_.includes(['firemap', 'northstar'], item.prod) &&
-        (item.name.toLowerCase().indexOf(lowerCaseQuery) > -1 || _.join(item.append_tags, ' ').toLowerCase().indexOf(lowerCaseQuery) > -1) &&
+        matchSearch(item, search) &&
         ((prod && prod === item.prod) || !prod) &&
         ((item.severities &&
           _.some(item.severities, (severity) => {

--- a/src/pages/alertRules/List/ListNG.tsx
+++ b/src/pages/alertRules/List/ListNG.tsx
@@ -453,7 +453,7 @@ export default function AlertRules(props: Props) {
           </Select>
           <Input
             placeholder={t('search_placeholder')}
-            style={{ width: 200 }}
+            style={{ width: 220 }}
             value={queryValue}
             onChange={(e) => {
               setQueryValue(e.target.value);
@@ -536,7 +536,8 @@ export default function AlertRules(props: Props) {
         }}
         loading={loading}
         dataSource={filterData()}
-        locale={emptyGuide ? { emptyText: emptyGuide } : undefined}
+        // 创建引导只在确实没有规则时展示；筛选无结果时使用默认空状态，避免误导为「尚未创建规则」
+        locale={emptyGuide && _.isEmpty(data) ? { emptyText: emptyGuide } : undefined}
         rowSelection={
           showRowSelection
             ? {

--- a/src/pages/alertRules/List/utils.test.ts
+++ b/src/pages/alertRules/List/utils.test.ts
@@ -97,6 +97,12 @@ describe('matchSearch', () => {
     expect(matchSearch(target, 'status:500')).toBe(true);
   });
 
+  it('命中其他数据源统一查询字段 query_string、promql、expression 中的片段', () => {
+    expect(matchSearch(searchRule({ queries: [{ query_string: 'fields @message | filter qa_es_unique' }] }), 'qa_es_unique')).toBe(true);
+    expect(matchSearch(searchRule({ queries: [{ query_type: 'promql', promql: 'sum(gcm_request_count)' }] }), 'gcm_request_count')).toBe(true);
+    expect(matchSearch(searchRule({ queries: [{ expression: 'SUM(METRICS())' }] }), 'metrics()')).toBe(true);
+  });
+
   it('没有查询语句的规则只按名称和标签匹配', () => {
     expect(matchSearch(searchRule(), 'node_')).toBe(false);
     expect(matchSearch(searchRule({}), 'node_')).toBe(false);

--- a/src/pages/alertRules/List/utils.test.ts
+++ b/src/pages/alertRules/List/utils.test.ts
@@ -1,4 +1,4 @@
-import { matchTriggerType, TRIGGER_TYPE_OPTIONS } from './utils';
+import { matchSearch, matchTriggerType, TRIGGER_TYPE_OPTIONS } from './utils';
 
 const rule = (rule_config?: unknown) => ({ rule_config });
 
@@ -52,5 +52,56 @@ describe('matchTriggerType', () => {
 describe('TRIGGER_TYPE_OPTIONS', () => {
   it('包含阈值告警、无数据告警、智能告警三种类型', () => {
     expect(TRIGGER_TYPE_OPTIONS.map((opt) => opt.value)).toEqual(['threshold', 'nodata', 'anomaly']);
+  });
+});
+
+describe('matchSearch', () => {
+  const searchRule = (rule_config?: unknown) => ({ name: 'CPU 使用率过高', append_tags: ['team=infra', 'env=prod'], rule_config });
+
+  it('未输入搜索词时返回 true（不参与过滤）', () => {
+    expect(matchSearch(searchRule(), undefined)).toBe(true);
+    expect(matchSearch(searchRule(), '')).toBe(true);
+  });
+
+  it('按名称或附加标签匹配，不区分大小写', () => {
+    expect(matchSearch(searchRule(), 'cpu')).toBe(true);
+    expect(matchSearch(searchRule(), 'ENV=PROD')).toBe(true);
+    expect(matchSearch(searchRule(), 'memory')).toBe(false);
+  });
+
+  it('命中 Prometheus 普通模式 prom_ql 中的片段', () => {
+    const target = searchRule({ queries: [{ prom_ql: 'rate(node_cpu_seconds_total[5m]) == 0', severity: 2 }] });
+    expect(matchSearch(target, 'node_cpu_seconds_total')).toBe(true);
+    expect(matchSearch(target, '== 0')).toBe(true);
+    expect(matchSearch(target, 'node_load1')).toBe(false);
+  });
+
+  it('命中 Prometheus 高级模式（v2）query 中的片段', () => {
+    const target = searchRule({ version: 'v2', queries: [{ ref: 'A', query: 'up{job="node"}' }] });
+    expect(matchSearch(target, 'job="node"')).toBe(true);
+  });
+
+  it('多条查询任意一条命中即可', () => {
+    const target = searchRule({ queries: [{ prom_ql: 'node_load1 > 10' }, { prom_ql: 'node_memory_MemAvailable_bytes < 1e9' }] });
+    expect(matchSearch(target, 'memavailable')).toBe(true);
+    expect(matchSearch(target, 'NODE_LOAD1')).toBe(true);
+  });
+
+  it('命中 SQL 类数据源 sql 中的片段', () => {
+    const target = searchRule({ queries: [{ sql: 'SELECT count(*) FROM orders' }] });
+    expect(matchSearch(target, 'from orders')).toBe(true);
+  });
+
+  it('命中 Elasticsearch filter 中的查询条件（名称和标签未命中）', () => {
+    const target = searchRule({ queries: [{ index: 'logs-*', filter: 'status:500' }] });
+    expect(matchSearch(target, 'status:500')).toBe(true);
+  });
+
+  it('没有查询语句的规则只按名称和标签匹配', () => {
+    expect(matchSearch(searchRule(), 'node_')).toBe(false);
+    expect(matchSearch(searchRule({}), 'node_')).toBe(false);
+    // 主机类规则的查询不含查询语句字段，字段名和非字符串值都不参与匹配
+    expect(matchSearch(searchRule({ queries: [{ key: 'group_ids', op: '==', values: [1] }] }), 'group_ids')).toBe(false);
+    expect(matchSearch(searchRule({ queries: [{ query: { index: 'logs' } }] }), 'logs')).toBe(false);
   });
 });

--- a/src/pages/alertRules/List/utils.ts
+++ b/src/pages/alertRules/List/utils.ts
@@ -42,8 +42,8 @@ export function matchTriggerType(rule: Pick<AlertRuleType<any>, 'rule_config'> |
   }
 }
 
-// 查询语句所在字段：prom_ql（Prometheus 普通模式、Loki）、query（Prometheus 高级模式及多数数据源）、sql（SQL 类数据源）、filter（Elasticsearch 的 Lucene 查询条件）
-const QUERY_TEXT_KEYS = ['prom_ql', 'query', 'sql', 'filter'];
+// 查询语句所在字段：与规则摘要（FormNG/components/Sidebar/ruleConditionSummary.ts）的 QUERY_TEXT_KEYS 一致，另加 Elasticsearch/OpenSearch 的 filter
+const QUERY_TEXT_KEYS = ['prom_ql', 'query', 'sql', 'promql', 'query_string', 'expression', 'filter'];
 
 // 判断告警规则的名称、附加标签或查询语句是否包含搜索词（不区分大小写的子串匹配）
 export function matchSearch(rule: Pick<AlertRuleType<any>, 'name' | 'append_tags' | 'rule_config'>, search?: string): boolean {

--- a/src/pages/alertRules/List/utils.ts
+++ b/src/pages/alertRules/List/utils.ts
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import type { AlertRuleType } from '@/pages/alertRules/types';
 
 export const downloadFile = (data = '', filename = 'export.csv') => {
@@ -38,4 +40,14 @@ export function matchTriggerType(rule: Pick<AlertRuleType<any>, 'rule_config'> |
     default:
       return true;
   }
+}
+
+// 查询语句所在字段：prom_ql（Prometheus 普通模式、Loki）、query（Prometheus 高级模式及多数数据源）、sql（SQL 类数据源）、filter（Elasticsearch 的 Lucene 查询条件）
+const QUERY_TEXT_KEYS = ['prom_ql', 'query', 'sql', 'filter'];
+
+// 判断告警规则的名称、附加标签或查询语句是否包含搜索词（不区分大小写的子串匹配）
+export function matchSearch(rule: Pick<AlertRuleType<any>, 'name' | 'append_tags' | 'rule_config'>, search?: string): boolean {
+  const lowerCaseSearch = search?.toLowerCase() || '';
+  const queryTexts = _.flatMap(rule.rule_config?.queries, (query) => _.map(QUERY_TEXT_KEYS, (key) => query?.[key]));
+  return _.some([rule.name, _.join(rule.append_tags, ' '), ...queryTexts], (text) => typeof text === 'string' && text.toLowerCase().includes(lowerCaseSearch));
 }

--- a/src/pages/alertRules/locale/en_US.ts
+++ b/src/pages/alertRules/locale/en_US.ts
@@ -11,7 +11,7 @@ const en_US = {
   name_placeholder: 'Please enter rule name',
   group_id_placeholder: 'Please select business group',
   note_placeholder: 'Provide handling suggestions, related docs, or on-call info when alert triggers',
-  search_placeholder: 'Search by name, tags or query',
+  search_placeholder: 'Name, tags or query',
   status_triggered: 'Triggered',
   status_normal: 'Normal',
   notify_rule_not_found: 'Corresponding notification rule not found',

--- a/src/pages/alertRules/locale/en_US.ts
+++ b/src/pages/alertRules/locale/en_US.ts
@@ -11,7 +11,7 @@ const en_US = {
   name_placeholder: 'Please enter rule name',
   group_id_placeholder: 'Please select business group',
   note_placeholder: 'Provide handling suggestions, related docs, or on-call info when alert triggers',
-  search_placeholder: 'Search by name or tags',
+  search_placeholder: 'Search by name, tags or query',
   status_triggered: 'Triggered',
   status_normal: 'Normal',
   notify_rule_not_found: 'Corresponding notification rule not found',

--- a/src/pages/alertRules/locale/es_ES.ts
+++ b/src/pages/alertRules/locale/es_ES.ts
@@ -12,7 +12,7 @@ const es_ES = {
   "name_placeholder": "Introduce el nombre de la regla",
   "group_id_placeholder": "Selecciona el grupo de negocio",
   "note_placeholder": "Usa este campo para las pautas de respuesta a la alerta, enlaces de documentación, el turno de guardia y otra información complementaria",
-  "search_placeholder": "Buscar por nombre o etiqueta",
+  "search_placeholder": "Buscar por nombre, etiqueta o consulta",
   "status_triggered": "En alerta",
   "status_normal": "Sin alertas",
   "notify_rule_not_found": "No se encontró ninguna regla de notificación correspondiente",

--- a/src/pages/alertRules/locale/es_ES.ts
+++ b/src/pages/alertRules/locale/es_ES.ts
@@ -12,7 +12,7 @@ const es_ES = {
   "name_placeholder": "Introduce el nombre de la regla",
   "group_id_placeholder": "Selecciona el grupo de negocio",
   "note_placeholder": "Usa este campo para las pautas de respuesta a la alerta, enlaces de documentación, el turno de guardia y otra información complementaria",
-  "search_placeholder": "Buscar por nombre, etiqueta o consulta",
+  "search_placeholder": "Nombre, etiqueta o consulta",
   "status_triggered": "En alerta",
   "status_normal": "Sin alertas",
   "notify_rule_not_found": "No se encontró ninguna regla de notificación correspondiente",

--- a/src/pages/alertRules/locale/fr_FR.ts
+++ b/src/pages/alertRules/locale/fr_FR.ts
@@ -12,7 +12,7 @@ const fr_FR = {
   "name_placeholder": "Saisissez le nom de la règle",
   "group_id_placeholder": "Sélectionnez un groupe métier",
   "note_placeholder": "Notez ici les consignes de traitement, les liens vers la documentation, le planning d'astreinte et toute autre information utile",
-  "search_placeholder": "Rechercher par nom, étiquette ou requête",
+  "search_placeholder": "Nom, étiquette ou requête",
   "status_triggered": "En alerte",
   "status_normal": "Aucune alerte",
   "notify_rule_not_found": "Aucune règle de notification correspondante",

--- a/src/pages/alertRules/locale/fr_FR.ts
+++ b/src/pages/alertRules/locale/fr_FR.ts
@@ -12,7 +12,7 @@ const fr_FR = {
   "name_placeholder": "Saisissez le nom de la règle",
   "group_id_placeholder": "Sélectionnez un groupe métier",
   "note_placeholder": "Notez ici les consignes de traitement, les liens vers la documentation, le planning d'astreinte et toute autre information utile",
-  "search_placeholder": "Rechercher par nom ou étiquette",
+  "search_placeholder": "Rechercher par nom, étiquette ou requête",
   "status_triggered": "En alerte",
   "status_normal": "Aucune alerte",
   "notify_rule_not_found": "Aucune règle de notification correspondante",

--- a/src/pages/alertRules/locale/id_ID.ts
+++ b/src/pages/alertRules/locale/id_ID.ts
@@ -12,7 +12,7 @@ const id_ID = {
   "name_placeholder": "Masukkan nama aturan",
   "group_id_placeholder": "Pilih grup bisnis",
   "note_placeholder": "Tempat menuliskan saran penanganan saat alert terpicu, tautan dokumen terkait, jadwal jaga, dan catatan tambahan lain",
-  "search_placeholder": "Cari nama atau label",
+  "search_placeholder": "Cari nama, label, atau kueri",
   "status_triggered": "Sedang alert",
   "status_normal": "Tidak ada alert",
   "notify_rule_not_found": "Aturan notifikasi yang cocok tidak ditemukan",

--- a/src/pages/alertRules/locale/ja_JP.ts
+++ b/src/pages/alertRules/locale/ja_JP.ts
@@ -11,7 +11,7 @@ const ja_JP = {
   name_placeholder: 'ルール名を入力してください',
   group_id_placeholder: 'ビジネスグループを選択してください',
   note_placeholder: 'アラート発火時の処理提案、関連ドキュメントリンク、当直情報などを入力',
-  search_placeholder: '名前またはタグを検索',
+  search_placeholder: '名前、タグまたはクエリを検索',
   status_triggered: 'アラート中',
   status_normal: '正常',
   notify_rule_not_found: '対応する通知ルールが見つかりません',

--- a/src/pages/alertRules/locale/ko_KR.ts
+++ b/src/pages/alertRules/locale/ko_KR.ts
@@ -12,7 +12,7 @@ const ko_KR = {
   "name_placeholder": "규칙 이름을 입력하세요",
   "group_id_placeholder": "비즈니스 그룹을 선택하세요",
   "note_placeholder": "알림이 발생했을 때의 대응 방법, 관련 문서 링크, 당직 일정 등 보충 정보를 적을 수 있습니다",
-  "search_placeholder": "이름이나 레이블 검색",
+  "search_placeholder": "이름, 레이블 또는 쿼리 검색",
   "status_triggered": "알림 발생 중",
   "status_normal": "알림 없음",
   "notify_rule_not_found": "해당하는 통지 규칙을 찾지 못했습니다",

--- a/src/pages/alertRules/locale/pt_BR.ts
+++ b/src/pages/alertRules/locale/pt_BR.ts
@@ -12,7 +12,7 @@ const pt_BR = {
   "name_placeholder": "Informe o nome da regra",
   "group_id_placeholder": "Selecione o grupo de negócio",
   "note_placeholder": "Use este campo para orientações de resposta ao alerta, links de documentação, escala de plantão e outras informações complementares",
-  "search_placeholder": "Buscar por nome, rótulo ou consulta",
+  "search_placeholder": "Nome, rótulo ou consulta",
   "status_triggered": "Em alerta",
   "status_normal": "Sem alertas",
   "notify_rule_not_found": "Nenhuma regra de notificação correspondente foi encontrada",

--- a/src/pages/alertRules/locale/pt_BR.ts
+++ b/src/pages/alertRules/locale/pt_BR.ts
@@ -12,7 +12,7 @@ const pt_BR = {
   "name_placeholder": "Informe o nome da regra",
   "group_id_placeholder": "Selecione o grupo de negócio",
   "note_placeholder": "Use este campo para orientações de resposta ao alerta, links de documentação, escala de plantão e outras informações complementares",
-  "search_placeholder": "Buscar por nome ou rótulo",
+  "search_placeholder": "Buscar por nome, rótulo ou consulta",
   "status_triggered": "Em alerta",
   "status_normal": "Sem alertas",
   "notify_rule_not_found": "Nenhuma regra de notificação correspondente foi encontrada",

--- a/src/pages/alertRules/locale/ru_RU.ts
+++ b/src/pages/alertRules/locale/ru_RU.ts
@@ -11,7 +11,7 @@ const ru_RU = {
   name_placeholder: 'Введите название правила',
   group_id_placeholder: 'Выберите бизнес-группу',
   note_placeholder: 'Укажите рекомендации по обработке, ссылки на документацию или информацию о дежурстве',
-  search_placeholder: 'Поиск по названию или тегам',
+  search_placeholder: 'Поиск по названию, тегам или запросу',
   status_triggered: 'Сработало',
   status_normal: 'Нет срабатываний',
   notify_rule_not_found: 'Соответствующее правило уведомления не найдено',

--- a/src/pages/alertRules/locale/ru_RU.ts
+++ b/src/pages/alertRules/locale/ru_RU.ts
@@ -11,7 +11,7 @@ const ru_RU = {
   name_placeholder: 'Введите название правила',
   group_id_placeholder: 'Выберите бизнес-группу',
   note_placeholder: 'Укажите рекомендации по обработке, ссылки на документацию или информацию о дежурстве',
-  search_placeholder: 'Поиск по названию, тегам или запросу',
+  search_placeholder: 'Название, теги или запрос',
   status_triggered: 'Сработало',
   status_normal: 'Нет срабатываний',
   notify_rule_not_found: 'Соответствующее правило уведомления не найдено',

--- a/src/pages/alertRules/locale/zh_CN.ts
+++ b/src/pages/alertRules/locale/zh_CN.ts
@@ -11,7 +11,7 @@ const zh_CN = {
   name_placeholder: '请输入规则名称',
   group_id_placeholder: '请选择业务组',
   note_placeholder: '可填写告警触发时的处理建议、关联文档链接或值班安排等补充信息',
-  search_placeholder: '搜索名称或标签',
+  search_placeholder: '搜索名称、标签或查询语句',
   status_triggered: '告警中',
   status_normal: '无告警',
   notify_rule_not_found: '未找到对应的通知规则',

--- a/src/pages/alertRules/locale/zh_HK.ts
+++ b/src/pages/alertRules/locale/zh_HK.ts
@@ -11,7 +11,7 @@ const zh_HK = {
   name_placeholder: '請輸入規則名稱',
   group_id_placeholder: '請選擇業務組',
   note_placeholder: '可填寫告警觸發時的處理建議、關聯文檔鏈接或值班安排等補充信息',
-  search_placeholder: '搜尋名稱或標籤',
+  search_placeholder: '搜尋名稱、標籤或查詢語句',
   status_triggered: '告警中',
   status_normal: '無告警',
   notify_rule_not_found: '未找到對應的通知規則',


### PR DESCRIPTION
## 一句话目标
告警规则列表的搜索框目前只能搜名称和标签。改为也能搜规则里配置的 PromQL 等查询语句，方便快速找到用了某个指标或表达式的规则（比如找出所有引用 `node_cpu_seconds_total` 的规则）。

## 功能点
1. 搜索框里输入的内容，除了匹配规则名称、附加标签，还要匹配规则配置里的查询语句
2. Prometheus 规则的「普通模式」和「高级模式」写的 PromQL 都要能搜到
3. 规则有多条查询时，任意一条命中就算匹配
4. 匹配方式和现在一样：不区分大小写，按片段包含匹配，不分词。名称、标签、查询语句三者命中任意一个即可
5. 搜索框提示语从「搜索名称或标签」改为类似「搜索名称、标签或查询语句」，所有语言一起更新

## 涉及的 repo / 文件 / 页面
- repo：`n9e/fe`（只改前端）
- 页面：告警规则列表页
- 文件：`src/pages/alertRules/List/ListNG.tsx`（列表过滤）、`src/pages/alertRules/List/utils.ts` 和 `utils.test.ts`（匹配函数及单测）、`src/pages/alertRules/locale/` 下各语言文件（提示语）

## 验收标准
- 输入某条 Prometheus 普通模式规则中 PromQL 的片段，比如指标名或 `== 0` 这样的表达式片段，能搜出这条规则
- 高级模式（v2）的 Prometheus 规则，同样能按 PromQL 片段搜出来
- 大小写不同也能命中；原来按名称、标签搜出来的结果不变
- 和数据源、级别、启用状态、告警类型等筛选条件一起用时，仍然要同时满足（「且」的关系）
- 各语言的搜索框提示语都已更新，能看出支持搜查询语句
- `List/utils.test.ts` 新增单测，覆盖：普通模式 / 高级模式、多条查询、大小写、没有查询语句的规则

## 现状与既有约定
- 列表搜索只在前端过滤，不请求后端：`ListNG.tsx` 的 `filterData` 把搜索词转成小写，只和 `name`、`append_tags` 做包含匹配
- 列表接口已经返回完整的 `rule_config`，同一个过滤函数里的 `matchTriggerType` 就在读它，所以不用改后端
- PromQL 存在哪：普通模式在 `rule_config.queries[].prom_ql`；高级模式（`rule_config.version` 为 `v2`）在 `rule_config.queries[].query`。老规则顶层的 prom_ql 由后端 `DB2FE` 统一转进 `queries`
- 其他数据源的查询语句：Loki 也用 `prom_ql`，其他类型用 `query`、`sql` 等字段。`src/pages/alertRules/FormNG/components/Sidebar/ruleConditionSummary.ts` 里已有统一的字段列表 `QUERY_TEXT_KEYS`（query / prom_ql / sql / promql / query_string / expression）和取文本的函数 `findRawText`，可参考
- 列表过滤用的辅助函数按惯例放在 `List/utils.ts`，并在 `List/utils.test.ts` 写单测（参考 `matchTriggerType`）

## 假设与待确认
- **搜索范围默认放宽为「规则配置里的查询语句」**：除了 Prometheus 的 PromQL，Loki、ES、SQL 类等数据源的查询语句也能搜到（这和仓库现有的统一字段约定一致）。如果只想支持 Prometheus，请在这里改窄
- 不改后端：`nightingale` 的 `models/alert_rule.go` 里 `AlertRulesGetsBy` 也有个 `query` 参数（按 append_tags 过滤），但它属于按 prod 取规则的另一个接口，列表页不用，这次不动
- 不做正则、分词，也不在列表里高亮命中的内容
- 主机类等本来就没有查询语句文本的规则，只按名称和标签匹配

---
Created by Ironship task 2b1849beaa8c4b92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Alert rule searches now match rule names, tags, and query content across supported rule types.
  - Search matching is case-insensitive and available in both the alert rules list and rule-selection modal.
  - The search field is slightly wider for improved usability.

- **Bug Fixes**
  - The creation guide no longer appears when filters simply produce no results; it appears only when no rules exist.
  - Search instructions have been updated across supported languages to mention query content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->